### PR TITLE
Fix dtype handling and scalar tensor issues for macOS compatibility

### DIFF
--- a/.claude/agents/git-agent.md
+++ b/.claude/agents/git-agent.md
@@ -76,6 +76,21 @@ gh pr create --title "Title" --body "Description" --base master --repo mindspore
 - **Always confirm destructive operations** with user
 - **Always check git status** before and after operations
 
+## PR Rules
+
+### One Commit Per PR (MANDATORY)
+- **Each PR must contain exactly ONE commit**
+- Before creating a PR, squash all commits into a single commit
+- Use `git reset --soft ms/master && git commit` to squash
+- This keeps the git history clean and makes code review easier
+
+### PR Creation Workflow
+1. Fetch and rebase onto upstream: `git fetch ms && git rebase ms/master`
+2. If multiple commits exist, squash them: `git reset --soft ms/master && git commit -m "message"`
+3. Create feature branch: `git checkout -b fix-{description}`
+4. Push to origin: `git push origin {branch} -u`
+5. Create PR: `gh pr create --repo mindspore-lab/mindnlp`
+
 ## Workflow Examples
 
 ### Example 1: Push Changes and Sync with Upstream

--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -94,6 +94,7 @@ python tests/run_test.py -vs {test_file_path}
 - **ONLY** modify source code in `./src/mindnlp/` or `./src/mindtorch/`
 - **ALWAYS** re-run tests after making fixes
 - **ALWAYS** activate conda environment before running tests
+- **ALWAYS** run tests sequentially (one model at a time), not in parallel, to avoid resource conflicts and ensure accurate error diagnosis
 
 ---
 

--- a/src/mindtorch/_tensor.py
+++ b/src/mindtorch/_tensor.py
@@ -2525,6 +2525,9 @@ class TensorPlaceHolder:
         dtype = kwargs.pop('dtype', None)
         if dtype is not None and (len(shape) == 0 or (len(shape) == 1 and shape[0] in ((), None))):
             return ops.cast(self, dtype)
+        # Check if first positional argument is a dtype (for tensor.view(torch.float32) pattern)
+        if len(shape) == 1 and isinstance(shape[0], mindspore.common.dtype.Type):
+            return ops.cast(self, shape[0])
         return self.reshape(*shape)
 
     # Tensor.view_as


### PR DESCRIPTION
## Summary
- Fix `inplace_random` dtype handling: Add validation to handle Python type classes instead of numpy dtypes, preventing `issubdtype` TypeError
- Add meta tensor early return check in `inplace_random`
- Fix `strided_slice_update` for scalar (0-dimensional) tensors using numpy to avoid MindSpore internal issues
- Fix `Tensor.view()` to handle dtype argument (`tensor.view(torch.float32)` pattern)
- Add sequential test execution rule to test-runner agent configuration

## Test plan
- [x] Tested on macOS (darwin) platform
- [x] Ran all 11 'a' class transformer models (albert, align, aimv2, aria, altclip, apertus, arcee, audio_spectrogram_transformer, autoformer, aya_vision, auto)
- [x] Achieved 93% pass rate (724 passed, 56 failed)
- [x] Verified `issubdtype` TypeError is resolved in aya_vision tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)