### PR TITLE
fix: Add ReflectionPad NumPy fallback, cross function, and backends.cpu module

### DIFF
--- a/src/mindtorch/backends/__init__.py
+++ b/src/mindtorch/backends/__init__.py
@@ -1,4 +1,4 @@
-from . import cuda, mps, cudnn, mkldnn
+from . import cuda, mps, cudnn, mkldnn, cpu
 
 __allow_nonbracketed_mutation_flag = True
 

--- a/src/mindtorch/backends/cpu/__init__.py
+++ b/src/mindtorch/backends/cpu/__init__.py
@@ -1,0 +1,58 @@
+"""CPU backend module for mindtorch.
+
+This module provides CPU-related backend functionality similar to torch.backends.cpu.
+"""
+
+
+def get_cpu_capability() -> str:
+    """Get the CPU capability string.
+
+    Returns a string indicating the CPU's SIMD capability level.
+    Possible return values: "AVX512", "AVX2", "AVX", "DEFAULT"
+
+    Returns:
+        str: The CPU capability string.
+    """
+    try:
+        import platform
+        import subprocess
+
+        system = platform.system()
+
+        if system == "Darwin":
+            try:
+                result = subprocess.run(
+                    ["sysctl", "-n", "hw.optional.avx2_0"],
+                    capture_output=True,
+                    text=True,
+                    timeout=1
+                )
+                if result.returncode == 0 and result.stdout.strip() == "1":
+                    return "AVX2"
+
+                result = subprocess.run(
+                    ["sysctl", "-n", "hw.optional.avx1_0"],
+                    capture_output=True,
+                    text=True,
+                    timeout=1
+                )
+                if result.returncode == 0 and result.stdout.strip() == "1":
+                    return "AVX"
+            except (subprocess.TimeoutExpired, FileNotFoundError):
+                pass
+        elif system == "Linux":
+            try:
+                with open("/proc/cpuinfo", "r") as f:
+                    cpuinfo = f.read()
+                    if "avx512" in cpuinfo.lower():
+                        return "AVX512"
+                    elif "avx2" in cpuinfo.lower():
+                        return "AVX2"
+                    elif "avx" in cpuinfo.lower():
+                        return "AVX"
+            except (FileNotFoundError, PermissionError):
+                pass
+    except Exception:
+        pass
+
+    return "DEFAULT"


### PR DESCRIPTION
## Summary
- Add NumPy-based fallback for ReflectionPad operations when MindSpore kernel is unregistered
- Add `cross` function to CPU API for computing cross product of two tensors
- Add `backends.cpu` module with `get_cpu_capability()` function for CPU SIMD detection
- Patch `id_tensor_storage` in transformers for proper shared tensor detection (critical for saving models with tied weights using safetensors)

## Changes

### 1. ReflectionPad NumPy Fallback (`src/mindtorch/_apis/cpu.py`)
When MindSpore's ReflectionPad kernel is not registered (e.g., on certain platforms), the code now falls back to a NumPy-based implementation that supports 1D, 2D, and 3D padding.

### 2. Cross Function (`src/mindtorch/_apis/cpu.py`)
Added `cross(input, other, dim)` function that computes the cross product of two tensors, delegating to the legacy implementation.

### 3. backends.cpu Module (`src/mindtorch/backends/cpu/__init__.py`)
New module providing CPU backend functionality:
- `get_cpu_capability()`: Returns CPU SIMD capability ("AVX512", "AVX2", "AVX", or "DEFAULT")
- Supports macOS (via sysctl) and Linux (via /proc/cpuinfo)

### 4. id_tensor_storage Patch (`src/mindnlp/patch/transformers/common.py`)
Patches transformers' `id_tensor_storage` function to use `data_ptr()` for MindTorch tensors. This ensures proper identification of tied weights (tensors sharing the same underlying data) when saving models with safetensors.

## Test Results
These fixes improve compatibility with transformer models that use:
- Reflection padding operations
- Cross product computations
- Weight tying/sharing during model saving

🤖 Generated with [Claude Code](https://claude.com/claude-code)