### PR TITLE
[bugfix] PreTrainedModel.from_pretrained.load_param_into_net

### DIFF
--- a/mindnlp/transformers/modeling_utils.py
+++ b/mindnlp/transformers/modeling_utils.py
@@ -1174,7 +1174,7 @@ class PreTrainedModel(nn.Cell, CellUtilMixin, GenerationMixin, PeftAdapterMixin)
                 if add_prefix_to_model:
                     param_name = prefix + '.' + pname_in_net
                 elif remove_prefix_from_model:
-                    param_name = pname_in_net.replace(f'{prefix}.', '')
+                    param_name = pname_in_net.replace(f'{prefix}.', '', 1)
                 else:
                     param_name = pname_in_net
 


### PR DESCRIPTION
根据 1165~1166 行的逻辑，前缀判定只与字符串**开始**有关，故此处replace只需要count=1