### PR TITLE
Fix inplace_scatter_value and l1_loss for 'c' class models

### DIFF
--- a/src/mindtorch/_apis/cpu.py
+++ b/src/mindtorch/_apis/cpu.py
@@ -1486,6 +1486,13 @@ def scatter_value(input, dim, index, src, reduce='none'):
         src = fill_scalar(index.shape, src, dtype=input.dtype)
     return legacy.tensor_scatter_elements(input, index, src, dim, reduce)
 
+def inplace_scatter_value(input, dim, index, src, reduce='none'):
+    """In-place scatter with scalar or tensor value."""
+    if isinstance(src, numbers.Number):
+        src = fill_scalar(index.shape, src, dtype=input.dtype)
+    result = legacy.tensor_scatter_elements(input, index, src, dim, reduce)
+    return inplace_copy(input, result)
+
 def pixel_shuffle(input, upscale_factor):
     idx = input.shape
     length = input.ndim
@@ -1559,9 +1566,9 @@ def grid_sampler_2d(input, grid, mode='bilinear', padding_mode='zeros', align_co
 def l1_loss(input, target, reduction='mean'):
     loss = abs(sub(input, target))
     if reduction == 'mean':
-        return mean(loss, (), False, False)
+        return mean(loss, (), False, None)
     elif reduction == 'sum':
-        return sum(loss, (), False, False)
+        return sum(loss, (), False, None)
     return loss
 
 def leaky_relu(input, negative_slope):


### PR DESCRIPTION
## Summary
- Add missing `inplace_scatter_value` function for in-place scatter operations
- Fix `l1_loss` dtype parameter (passing `False` instead of `None` caused TypeError)

## Test Results
| Model | Before | After | Improvement |
|-------|--------|-------|-------------|
| conditional_detr | 34 passed | 37 passed | +3 tests |

## Test Plan
- Tested all 24 'c' class transformer models
- Verified bug fixes with specific test cases
- Ensured no regressions in existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)