### PR TITLE
【昇腾AI创新大赛】 segformer

### DIFF
--- a/mindnlp/transformers/models/segformer/modeling_segformer.py
+++ b/mindnlp/transformers/models/segformer/modeling_segformer.py
@@ -1140,6 +1140,9 @@ attentions.
         """
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
+        if labels is not None and self.config.num_labels < 1:
+            raise ValueError(f"Number of labels should be >=0: {self.config.num_labels}")
+
         outputs = self.segformer(
             pixel_values,
             output_attentions=output_attentions,


### PR DESCRIPTION
模型库中已有segformer，但赛题中仍具有此模型，查看了hf对segformer的更新，同步修改了下，虽不知是否还有效，但也申请pr试试，已通过本地pylint+run_slow
![image](https://github.com/mindspore-lab/mindnlp/assets/55754693/33defd1f-5e50-4ee9-a982-242e055d005f)
