### PR TITLE
fix bug for gpt_neox_japanese

### DIFF
--- a/mindnlp/transformers/models/gpt_neox_japanese/modeling_gpt_neox_japanese.py
+++ b/mindnlp/transformers/models/gpt_neox_japanese/modeling_gpt_neox_japanese.py
@@ -754,10 +754,8 @@ class GPTNeoXJapaneseForCausalLM(GPTNeoXJapanesePreTrainedModel):
 
 
 __all__ = [
-    "GPTNeoXJapaneseAttention",
-    "GPTNeoXJapaneseMLP",
+    "GPTNeoXJapaneseForCausalLM",
     "GPTNeoXJapaneseLayer",
     "GPTNeoXJapaneseModel",
     "GPTNeoXJapanesePreTrainedModel",
-    "GPTNeoXJapaneseForCausalLM",
 ]


### PR DESCRIPTION
![Snipaste_2024-06-07_00-19-10](https://github.com/mindspore-lab/mindnlp/assets/61312155/4276c7a6-a824-45c3-ba6d-e39859bcb07b)
![Snipaste_2024-06-07_00-19-15](https://github.com/mindspore-lab/mindnlp/assets/61312155/3517cba6-9582-498f-a3b4-30e40bcd7363)

这次和squeeze不同，是多了不需要测试的冗余的模块。