### PR TITLE
Fix lora Error

### DIFF
--- a/mindnlp/peft/tuners/lora.py
+++ b/mindnlp/peft/tuners/lora.py
@@ -439,24 +439,24 @@ class LoraModel(BaseTuner):
             )
         return active_adapter
 
-    def _mark_only_adapters_as_trainable(self,model) -> None:
+    def _mark_only_adapters_as_trainable(self) -> None:
         """mark_only_lora_as_trainable"""
         # get bias
         active_adapter = self._get_active_adapter()
         bias = self.peft_config[active_adapter].bias
 
-        for n, p in model.parameters_and_names():  # named_parameters() -> parameters_and_names()
+        for n, p in self.model.parameters_and_names():  # named_parameters() -> parameters_and_names()
             if "lora_" not in n:
                 p.requires_grad = False
                 # print(n, p, "requires_grad = False")
         if bias == "none":
             return
         elif bias == "all":
-            for n, p in model.parameters_and_names():
+            for n, p in self.model.parameters_and_names():
                 if "bias" in n:
                     p.requires_grad = True
         elif bias == "lora_only":
-            for m in model.cells():  # .cells() for modules()
+            for m in self.model.cells():  # .cells() for modules()
                 if isinstance(m, LoraLayer) and hasattr(m, "bias") and m.bias is not None:
                     m.bias.requires_grad = True
         else:
@@ -541,7 +541,7 @@ class LoraModel(BaseTuner):
         return new_module
 
 
-class LoraLayer():
+class LoraLayer(BaseTunerLayer):
     """Lora Layer"""
     # TODO add CellDict Support
     def __init__(self, in_features: int, out_features: int, **kwargs):

--- a/mindnlp/peft/tuners/lora.py
+++ b/mindnlp/peft/tuners/lora.py
@@ -439,24 +439,24 @@ class LoraModel(BaseTuner):
             )
         return active_adapter
 
-    def _mark_only_adapters_as_trainable(self) -> None:
+    def _mark_only_adapters_as_trainable(self,model) -> None:
         """mark_only_lora_as_trainable"""
         # get bias
         active_adapter = self._get_active_adapter()
         bias = self.peft_config[active_adapter].bias
 
-        for n, p in self.model.parameters_and_names():  # named_parameters() -> parameters_and_names()
+        for n, p in model.parameters_and_names():  # named_parameters() -> parameters_and_names()
             if "lora_" not in n:
                 p.requires_grad = False
                 # print(n, p, "requires_grad = False")
         if bias == "none":
             return
         elif bias == "all":
-            for n, p in self.model.parameters_and_names():
+            for n, p in model.parameters_and_names():
                 if "bias" in n:
                     p.requires_grad = True
         elif bias == "lora_only":
-            for m in self.model.cells():  # .cells() for modules()
+            for m in model.cells():  # .cells() for modules()
                 if isinstance(m, LoraLayer) and hasattr(m, "bias") and m.bias is not None:
                     m.bias.requires_grad = True
         else:
@@ -541,7 +541,7 @@ class LoraModel(BaseTuner):
         return new_module
 
 
-class LoraLayer(BaseTunerLayer):
+class LoraLayer():
     """Lora Layer"""
     # TODO add CellDict Support
     def __init__(self, in_features: int, out_features: int, **kwargs):

--- a/mindnlp/peft/tuners/lora.py
+++ b/mindnlp/peft/tuners/lora.py
@@ -41,7 +41,7 @@ from ..utils import (
     transpose,
 )
 
-from .tuners_utils import BaseTuner, BaseTunerLayer
+from .tuners_utils import BaseTuner
 
 # if is_bnb_available():
 #     import bitsandbytes as bnb


### PR DESCRIPTION
之前lora layer继承BaseTunerLayer，并重定义了BaseTunerLayer的功能，ia3算法pr中将BaseTunerLayer完全移植过来，导致了冲突，lora算法无法训练，出现这个 https://gitee.com/mindspore/community/issues/I9JPA5?from=project-issue issue中问题，先暂时将loralayer父类BaseTunerLayer去掉，可以正常运行，不影响lora功能，后续将lora算法重写一下