### PR TITLE
Update __init__.py

### DIFF
--- a/mindnlp/__init__.py
+++ b/mindnlp/__init__.py
@@ -45,8 +45,6 @@ if platform.system().lower() == 'linux':
 
 from mindspore import jit as ms_jit
 from mindnlp import transformers
-from mindnlp import dataset
-from mindnlp import evaluate
-from mindnlp import core
+
 
 __all__ = ['ms_jit', 'transformers']


### PR DESCRIPTION
删除了mindnlp目录下的init.py中的`from mindnlp import dataset`,`from mindnlp import evaluate`,`from mindnlp import core`，这三个方法在init.py中没用到，但会导致一些问题，因此删除
