### PR TITLE
Fix mint.nonzero interface call

### DIFF
--- a/mindnlp/core/ops/array.py
+++ b/mindnlp/core/ops/array.py
@@ -130,7 +130,7 @@ def narrow(input, dim, start, length):
 has_nonzero = hasattr(mindspore.mint, 'nonzero')
 def nonzero(input, *, as_tuple=False):
     if use_pyboost() and has_nonzero:
-        return mindspore.mint.nonzero(input, as_tuple)
+        return mindspore.mint.nonzero(input, as_tuple=as_tuple)
     _nonzero = _get_cache_prim(ops.NonZero)()
     out = _nonzero(input)
     if as_tuple:


### PR DESCRIPTION
## Test Report
Software Environment / 软件环境 (Mandatory / 必填):
-- MindSpore version (e.g., 1.7.0.Bxxx) : 2.5.0
-- Python version (e.g., Python 3.7.5) : 3.10.0
-- OS platform and distribution (e.g., Linux Ubuntu 16.04): Ubuntu 22.04.4 LTS
-- GCC/Compiler version (if compiled from source): 11.04

Test Code:
<img width="931" alt="image" src="https://github.com/user-attachments/assets/1176577e-15d6-4cd2-aeec-1f0afd4130fa" />


## Related Issues
Fixes #2000 