### PR TITLE
feat(mindtorch_v2): Add torch_proxy, BERT validation, and autograd fixes

### DIFF
--- a/docs/plans/2026-01-26-phase5-bert-validation.md
+++ b/docs/plans/2026-01-26-phase5-bert-validation.md
@@ -1,0 +1,242 @@
+# Phase 5: BERT Validation Plan
+
+**Date**: 2026-01-26
+**Status**: Ready for Implementation
+**Goal**: Run BERT forward + backward on mindtorch_v2 and fix gaps until tests pass
+
+## Current State Summary
+
+**Implemented in Phases 1-4:**
+- Storage-based Tensor with view semantics
+- Dispatch system with CPU backend (NumPy)
+- Autograd engine with backward functions for core ops
+- nn.Module, Parameter, Linear, Embedding, LayerNorm, Dropout
+- Activations: ReLU, GELU, SiLU, Sigmoid, Tanh, Softmax
+
+## Phase 5 Tasks
+
+### Task 1: Create mindtorch_v2 Test Infrastructure
+
+**Goal**: Set up test runner that uses mindtorch_v2 instead of mindtorch v1
+
+**Steps**:
+1. Create `tests/mindtorch_v2/` directory for v2-specific tests
+2. Create `tests/mindtorch_v2/conftest.py` with fixtures that import from mindtorch_v2
+3. Create `tests/mindtorch_v2/test_basic.py` with smoke tests for:
+   - Tensor creation and basic ops
+   - Autograd forward/backward
+   - nn.Module forward pass
+4. Run basic tests to verify infrastructure works
+
+**Verification**: `python -m pytest tests/mindtorch_v2/test_basic.py -v`
+
+### Task 2: Implement Missing Tensor Operations
+
+**Goal**: Add tensor operations required by BERT that are missing
+
+**Steps**:
+1. Add `cat` / `torch.cat` - concatenate tensors along dimension
+2. Add `stack` / `torch.stack` - stack tensors along new dimension
+3. Add `split` / `torch.split` - split tensor into chunks
+4. Add `chunk` / `torch.chunk` - split tensor into specified number of chunks
+5. Add `clone` - create a copy of tensor with new storage
+6. Add `repeat` - repeat tensor along dimensions
+7. Add `masked_fill` / `masked_fill_` - fill tensor where mask is True
+8. Add `where` / `torch.where` - select elements based on condition
+9. Add backward functions for new ops
+
+**Verification**: Create unit tests for each new op in `tests/mindtorch_v2/test_ops.py`
+
+### Task 3: Implement Missing Reduction/Math Operations
+
+**Goal**: Add reduction and math ops needed by BERT attention
+
+**Steps**:
+1. Add `var` - variance reduction
+2. Add `std` - standard deviation reduction
+3. Add `clamp` / `clamp_` - clamp values to range
+4. Add `rsqrt` - reciprocal square root
+5. Add `reciprocal` - 1/x element-wise
+6. Add `baddbmm` - batched matrix multiply with add
+7. Add `bmm` - batched matrix multiply
+8. Add `einsum` - Einstein summation (needed for some attention implementations)
+9. Add backward functions for new ops
+
+**Verification**: Create unit tests in `tests/mindtorch_v2/test_math.py`
+
+### Task 4: Implement Missing nn Modules
+
+**Goal**: Add nn modules required by BERT
+
+**Steps**:
+1. Add `nn.Conv1d` - 1D convolution (some BERT variants use this)
+2. Add `nn.BatchNorm1d` - batch normalization
+3. Add `nn.CrossEntropyLoss` - loss function
+4. Add `nn.MSELoss` - loss function
+5. Add `nn.BCEWithLogitsLoss` - loss function
+6. Add `nn.ParameterList` - list of parameters
+7. Add `nn.init` module with initialization functions:
+   - `xavier_uniform_`, `xavier_normal_`
+   - `kaiming_uniform_`, `kaiming_normal_`
+   - `normal_`, `uniform_`, `zeros_`, `ones_`
+
+**Verification**: Create unit tests in `tests/mindtorch_v2/test_nn.py`
+
+### Task 5: Implement AdamW Optimizer
+
+**Goal**: Add AdamW optimizer for training
+
+**Steps**:
+1. Create `mindtorch_v2/optim/__init__.py`
+2. Create `mindtorch_v2/optim/optimizer.py` with base Optimizer class:
+   - `zero_grad()` method
+   - `step()` method
+   - `param_groups` attribute
+   - `state` dict for optimizer state
+3. Create `mindtorch_v2/optim/adamw.py` with AdamW implementation:
+   - Standard AdamW algorithm with weight decay
+   - Support for `lr`, `betas`, `eps`, `weight_decay`
+   - First and second moment tracking
+4. Add `optim.SGD` as fallback optimizer
+
+**Verification**:
+```python
+# Test optimizer on simple model
+model = nn.Linear(10, 2)
+optimizer = optim.AdamW(model.parameters(), lr=0.001)
+for _ in range(10):
+    loss = model(x).sum()
+    loss.backward()
+    optimizer.step()
+    optimizer.zero_grad()
+```
+
+### Task 6: Create BERT Model Shim
+
+**Goal**: Create a minimal BERT-like model for testing forward/backward
+
+**Steps**:
+1. Create `tests/mindtorch_v2/models/bert_simple.py` with:
+   - `BertEmbeddings` - token + position + segment embeddings
+   - `BertSelfAttention` - multi-head self-attention
+   - `BertAttention` - self-attention + output projection
+   - `BertIntermediate` - feed-forward intermediate layer
+   - `BertOutput` - feed-forward output with residual
+   - `BertLayer` - full transformer layer
+   - `BertEncoder` - stack of layers
+   - `BertModel` - full model
+2. Use only mindtorch_v2 imports (no torch dependency)
+3. Initialize with small config (2 layers, 4 heads, hidden=64)
+
+**Verification**:
+```python
+config = BertConfig(hidden_size=64, num_attention_heads=4, num_hidden_layers=2)
+model = BertModel(config)
+outputs = model(input_ids, attention_mask)
+```
+
+### Task 7: Run BERT Forward Pass
+
+**Goal**: Execute BERT forward pass and fix any failures
+
+**Steps**:
+1. Create random input tensors (batch=2, seq_len=16)
+2. Run forward pass through BERT model
+3. Identify and fix failures:
+   - Missing ops → implement in Task 2/3
+   - Shape mismatches → fix tensor operations
+   - Dtype issues → add proper dtype handling
+4. Iterate until forward pass completes without error
+
+**Verification**: Forward pass produces output tensor of expected shape
+
+### Task 8: Run BERT Backward Pass
+
+**Goal**: Execute BERT backward pass and fix any failures
+
+**Steps**:
+1. Compute loss from BERT output (sum or mean)
+2. Call `loss.backward()`
+3. Identify and fix failures:
+   - Missing backward functions → implement
+   - Gradient shape mismatches → fix backward implementations
+   - Accumulation issues → fix autograd engine
+4. Verify all parameters have gradients
+
+**Verification**:
+```python
+loss.backward()
+for name, param in model.named_parameters():
+    assert param.grad is not None, f"No gradient for {name}"
+```
+
+### Task 9: Run BERT Training Loop
+
+**Goal**: Complete training loop with optimizer
+
+**Steps**:
+1. Create optimizer with model parameters
+2. Run 10 training iterations:
+   - Forward pass
+   - Backward pass
+   - Optimizer step
+   - Zero gradients
+3. Verify loss decreases (or at least doesn't explode)
+4. Fix any issues with gradient updates
+
+**Verification**: Training loop completes without error, loss values are finite
+
+### Task 10: Integration with transformers Tests
+
+**Goal**: Run actual transformers BERT tests with mindtorch_v2
+
+**Steps**:
+1. Create import shim that makes mindtorch_v2 available as `torch`
+2. Modify test runner to use mindtorch_v2 backend
+3. Run: `python tests/run_test.py -vs tests/transformers/tests/models/bert/test_modeling_bert.py::BertModelTest::test_model`
+4. Fix failures iteratively
+5. Track pass/fail count
+
+**Verification**: `BertModelTest::test_model` passes
+
+## Success Criteria
+
+Phase 5 is complete when:
+1. [ ] All basic mindtorch_v2 tests pass
+2. [ ] Simple BERT model forward pass works
+3. [ ] Simple BERT model backward pass works
+4. [ ] Training loop with AdamW completes
+5. [ ] At least one transformers BERT test passes
+
+## Notes
+
+- **Development on macOS/CPU**: All implementations use NumPy backend
+- **No MindSpore ops**: Avoid using `mindspore.ops` directly; use primitives via `_op_prim`
+- **Follow PyTorch semantics**: When in doubt, match PyTorch behavior exactly
+- **Test incrementally**: Run tests after each implementation to catch issues early
+
+## Dependencies Between Tasks
+
+```
+Task 1 (infrastructure)
+    ↓
+Task 2 (tensor ops) ←──────┐
+    ↓                      │
+Task 3 (math ops) ←────────┤
+    ↓                      │
+Task 4 (nn modules) ←──────┤
+    ↓                      │
+Task 5 (optimizer)         │
+    ↓                      │
+Task 6 (BERT model) ───────┘
+    ↓
+Task 7 (forward pass)
+    ↓
+Task 8 (backward pass)
+    ↓
+Task 9 (training loop)
+    ↓
+Task 10 (integration)
+```
+
+Tasks 2-5 can be done in parallel. Task 6 depends on 2-4. Tasks 7-10 are sequential.

--- a/docs/plans/2026-01-27-mindtorch-v2-torch-proxy-design.md
+++ b/docs/plans/2026-01-27-mindtorch-v2-torch-proxy-design.md
@@ -1,0 +1,243 @@
+# mindtorch_v2 Torch Proxy Design
+
+**Date**: 2026-01-27
+**Status**: Ready for Implementation
+**Goal**: Make mindtorch_v2 a drop-in replacement for torch so HuggingFace `transformers.BertModel` works directly
+
+## Success Criteria
+
+`BertModelTest::test_model` from transformers test suite passes with mindtorch_v2 as the torch backend.
+
+## Scope
+
+- **Target**: BERT-first minimal compatibility, expand incrementally
+- **Operations**: Forward + backward pass (inference + gradient computation)
+- **Implementation**: HuggingFace's actual `transformers.BertModel`
+- **Approach**: Implement real equivalents of PyTorch internals (no fragile stubs)
+
+## High-Level Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    Python Import System                  │
+├─────────────────────────────────────────────────────────┤
+│  sys.meta_path.insert(0, MindTorchV2Finder)             │
+│         │                                                │
+│         ▼                                                │
+│  ┌─────────────────┐    ┌─────────────────────────────┐ │
+│  │ MindTorchV2Finder│───▶│ MindTorchV2Loader          │ │
+│  │ (finds torch.*)  │    │ (returns shim modules)     │ │
+│  └─────────────────┘    └─────────────────────────────┘ │
+│                                   │                      │
+│                                   ▼                      │
+│                    ┌─────────────────────────────────┐  │
+│                    │      mindtorch_v2 + shims       │  │
+│                    │  ┌───────────┬───────────────┐  │  │
+│                    │  │ Real impl │ Stub modules  │  │  │
+│                    │  │ (Tensor,  │ (_C, _dynamo, │  │  │
+│                    │  │  nn, etc) │  jit, etc)    │  │  │
+│                    │  └───────────┴───────────────┘  │  │
+│                    └─────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────┘
+```
+
+## Module Classification
+
+### Tier 1: Real Implementation (must work correctly)
+
+Actually used by BERT's forward/backward:
+
+| torch module | mindtorch_v2 equivalent |
+|--------------|------------------------|
+| `torch` | `mindtorch_v2` |
+| `torch.nn` | `mindtorch_v2.nn` |
+| `torch.nn.functional` | `mindtorch_v2.nn.functional` |
+| `torch.nn.Module` | `mindtorch_v2.nn.Module` |
+| `torch.Tensor` | `mindtorch_v2.Tensor` |
+| `torch.autograd` | `mindtorch_v2._autograd` |
+
+### Tier 2: Functional Stubs (called but can be no-ops)
+
+Called but don't affect BERT correctness:
+
+| Function | Stub behavior |
+|----------|---------------|
+| `torch.cuda.is_available()` | `return False` |
+| `torch.jit.script()` | `return function unchanged` |
+| `torch.compile()` | `return function unchanged` |
+| `torch.backends.cudnn.enabled` | `False` |
+| `torch.distributed.is_initialized()` | `return False` |
+
+### Tier 3: Import-Only Stubs (must exist but never called)
+
+Imported by transformers' init but BERT never uses:
+
+| Module | Stub approach |
+|--------|---------------|
+| `torch._C` | Empty module with `__getattr__` returning None |
+| `torch._dynamo` | Empty module |
+| `torch._inductor` | Empty module |
+| `torch.utils._pytree` | Minimal `tree_flatten`/`tree_unflatten` |
+
+## File Structure
+
+```
+src/mindtorch_v2/
+├── __init__.py              # Main module (already exists)
+├── _torch_proxy/            # NEW: Proxy loader system
+│   ├── __init__.py          # Initializes proxy, exports install()
+│   ├── finder.py            # MindTorchV2Finder class
+│   ├── loader.py            # MindTorchV2Loader class
+│   └── stubs/               # Stub modules for Tier 2 & 3
+│       ├── __init__.py
+│       ├── _C.py            # torch._C stub
+│       ├── cuda.py          # torch.cuda stub
+│       ├── jit.py           # torch.jit stub
+│       ├── backends.py      # torch.backends stub
+│       ├── distributed.py   # torch.distributed stub
+│       └── _pytree.py       # torch.utils._pytree stub
+├── _tensor.py               # (exists)
+├── _autograd/               # (exists)
+├── nn/                      # (exists)
+└── optim/                   # (exists)
+```
+
+## Implementation Details
+
+### MindTorchV2Finder
+
+```python
+class MindTorchV2Finder:
+    """Intercept all torch.* imports."""
+
+    def find_module(self, fullname, path=None):
+        if fullname == 'torch' or fullname.startswith('torch.'):
+            return MindTorchV2Loader()
+        return None  # Let normal import handle non-torch
+```
+
+### MindTorchV2Loader
+
+```python
+class MindTorchV2Loader:
+    """Return mindtorch_v2 or stubs for torch.* imports."""
+
+    REAL_MODULES = {
+        'torch': 'mindtorch_v2',
+        'torch.nn': 'mindtorch_v2.nn',
+        'torch.nn.functional': 'mindtorch_v2.nn.functional',
+        'torch.optim': 'mindtorch_v2.optim',
+        'torch.autograd': 'mindtorch_v2._autograd',
+    }
+
+    def load_module(self, fullname):
+        if fullname in self.REAL_MODULES:
+            real_name = self.REAL_MODULES[fullname]
+            module = importlib.import_module(real_name)
+        else:
+            module = self._create_stub(fullname)
+
+        sys.modules[fullname] = module
+        return module
+```
+
+### Critical Stubs
+
+**torch._C:**
+```python
+class _C:
+    def __getattr__(self, name):
+        return None
+```
+
+**torch.utils._pytree:**
+```python
+def tree_flatten(obj):
+    if isinstance(obj, (list, tuple)):
+        return list(obj), type(obj)
+    return [obj], None
+
+def tree_unflatten(values, spec):
+    if spec is None:
+        return values[0]
+    return spec(values)
+```
+
+**torch.cuda:**
+```python
+def is_available(): return False
+def device_count(): return 0
+def current_device(): return 0
+def synchronize(): pass
+```
+
+**torch.jit:**
+```python
+def script(fn): return fn
+def trace(fn, *args): return fn
+def is_scripting(): return False
+def is_tracing(): return False
+```
+
+### Missing Tier 1 Implementations
+
+**Add to mindtorch_v2/__init__.py:**
+```python
+FloatTensor = lambda *args: Tensor(*args, dtype=float32)
+LongTensor = lambda *args: Tensor(*args, dtype=int64)
+from_numpy = lambda arr: Tensor(arr)
+einsum = lambda eq, *ops: Tensor(np.einsum(eq, *[o.numpy() for o in ops]))
+compile = lambda fn: fn  # No-op for now
+```
+
+**Add to mindtorch_v2/nn/functional.py:**
+```python
+def scaled_dot_product_attention(query, key, value, attn_mask=None, ...):
+    scores = matmul(query, key.transpose(-2, -1)) / math.sqrt(query.shape[-1])
+    if attn_mask is not None:
+        scores = scores + attn_mask
+    attn = softmax(scores, dim=-1)
+    return matmul(attn, value)
+```
+
+## Verification Strategy
+
+```
+Step 1: Import succeeds
+────────────────────────
+from mindtorch_v2._torch_proxy import install
+install()
+from transformers import BertModel, BertConfig  # No error
+
+Step 2: Model creation works
+────────────────────────────
+config = BertConfig(hidden_size=64, num_hidden_layers=2, ...)
+model = BertModel(config)  # No error
+
+Step 3: Forward pass works
+──────────────────────────
+input_ids = torch.randint(0, 1000, (2, 8))
+output = model(input_ids)
+assert output.last_hidden_state.shape == (2, 8, 64)
+
+Step 4: Backward pass works
+───────────────────────────
+loss = output.last_hidden_state.sum()
+loss.backward()
+assert all(p.grad is not None for p in model.parameters())
+
+Step 5: Test suite passes
+─────────────────────────
+pytest tests/transformers/tests/models/bert/test_modeling_bert.py::BertModelTest::test_model
+```
+
+## Implementation Tasks
+
+1. Create `_torch_proxy/` directory structure
+2. Implement `MindTorchV2Finder` and `MindTorchV2Loader`
+3. Create Tier 3 stubs (`_C`, `_pytree`, `_dynamo`, etc.)
+4. Create Tier 2 stubs (`cuda`, `jit`, `backends`, `distributed`)
+5. Add missing Tier 1 functions to mindtorch_v2
+6. Add `scaled_dot_product_attention` to nn.functional
+7. Verify Step 1-4 progressively
+8. Run `BertModelTest::test_model` and fix failures

--- a/src/mindtorch_v2/__init__.py
+++ b/src/mindtorch_v2/__init__.py
@@ -7,6 +7,8 @@ from ._storage import TypedStorage, UntypedStorage
 from ._dtype import (
     # Core dtypes
     float16, float32, float64, bfloat16,
+    # Float8 dtypes
+    float8_e4m3fn, float8_e4m3fnuz, float8_e5m2, float8_e5m2fnuz,
     int8, int16, int32, int64,
     uint8, uint16, uint32, uint64,
     bool, complex64, complex128,
@@ -22,7 +24,7 @@ from ._tensor import Tensor
 from ._creation import (
     tensor, zeros, ones, empty, full,
     arange, linspace, eye,
-    randn, rand,
+    randn, rand, randint,
     zeros_like, ones_like, empty_like,
     from_numpy,
 )
@@ -32,6 +34,16 @@ from ._functional import (
     matmul,
     sum, mean, max, min, prod, argmax, argmin,
     eq, ne, gt, lt, ge, le,
+    # Tensor manipulation
+    cat, stack, split, chunk, clone, where,
+    # Additional math ops
+    var, std, clamp, rsqrt, reciprocal, bmm, baddbmm,
+    # Boolean reductions
+    all, any,
+    # Element testing
+    isin,
+    # Top-k and sampling
+    topk, multinomial,
 )
 from ._autograd import (
     is_grad_enabled,
@@ -42,3 +54,17 @@ from ._autograd import (
 
 # Import backends to register ops
 from ._backends import cpu
+
+# Import submodules
+from . import nn
+from . import optim
+
+# Memory format constants (for PyTorch API compatibility)
+class memory_format:
+    """Memory format enumeration."""
+    pass
+
+contiguous_format = memory_format()
+preserve_format = memory_format()
+channels_last = memory_format()
+channels_last_3d = memory_format()

--- a/src/mindtorch_v2/_creation.py
+++ b/src/mindtorch_v2/_creation.py
@@ -132,3 +132,24 @@ def from_numpy(ndarray):
     arr = np.ascontiguousarray(ndarray)
     dt = dtype_mod.numpy_to_dtype(arr.dtype)
     return Tensor(arr, dtype=dt)
+
+
+def randint(low, high=None, size=None, *, dtype=None, device=None, requires_grad=False):
+    """Create tensor with random integers in [low, high).
+
+    Args:
+        low: Lowest integer (inclusive), or high if high is None
+        high: One above highest integer (exclusive)
+        size: Shape of output tensor
+    """
+    if high is None:
+        high = low
+        low = 0
+    if size is None:
+        size = ()
+    if isinstance(size, int):
+        size = (size,)
+
+    dt = dtype or dtype_mod.int64
+    arr = np.random.randint(low, high, size=size)
+    return Tensor(arr, dtype=dt, device=device, requires_grad=requires_grad)

--- a/src/mindtorch_v2/_dispatch/dispatcher.py
+++ b/src/mindtorch_v2/_dispatch/dispatcher.py
@@ -55,15 +55,20 @@ def _make_grad_fn(op_name: str, args, result, kwargs=None):
         'sum': F.SumBackward,
         'mean': F.MeanBackward,
         'matmul': F.MatmulBackward,
+        'bmm': F.BmmBackward,
         'exp': F.ExpBackward,
         'log': F.LogBackward,
         'sqrt': F.SqrtBackward,
+        'tanh': F.TanhBackward,
         'transpose': F.TransposeBackward,
         'embedding': F.EmbeddingBackward,
         'layer_norm': F.LayerNormBackward,
         'relu': F.ReluBackward,
         'gelu': F.GeluBackward,
         'silu': F.SiluBackward,
+        'softmax': F.SoftmaxBackward,
+        'clone': F.CloneBackward,
+        'dropout': F.DropoutBackward,
     }
 
     BackwardClass = backward_classes.get(op_name)
@@ -72,37 +77,134 @@ def _make_grad_fn(op_name: str, args, result, kwargs=None):
 
     grad_fn = BackwardClass()
 
-    # Build next_functions
+    # Build next_functions - special handling for ops with complex signatures
     next_fns = []
     tensors_to_save = []
 
-    for arg in args:
-        if isinstance(arg, Tensor):
-            if arg.requires_grad:
-                if arg.grad_fn is not None:
-                    next_fns.append((arg.grad_fn, 0))
-                else:
-                    # Leaf tensor - create AccumulateGrad
-                    acc_grad = AccumulateGrad(arg)
-                    next_fns.append((acc_grad, 0))
+    if op_name == 'layer_norm':
+        # layer_norm args: (input, normalized_shape, weight, bias, eps)
+        # We need to track: input, weight, bias
+        input_tensor = args[0]
+        weight = args[2] if len(args) > 2 else kwargs.get('weight')
+        bias = args[3] if len(args) > 3 else kwargs.get('bias')
+
+        # Input tensor
+        if isinstance(input_tensor, Tensor) and input_tensor.requires_grad:
+            if input_tensor.grad_fn is not None:
+                next_fns.append((input_tensor.grad_fn, 0))
             else:
-                next_fns.append((None, 0))
-            tensors_to_save.append(arg)
+                acc_grad = AccumulateGrad(input_tensor)
+                next_fns.append((acc_grad, 0))
         else:
-            # Scalar - wrap in tensor for saving
-            tensors_to_save.append(Tensor(arg))
+            next_fns.append((None, 0))
+
+        # normalized_shape - not a tensor, no gradient
+        next_fns.append((None, 0))
+
+        # Weight tensor
+        if weight is not None and isinstance(weight, Tensor) and weight.requires_grad:
+            if weight.grad_fn is not None:
+                next_fns.append((weight.grad_fn, 0))
+            else:
+                acc_grad = AccumulateGrad(weight)
+                next_fns.append((acc_grad, 0))
+        else:
+            next_fns.append((None, 0))
+
+        # Bias tensor
+        if bias is not None and isinstance(bias, Tensor) and bias.requires_grad:
+            if bias.grad_fn is not None:
+                next_fns.append((bias.grad_fn, 0))
+            else:
+                acc_grad = AccumulateGrad(bias)
+                next_fns.append((acc_grad, 0))
+        else:
+            next_fns.append((None, 0))
+
+        # eps - not a tensor, no gradient
+        next_fns.append((None, 0))
+
+    elif op_name == 'embedding':
+        # embedding args: (indices, weight)
+        # Only weight needs gradient, indices don't
+        indices = args[0]
+        weight = args[1]
+
+        # Indices - no gradient
+        next_fns.append((None, 0))
+
+        # Weight tensor
+        if isinstance(weight, Tensor) and weight.requires_grad:
+            if weight.grad_fn is not None:
+                next_fns.append((weight.grad_fn, 0))
+            else:
+                acc_grad = AccumulateGrad(weight)
+                next_fns.append((acc_grad, 0))
+        else:
+            next_fns.append((None, 0))
+
+        tensors_to_save = [indices, weight]
+
+    else:
+        # Default handling for other ops
+        for arg in args:
+            if isinstance(arg, Tensor):
+                if arg.requires_grad:
+                    if arg.grad_fn is not None:
+                        next_fns.append((arg.grad_fn, 0))
+                    else:
+                        # Leaf tensor - create AccumulateGrad
+                        acc_grad = AccumulateGrad(arg)
+                        next_fns.append((acc_grad, 0))
+                else:
+                    next_fns.append((None, 0))
+                tensors_to_save.append(arg)
+            else:
+                # Non-tensor args don't get gradients
+                pass
 
     grad_fn._next_functions = tuple(next_fns)
 
     # Save tensors for backward
-    if op_name in ('mul', 'div', 'pow', 'matmul', 'embedding'):
+    if op_name == 'mul':
+        # Handle scalar multiplier
+        if len(tensors_to_save) == 1:
+            grad_fn.save_for_backward(tensors_to_save[0])
+            # Find the scalar (non-tensor) argument
+            for arg in args:
+                if not isinstance(arg, Tensor):
+                    grad_fn._scalar_multiplier = arg
+                    break
+        else:
+            grad_fn.save_for_backward(*tensors_to_save)
+    elif op_name == 'pow':
+        # Handle scalar exponent
+        if len(tensors_to_save) == 1:
+            grad_fn.save_for_backward(tensors_to_save[0])
+            # Find the scalar (non-tensor) argument - the exponent
+            for arg in args[1:]:  # Skip first arg (base)
+                if not isinstance(arg, Tensor):
+                    grad_fn._scalar_exponent = arg
+                    break
+        else:
+            grad_fn.save_for_backward(*tensors_to_save)
+    elif op_name in ('matmul', 'embedding', 'bmm'):
         grad_fn.save_for_backward(*tensors_to_save)
+    elif op_name == 'div':
+        # Handle scalar divisor
+        if len(tensors_to_save) == 1:
+            grad_fn.save_for_backward(tensors_to_save[0])
+            grad_fn._scalar_divisor = args[1]  # Save the scalar
+        else:
+            grad_fn.save_for_backward(*tensors_to_save)
     elif op_name == 'exp':
         grad_fn.save_for_backward(result)  # Save result for exp backward
     elif op_name == 'log':
         grad_fn.save_for_backward(tensors_to_save[0])  # Save input
     elif op_name == 'sqrt':
         grad_fn.save_for_backward(result)  # Save result
+    elif op_name == 'tanh':
+        grad_fn.save_for_backward(result)  # Save result (tanh output)
     elif op_name in ('sum', 'mean'):
         grad_fn._input_shape = tensors_to_save[0].shape
     elif op_name == 'transpose':
@@ -122,6 +224,20 @@ def _make_grad_fn(op_name: str, args, result, kwargs=None):
     elif op_name == 'gelu':
         grad_fn.save_for_backward(tensors_to_save[0])  # Save input
         grad_fn._approximate = kwargs.get('approximate', 'none')
+    elif op_name == 'softmax':
+        grad_fn.save_for_backward(result)  # Save softmax output
+        grad_fn._dim = kwargs.get('dim', -1)
+    elif op_name == 'clone':
+        pass  # No tensors to save for clone
+    elif op_name in ('add', 'sub'):
+        # Save shapes for broadcasting gradient reduction
+        if len(tensors_to_save) >= 2:
+            grad_fn._a_shape = tensors_to_save[0].shape
+            grad_fn._b_shape = tensors_to_save[1].shape
+        elif len(tensors_to_save) == 1:
+            # Scalar case
+            grad_fn._a_shape = tensors_to_save[0].shape
+            grad_fn._b_shape = ()
 
     return grad_fn
 
@@ -158,13 +274,22 @@ def dispatch(op_name: str, *args, **kwargs) -> Any:
             f"No implementation found for op '{op_name}' with dispatch key {backend_key}"
         )
 
-    # Execute forward
-    result = impl(*args, **kwargs)
+    # Special handling for dropout - need mask for backward
+    mask = None
+    if op_name == 'dropout' and is_grad_enabled() and _requires_grad(args):
+        result, mask = impl(*args, **kwargs, return_mask=True)
+    else:
+        # Execute forward
+        result = impl(*args, **kwargs)
 
     # Record autograd if needed
     if is_grad_enabled() and _requires_grad(args) and isinstance(result, Tensor):
         grad_fn = _make_grad_fn(op_name, args, result, kwargs)
         if grad_fn is not None:
+            # Special handling for dropout - save mask
+            if op_name == 'dropout' and mask is not None:
+                grad_fn._mask = mask
+                grad_fn._p = kwargs.get('p', 0.5)
             result._grad_fn = grad_fn
             result._requires_grad = True
 

--- a/src/mindtorch_v2/_dtype.py
+++ b/src/mindtorch_v2/_dtype.py
@@ -56,6 +56,12 @@ float32 = DType("float32", mindspore.float32, np.float32, 4, is_float=True)
 float64 = DType("float64", mindspore.float64, np.float64, 8, is_float=True)
 bfloat16 = DType("bfloat16", mindspore.bfloat16, None, 2, is_float=True)
 
+# Float8 dtypes (stub - MindSpore may not natively support these)
+float8_e4m3fn = DType("float8_e4m3fn", None, None, 1, is_float=True)
+float8_e4m3fnuz = DType("float8_e4m3fnuz", None, None, 1, is_float=True)
+float8_e5m2 = DType("float8_e5m2", None, None, 1, is_float=True)
+float8_e5m2fnuz = DType("float8_e5m2fnuz", None, None, 1, is_float=True)
+
 int8 = DType("int8", mindspore.int8, np.int8, 1)
 int16 = DType("int16", mindspore.int16, np.int16, 2)
 int32 = DType("int32", mindspore.int32, np.int32, 4)

--- a/src/mindtorch_v2/_functional.py
+++ b/src/mindtorch_v2/_functional.py
@@ -149,3 +149,97 @@ def ge(input, other, *, out=None):
 def le(input, other, *, out=None):
     """Element-wise less than or equal comparison."""
     return dispatch("le", input, other)
+
+
+# --- Tensor manipulation ops ---
+
+def cat(tensors, dim=0, *, out=None):
+    """Concatenate tensors along a dimension."""
+    return dispatch("cat", tensors, dim=dim)
+
+
+def stack(tensors, dim=0, *, out=None):
+    """Stack tensors along a new dimension."""
+    return dispatch("stack", tensors, dim=dim)
+
+
+def split(tensor, split_size_or_sections, dim=0):
+    """Split tensor into chunks."""
+    return dispatch("split", tensor, split_size_or_sections, dim=dim)
+
+
+def chunk(input, chunks, dim=0):
+    """Split tensor into specified number of chunks."""
+    return dispatch("chunk", input, chunks, dim=dim)
+
+
+def clone(input, *, memory_format=None):
+    """Create a copy of tensor with new storage."""
+    return dispatch("clone", input)
+
+
+def where(condition, input, other):
+    """Select elements based on condition."""
+    return dispatch("where", condition, input, other)
+
+
+# --- Additional math ops ---
+
+def var(input, dim=None, *, correction=1, keepdim=False, out=None):
+    """Variance of tensor elements."""
+    return dispatch("var", input, dim=dim, correction=correction, keepdim=keepdim)
+
+
+def std(input, dim=None, *, correction=1, keepdim=False, out=None):
+    """Standard deviation of tensor elements."""
+    return dispatch("std", input, dim=dim, correction=correction, keepdim=keepdim)
+
+
+def clamp(input, min=None, max=None, *, out=None):
+    """Clamp values to range [min, max]."""
+    return dispatch("clamp", input, min=min, max=max)
+
+
+def rsqrt(input, *, out=None):
+    """Reciprocal square root element-wise."""
+    return dispatch("rsqrt", input)
+
+
+def reciprocal(input, *, out=None):
+    """Reciprocal (1/x) element-wise."""
+    return dispatch("reciprocal", input)
+
+
+def bmm(input, mat2, *, out=None):
+    """Batched matrix multiplication."""
+    return dispatch("bmm", input, mat2)
+
+
+def baddbmm(input, batch1, batch2, *, beta=1, alpha=1, out=None):
+    """Batched matrix multiply with add: beta*input + alpha*(batch1 @ batch2)."""
+    return dispatch("baddbmm", input, batch1, batch2, beta=beta, alpha=alpha)
+
+
+def all(input, dim=None, keepdim=False, *, out=None):
+    """Test if all elements evaluate to True."""
+    return dispatch("all", input, dim=dim, keepdim=keepdim)
+
+
+def any(input, dim=None, keepdim=False, *, out=None):
+    """Test if any element evaluates to True."""
+    return dispatch("any", input, dim=dim, keepdim=keepdim)
+
+
+def isin(elements, test_elements, *, assume_unique=False, invert=False):
+    """Test if each element of elements is in test_elements."""
+    return dispatch("isin", elements, test_elements, assume_unique=assume_unique, invert=invert)
+
+
+def topk(input, k, dim=-1, largest=True, sorted=True, *, out=None):
+    """Return the k largest/smallest elements along a dimension."""
+    return dispatch("topk", input, k, dim=dim, largest=largest, sorted=sorted)
+
+
+def multinomial(input, num_samples, replacement=False, *, generator=None, out=None):
+    """Draw samples from a multinomial distribution."""
+    return dispatch("multinomial", input, num_samples, replacement=replacement, generator=generator)

--- a/src/mindtorch_v2/_torch_proxy/__init__.py
+++ b/src/mindtorch_v2/_torch_proxy/__init__.py
@@ -1,0 +1,53 @@
+"""Torch proxy system for mindtorch_v2.
+
+This module provides a proxy loader that intercepts `import torch`
+and returns mindtorch_v2 instead, enabling HuggingFace transformers
+to work with mindtorch_v2 as the backend.
+
+Usage:
+    from mindtorch_v2._torch_proxy import install
+    install()  # Now `import torch` returns mindtorch_v2
+
+    from transformers import BertModel  # Uses mindtorch_v2
+"""
+
+from .finder import MindTorchV2Finder
+from .loader import MindTorchV2Loader
+
+_installed = False
+
+
+def install():
+    """Install the torch proxy into sys.meta_path.
+
+    After calling this, `import torch` will return mindtorch_v2.
+    """
+    global _installed
+    if _installed:
+        return
+
+    import sys
+
+    # Insert our finder at the beginning of meta_path
+    finder = MindTorchV2Finder()
+    sys.meta_path.insert(0, finder)
+    _installed = True
+
+
+def uninstall():
+    """Remove the torch proxy from sys.meta_path."""
+    global _installed
+    if not _installed:
+        return
+
+    import sys
+
+    # Remove all MindTorchV2Finder instances
+    sys.meta_path = [f for f in sys.meta_path if not isinstance(f, MindTorchV2Finder)]
+
+    # Clear torch modules from sys.modules
+    torch_modules = [k for k in sys.modules.keys() if k == 'torch' or k.startswith('torch.')]
+    for mod in torch_modules:
+        del sys.modules[mod]
+
+    _installed = False

--- a/src/mindtorch_v2/_torch_proxy/finder.py
+++ b/src/mindtorch_v2/_torch_proxy/finder.py
@@ -1,0 +1,37 @@
+"""MindTorchV2Finder - Intercepts torch imports."""
+
+import sys
+
+
+class MindTorchV2Finder:
+    """Meta path finder that intercepts all torch.* imports.
+
+    When installed in sys.meta_path, this finder will catch any
+    import of torch or torch.* and delegate to MindTorchV2Loader.
+    """
+
+    def find_module(self, fullname, path=None):
+        """Find module hook for the import system.
+
+        Args:
+            fullname: Full module name being imported (e.g., 'torch.nn')
+            path: Optional path for the module
+
+        Returns:
+            MindTorchV2Loader if this is a torch import, None otherwise
+        """
+        if fullname == 'torch' or fullname.startswith('torch.'):
+            from .loader import MindTorchV2Loader
+            return MindTorchV2Loader()
+        return None
+
+    def find_spec(self, fullname, path=None, target=None):
+        """Find spec hook for the import system (Python 3.4+).
+
+        Returns None to indicate we handle this via find_module/load_module.
+        """
+        if fullname == 'torch' or fullname.startswith('torch.'):
+            from importlib.machinery import ModuleSpec
+            from .loader import MindTorchV2Loader
+            return ModuleSpec(fullname, MindTorchV2Loader())
+        return None

--- a/src/mindtorch_v2/_torch_proxy/stubs/_C.py
+++ b/src/mindtorch_v2/_torch_proxy/stubs/_C.py
@@ -1,0 +1,57 @@
+"""Stub for torch._C - PyTorch's C++ extension module.
+
+This is a Tier 3 stub - imported by transformers but not actually
+used for BERT forward/backward passes.
+"""
+
+from types import ModuleType
+
+
+class _CStub(ModuleType):
+    """Stub module that returns None for any attribute access."""
+
+    def __getattr__(self, name):
+        # Return None for most attributes
+        return None
+
+    def __call__(self, *args, **kwargs):
+        return None
+
+
+# Create module-level attributes that transformers might check
+_C = _CStub('torch._C')
+
+# Common attributes that might be accessed
+_C._get_tracing_state = lambda: None
+_C._is_tracing = lambda: False
+_C.ScriptModule = type('ScriptModule', (), {})
+_C.ScriptFunction = type('ScriptFunction', (), {})
+_C.Graph = type('Graph', (), {})
+_C.Node = type('Node', (), {})
+_C.Value = type('Value', (), {})
+_C.Type = type('Type', (), {})
+_C.TensorType = type('TensorType', (), {})
+_C.ListType = type('ListType', (), {})
+_C.DictType = type('DictType', (), {})
+_C.OptionalType = type('OptionalType', (), {})
+_C.TupleType = type('TupleType', (), {})
+_C.ClassType = type('ClassType', (), {})
+_C.InterfaceType = type('InterfaceType', (), {})
+_C.AnyType = type('AnyType', (), {})
+_C.NoneType = type('NoneType', (), {})
+_C.BoolType = type('BoolType', (), {})
+_C.IntType = type('IntType', (), {})
+_C.FloatType = type('FloatType', (), {})
+_C.ComplexType = type('ComplexType', (), {})
+_C.StringType = type('StringType', (), {})
+_C.DeviceObjType = type('DeviceObjType', (), {})
+_C.StreamObjType = type('StreamObjType', (), {})
+_C.FunctionType = type('FunctionType', (), {})
+_C.PyObjectType = type('PyObjectType', (), {})
+
+# Export all attributes
+__all__ = ['_C']
+
+# Make this module behave like _C itself
+import sys
+sys.modules[__name__].__class__ = _CStub

--- a/src/mindtorch_v2/_torch_proxy/stubs/__init__.py
+++ b/src/mindtorch_v2/_torch_proxy/stubs/__init__.py
@@ -1,0 +1,1 @@
+"""Stub modules for torch internals that transformers imports but doesn't use."""

--- a/src/mindtorch_v2/_torch_proxy/stubs/_pytree.py
+++ b/src/mindtorch_v2/_torch_proxy/stubs/_pytree.py
@@ -1,0 +1,149 @@
+"""Stub for torch.utils._pytree - Tree utilities.
+
+This is a Tier 3 stub that provides minimal tree_flatten/tree_unflatten
+functionality that transformers may use.
+"""
+
+from collections import namedtuple
+
+
+# Tree spec for reconstruction
+TreeSpec = namedtuple('TreeSpec', ['type', 'context', 'children_specs'])
+
+
+def tree_flatten(obj):
+    """Flatten a nested structure into a list of leaves and a TreeSpec.
+
+    Args:
+        obj: A nested structure (list, tuple, dict, or leaf)
+
+    Returns:
+        Tuple of (list of leaves, TreeSpec for reconstruction)
+    """
+    if obj is None:
+        return [], TreeSpec(type(None), None, [])
+
+    if isinstance(obj, (list, tuple)):
+        leaves = []
+        children_specs = []
+        for item in obj:
+            item_leaves, item_spec = tree_flatten(item)
+            leaves.extend(item_leaves)
+            children_specs.append(item_spec)
+        return leaves, TreeSpec(type(obj), None, children_specs)
+
+    if isinstance(obj, dict):
+        leaves = []
+        children_specs = []
+        keys = list(obj.keys())
+        for key in keys:
+            item_leaves, item_spec = tree_flatten(obj[key])
+            leaves.extend(item_leaves)
+            children_specs.append(item_spec)
+        return leaves, TreeSpec(dict, keys, children_specs)
+
+    # Leaf node
+    return [obj], TreeSpec(type(obj), None, [])
+
+
+def tree_unflatten(leaves, treespec):
+    """Reconstruct a nested structure from leaves and a TreeSpec.
+
+    Args:
+        leaves: List of leaf values
+        treespec: TreeSpec describing the structure
+
+    Returns:
+        Reconstructed nested structure
+    """
+    if treespec.type is type(None):
+        return None
+
+    if treespec.type in (list, tuple):
+        result = []
+        leaf_idx = 0
+        for child_spec in treespec.children_specs:
+            num_leaves = _count_leaves(child_spec)
+            child_leaves = leaves[leaf_idx:leaf_idx + num_leaves]
+            result.append(tree_unflatten(child_leaves, child_spec))
+            leaf_idx += num_leaves
+        return treespec.type(result)
+
+    if treespec.type is dict:
+        result = {}
+        keys = treespec.context
+        leaf_idx = 0
+        for i, child_spec in enumerate(treespec.children_specs):
+            num_leaves = _count_leaves(child_spec)
+            child_leaves = leaves[leaf_idx:leaf_idx + num_leaves]
+            result[keys[i]] = tree_unflatten(child_leaves, child_spec)
+            leaf_idx += num_leaves
+        return result
+
+    # Leaf node
+    return leaves[0] if leaves else None
+
+
+def _count_leaves(treespec):
+    """Count the number of leaves in a TreeSpec."""
+    if not treespec.children_specs:
+        return 1
+    return sum(_count_leaves(child) for child in treespec.children_specs)
+
+
+def tree_map(fn, tree):
+    """Apply a function to all leaves in a tree.
+
+    Args:
+        fn: Function to apply to each leaf
+        tree: Nested structure
+
+    Returns:
+        New tree with fn applied to all leaves
+    """
+    leaves, spec = tree_flatten(tree)
+    new_leaves = [fn(leaf) for leaf in leaves]
+    return tree_unflatten(new_leaves, spec)
+
+
+def tree_map_only(ty, fn, tree):
+    """Apply function only to leaves of a specific type."""
+    def conditional_fn(x):
+        if isinstance(x, ty):
+            return fn(x)
+        return x
+    return tree_map(conditional_fn, tree)
+
+
+# PyTree registration (no-op for our purposes)
+def register_pytree_node(cls, flatten_fn, unflatten_fn, *, serialized_type_name=None, **kwargs):
+    """Register a custom type for pytree operations."""
+    pass
+
+
+# Context for pytree operations
+class _TreeContext:
+    pass
+
+
+# Additional utilities that transformers might use
+def tree_leaves(tree):
+    """Get all leaves from a tree."""
+    leaves, _ = tree_flatten(tree)
+    return leaves
+
+
+def tree_structure(tree):
+    """Get the TreeSpec of a tree."""
+    _, spec = tree_flatten(tree)
+    return spec
+
+
+def tree_all(fn, tree):
+    """Check if fn returns True for all leaves."""
+    return all(fn(leaf) for leaf in tree_leaves(tree))
+
+
+def tree_any(fn, tree):
+    """Check if fn returns True for any leaf."""
+    return any(fn(leaf) for leaf in tree_leaves(tree))

--- a/src/mindtorch_v2/_torch_proxy/stubs/amp.py
+++ b/src/mindtorch_v2/_torch_proxy/stubs/amp.py
@@ -1,0 +1,132 @@
+"""Stub for torch.amp - Automatic Mixed Precision.
+
+Tier 2 stub: provides context managers that are no-ops.
+"""
+
+from contextlib import contextmanager, nullcontext
+
+
+@contextmanager
+def autocast(device_type='cuda', dtype=None, enabled=True, cache_enabled=True):
+    """Automatic mixed precision context manager."""
+    yield
+
+
+class GradScaler:
+    """Gradient scaler for mixed precision training."""
+
+    def __init__(self, device='cuda', init_scale=65536.0, growth_factor=2.0,
+                 backoff_factor=0.5, growth_interval=2000, enabled=True):
+        self._enabled = enabled
+        self._scale = init_scale
+
+    def scale(self, outputs):
+        """Scale loss."""
+        return outputs
+
+    def unscale_(self, optimizer):
+        """Unscale gradients."""
+        pass
+
+    def step(self, optimizer, *args, **kwargs):
+        """Optimizer step with gradient unscaling."""
+        optimizer.step(*args, **kwargs)
+
+    def update(self, new_scale=None):
+        """Update scale."""
+        if new_scale is not None:
+            self._scale = new_scale
+
+    def get_scale(self):
+        """Get current scale."""
+        return self._scale
+
+    def is_enabled(self):
+        """Check if scaler is enabled."""
+        return self._enabled
+
+    def state_dict(self):
+        """Return state dict."""
+        return {
+            'scale': self._scale,
+            '_enabled': self._enabled,
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load state dict."""
+        self._scale = state_dict.get('scale', self._scale)
+        self._enabled = state_dict.get('_enabled', self._enabled)
+
+    def get_growth_factor(self):
+        return 2.0
+
+    def set_growth_factor(self, new_factor):
+        pass
+
+    def get_backoff_factor(self):
+        return 0.5
+
+    def set_backoff_factor(self, new_factor):
+        pass
+
+    def get_growth_interval(self):
+        return 2000
+
+    def set_growth_interval(self, new_interval):
+        pass
+
+
+# Custom autocast decorator
+def custom_fwd(fwd=None, *, cast_inputs=None):
+    """Decorator for custom forward with autocast."""
+    def decorator(fn):
+        return fn
+    if fwd is None:
+        return decorator
+    return fwd
+
+
+def custom_bwd(bwd):
+    """Decorator for custom backward with autocast."""
+    return bwd
+
+
+# Check functions
+def is_autocast_available(device_type):
+    """Check if autocast is available for device type."""
+    return False
+
+
+def is_autocast_enabled(device_type='cuda'):
+    """Check if autocast is enabled."""
+    return False
+
+
+def get_autocast_dtype(device_type='cuda'):
+    """Get autocast dtype."""
+    return None
+
+
+def set_autocast_enabled(device_type, enabled):
+    """Set autocast enabled state."""
+    pass
+
+
+def set_autocast_dtype(device_type, dtype):
+    """Set autocast dtype."""
+    pass
+
+
+def autocast_increment_nesting():
+    """Increment autocast nesting level."""
+    return 0
+
+
+def autocast_decrement_nesting():
+    """Decrement autocast nesting level."""
+    return 0
+
+
+def clear_autocast_cache():
+    """Clear autocast cache."""
+    pass

--- a/src/mindtorch_v2/_torch_proxy/stubs/backends.py
+++ b/src/mindtorch_v2/_torch_proxy/stubs/backends.py
@@ -1,0 +1,174 @@
+"""Stub for torch.backends - Backend configurations.
+
+Tier 2 stub: provides configuration flags but no actual backend functionality.
+"""
+
+
+class cuda:
+    """CUDA backend configuration."""
+
+    @staticmethod
+    def is_built():
+        """Check if CUDA backend is built."""
+        return False
+
+    # Matrix multiplication settings
+    matmul = type('matmul', (), {
+        'allow_tf32': False,
+        'allow_fp16_reduced_precision_reduction': True,
+        'allow_bf16_reduced_precision_reduction': True,
+    })()
+
+    # Flash attention settings
+    flash_sdp_enabled = lambda: False
+    enable_flash_sdp = lambda enable: None
+    math_sdp_enabled = lambda: True
+    enable_math_sdp = lambda enable: None
+    mem_efficient_sdp_enabled = lambda: False
+    enable_mem_efficient_sdp = lambda enable: None
+
+    # cuBLAS settings
+    cublaslt_enabled = False
+
+    # Prefer channels last
+    preferred_linalg_library = lambda lib=None: None
+
+
+class cudnn:
+    """cuDNN backend configuration."""
+
+    enabled = False
+    benchmark = False
+    deterministic = True
+    allow_tf32 = False
+    version = lambda: None
+
+    @staticmethod
+    def is_available():
+        """Check if cuDNN is available."""
+        return False
+
+
+class mkl:
+    """MKL backend configuration."""
+
+    @staticmethod
+    def is_available():
+        """Check if MKL is available."""
+        return False
+
+    verbose = False
+
+
+class mkldnn:
+    """MKL-DNN (oneDNN) backend configuration."""
+
+    @staticmethod
+    def is_available():
+        """Check if MKL-DNN is available."""
+        return False
+
+    enabled = False
+
+
+class openmp:
+    """OpenMP backend configuration."""
+
+    @staticmethod
+    def is_available():
+        """Check if OpenMP is available."""
+        return False
+
+
+class opt_einsum:
+    """opt_einsum backend configuration."""
+
+    enabled = True
+    strategy = 'auto'
+
+    @staticmethod
+    def is_available():
+        """Check if opt_einsum is available."""
+        try:
+            import opt_einsum
+            return True
+        except ImportError:
+            return False
+
+    @staticmethod
+    def get_opt_einsum():
+        """Get opt_einsum module."""
+        try:
+            import opt_einsum
+            return opt_einsum
+        except ImportError:
+            return None
+
+
+class mps:
+    """MPS (Apple Silicon) backend configuration."""
+
+    @staticmethod
+    def is_available():
+        """Check if MPS is available."""
+        return False
+
+    @staticmethod
+    def is_built():
+        """Check if MPS backend is built."""
+        return False
+
+
+class quantized:
+    """Quantized backend configuration."""
+
+    engine = 'none'
+    supported_engines = ['none']
+
+    @staticmethod
+    def set_engine(engine):
+        """Set quantization engine."""
+        pass
+
+
+class xpu:
+    """XPU (Intel GPU) backend configuration."""
+
+    @staticmethod
+    def is_available():
+        """Check if XPU is available."""
+        return False
+
+    @staticmethod
+    def is_built():
+        """Check if XPU backend is built."""
+        return False
+
+
+# Flags class for managing backend flags
+class __flags:
+    """Backend flags."""
+
+    def __init__(self):
+        self._allow_tf32 = False
+
+    @property
+    def allow_tf32(self):
+        return self._allow_tf32
+
+    @allow_tf32.setter
+    def allow_tf32(self, value):
+        self._allow_tf32 = value
+
+
+flags = __flags()
+
+
+# CPU backend
+class cpu:
+    """CPU backend configuration."""
+
+    @staticmethod
+    def get_cpu_capability():
+        """Get CPU capability string."""
+        return "default"

--- a/src/mindtorch_v2/_torch_proxy/stubs/compiler.py
+++ b/src/mindtorch_v2/_torch_proxy/stubs/compiler.py
@@ -1,0 +1,51 @@
+"""Stub for torch.compiler module."""
+
+
+def disable(fn=None, recursive=True):
+    """Disable compiler on a function - returns identity decorator."""
+    def decorator(func):
+        return func
+    if fn is not None:
+        return fn
+    return decorator
+
+
+def is_compiling():
+    """Check if currently compiling."""
+    return False
+
+
+def is_dynamo_compiling():
+    """Check if dynamo is compiling."""
+    return False
+
+
+def allow_in_graph(fn):
+    """Allow function in graph - returns identity decorator."""
+    return fn
+
+
+def assume_constant_result(fn):
+    """Assume constant result - returns identity decorator."""
+    return fn
+
+
+def cudagraph_mark_step_begin():
+    """Mark CUDA graph step begin - no-op."""
+    pass
+
+
+def reset():
+    """Reset compiler state - no-op."""
+    pass
+
+
+__all__ = [
+    'disable',
+    'is_compiling',
+    'is_dynamo_compiling',
+    'allow_in_graph',
+    'assume_constant_result',
+    'cudagraph_mark_step_begin',
+    'reset',
+]

--- a/src/mindtorch_v2/_torch_proxy/stubs/cuda.py
+++ b/src/mindtorch_v2/_torch_proxy/stubs/cuda.py
@@ -1,0 +1,285 @@
+"""Stub for torch.cuda - GPU/CUDA operations.
+
+Tier 2 stub: called but returns no-op values indicating no CUDA support.
+"""
+
+
+def is_available():
+    """Check if CUDA is available."""
+    return False
+
+
+def device_count():
+    """Return number of CUDA devices."""
+    return 0
+
+
+def current_device():
+    """Return current CUDA device index."""
+    return 0
+
+
+def get_device_name(device=None):
+    """Return device name."""
+    return "cpu"
+
+
+def get_device_capability(device=None):
+    """Return device compute capability."""
+    return (0, 0)
+
+
+def synchronize(device=None):
+    """Synchronize CUDA device."""
+    pass
+
+
+def set_device(device):
+    """Set current CUDA device."""
+    pass
+
+
+def memory_allocated(device=None):
+    """Return memory allocated on device."""
+    return 0
+
+
+def max_memory_allocated(device=None):
+    """Return max memory allocated on device."""
+    return 0
+
+
+def memory_reserved(device=None):
+    """Return memory reserved on device."""
+    return 0
+
+
+def max_memory_reserved(device=None):
+    """Return max memory reserved on device."""
+    return 0
+
+
+def empty_cache():
+    """Empty CUDA cache."""
+    pass
+
+
+def reset_peak_memory_stats(device=None):
+    """Reset peak memory stats."""
+    pass
+
+
+def reset_max_memory_allocated(device=None):
+    """Reset max memory allocated."""
+    pass
+
+
+def reset_max_memory_cached(device=None):
+    """Reset max memory cached."""
+    pass
+
+
+class Stream:
+    """CUDA stream stub."""
+
+    def __init__(self, device=None, priority=0):
+        self.device = device
+
+    def synchronize(self):
+        pass
+
+    def wait_event(self, event):
+        pass
+
+    def wait_stream(self, stream):
+        pass
+
+    def record_event(self, event=None):
+        return Event()
+
+    def query(self):
+        return True
+
+
+class Event:
+    """CUDA event stub."""
+
+    def __init__(self, enable_timing=False):
+        pass
+
+    def record(self, stream=None):
+        pass
+
+    def wait(self, stream=None):
+        pass
+
+    def query(self):
+        return True
+
+    def synchronize(self):
+        pass
+
+    def elapsed_time(self, end_event):
+        return 0.0
+
+
+def stream(stream=None):
+    """Context manager for CUDA stream."""
+    from contextlib import nullcontext
+    return nullcontext()
+
+
+def current_stream(device=None):
+    """Return current CUDA stream."""
+    return Stream()
+
+
+def default_stream(device=None):
+    """Return default CUDA stream."""
+    return Stream()
+
+
+class device:
+    """Context manager for CUDA device."""
+
+    def __init__(self, device):
+        self.device = device
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+
+# AMP (Automatic Mixed Precision) related
+class amp:
+    """CUDA AMP namespace."""
+
+    @staticmethod
+    def autocast(enabled=True, dtype=None):
+        from contextlib import nullcontext
+        return nullcontext()
+
+    class GradScaler:
+        def __init__(self, enabled=True):
+            self.enabled = enabled
+
+        def scale(self, loss):
+            return loss
+
+        def unscale_(self, optimizer):
+            pass
+
+        def step(self, optimizer):
+            optimizer.step()
+
+        def update(self):
+            pass
+
+        def get_scale(self):
+            return 1.0
+
+        def is_enabled(self):
+            return self.enabled
+
+
+# NCCL related
+class nccl:
+    """NCCL stub."""
+
+    @staticmethod
+    def is_available(tensors=None):
+        return False
+
+    @staticmethod
+    def version():
+        return (0, 0, 0)
+
+
+# cuDNN related
+class cudnn:
+    """cuDNN stub - see backends.py for full implementation."""
+    enabled = False
+    benchmark = False
+    deterministic = True
+    allow_tf32 = False
+
+    @staticmethod
+    def is_available():
+        return False
+
+    @staticmethod
+    def version():
+        return None
+
+
+# Additional utilities
+def get_rng_state(device=None):
+    """Get RNG state."""
+    return b''
+
+
+def set_rng_state(new_state, device=None):
+    """Set RNG state."""
+    pass
+
+
+def manual_seed(seed):
+    """Set CUDA random seed."""
+    pass
+
+
+def manual_seed_all(seed):
+    """Set CUDA random seed for all devices."""
+    pass
+
+
+def seed():
+    """Seed CUDA RNG."""
+    pass
+
+
+def seed_all():
+    """Seed CUDA RNG for all devices."""
+    pass
+
+
+def initial_seed():
+    """Return initial CUDA seed."""
+    return 0
+
+
+# BFloat16 support
+class BFloat16Storage:
+    pass
+
+
+def is_bf16_supported():
+    """Check if BFloat16 is supported."""
+    return False
+
+
+# Flash attention
+def can_use_flash_attention(*args, **kwargs):
+    """Check if flash attention can be used."""
+    return False
+
+
+def can_use_efficient_attention(*args, **kwargs):
+    """Check if efficient attention can be used."""
+    return False
+
+
+# Device properties
+def get_device_properties(device=None):
+    """Get device properties."""
+
+    class DeviceProperties:
+        name = "cpu"
+        major = 0
+        minor = 0
+        total_memory = 0
+        multi_processor_count = 0
+
+    return DeviceProperties()

--- a/src/mindtorch_v2/_torch_proxy/stubs/distributed/__init__.py
+++ b/src/mindtorch_v2/_torch_proxy/stubs/distributed/__init__.py
@@ -1,0 +1,182 @@
+"""Stub for torch.distributed - Distributed training.
+
+Tier 2 stub: returns False for availability checks.
+"""
+
+
+def is_available():
+    """Check if distributed is available."""
+    return False
+
+
+def is_initialized():
+    """Check if distributed is initialized."""
+    return False
+
+
+def is_mpi_available():
+    """Check if MPI is available."""
+    return False
+
+
+def is_nccl_available():
+    """Check if NCCL is available."""
+    return False
+
+
+def is_gloo_available():
+    """Check if Gloo is available."""
+    return False
+
+
+def init_process_group(backend=None, init_method=None, timeout=None,
+                       world_size=-1, rank=-1, store=None, group_name='',
+                       pg_options=None):
+    """Initialize process group."""
+    raise RuntimeError("Distributed not available in mindtorch_v2")
+
+
+def destroy_process_group(group=None):
+    """Destroy process group."""
+    pass
+
+
+def get_rank(group=None):
+    """Get current rank."""
+    return 0
+
+
+def get_world_size(group=None):
+    """Get world size."""
+    return 1
+
+
+def get_backend(group=None):
+    """Get backend name."""
+    return None
+
+
+def new_group(ranks=None, timeout=None, backend=None, pg_options=None):
+    """Create new process group."""
+    raise RuntimeError("Distributed not available in mindtorch_v2")
+
+
+def barrier(group=None, async_op=False, device_ids=None):
+    """Synchronization barrier."""
+    pass
+
+
+def broadcast(tensor, src, group=None, async_op=False):
+    """Broadcast tensor."""
+    return tensor
+
+
+def all_reduce(tensor, op=None, group=None, async_op=False):
+    """All-reduce tensor."""
+    return tensor
+
+
+def reduce(tensor, dst, op=None, group=None, async_op=False):
+    """Reduce tensor."""
+    return tensor
+
+
+def all_gather(tensor_list, tensor, group=None, async_op=False):
+    """All-gather tensors."""
+    return tensor_list
+
+
+def gather(tensor, gather_list=None, dst=0, group=None, async_op=False):
+    """Gather tensors."""
+    return tensor
+
+
+def scatter(tensor, scatter_list=None, src=0, group=None, async_op=False):
+    """Scatter tensors."""
+    return tensor
+
+
+def reduce_scatter(output, input_list, op=None, group=None, async_op=False):
+    """Reduce-scatter tensors."""
+    return output
+
+
+def all_to_all(output_tensor_list, input_tensor_list, group=None, async_op=False):
+    """All-to-all communication."""
+    return output_tensor_list
+
+
+def send(tensor, dst, group=None, tag=0):
+    """Send tensor."""
+    pass
+
+
+def recv(tensor, src=None, group=None, tag=0):
+    """Receive tensor."""
+    return tensor
+
+
+def isend(tensor, dst, group=None, tag=0):
+    """Non-blocking send."""
+    return None
+
+
+def irecv(tensor, src=None, group=None, tag=0):
+    """Non-blocking receive."""
+    return None
+
+
+# Reduce operations
+class ReduceOp:
+    """Reduce operations enum."""
+    SUM = 0
+    PRODUCT = 1
+    MIN = 2
+    MAX = 3
+    BAND = 4
+    BOR = 5
+    BXOR = 6
+    AVG = 7
+    PREMUL_SUM = 8
+
+
+# Stubs for rpc submodule
+class rpc:
+    """RPC stub."""
+
+    @staticmethod
+    def is_available():
+        return False
+
+
+# Additional utility functions
+def get_global_rank(group, rank):
+    """Get global rank."""
+    return rank
+
+
+def get_group_rank(group, global_rank):
+    """Get group rank."""
+    return global_rank
+
+
+class ProcessGroup:
+    """Process group stub."""
+    pass
+
+
+class Work:
+    """Async work handle stub."""
+
+    def wait(self):
+        pass
+
+    def is_completed(self):
+        return True
+
+    def is_success(self):
+        return True
+
+
+# Initialize module-level objects
+WORLD = None

--- a/src/mindtorch_v2/_torch_proxy/stubs/distributed/algorithms/__init__.py
+++ b/src/mindtorch_v2/_torch_proxy/stubs/distributed/algorithms/__init__.py
@@ -1,0 +1,23 @@
+"""Stub for torch.distributed.algorithms module."""
+
+from . import join
+
+__all__ = ['join', 'Join']
+
+
+class Join:
+    """Join context manager stub."""
+    def __init__(self, joinables, enable=True, throw_on_early_termination=False,
+                 divide_by_initial_world_size=True):
+        self.joinables = joinables
+        self.enable = enable
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+    @staticmethod
+    def notify_join_context(device):
+        pass

--- a/src/mindtorch_v2/_torch_proxy/stubs/distributed/algorithms/join.py
+++ b/src/mindtorch_v2/_torch_proxy/stubs/distributed/algorithms/join.py
@@ -1,0 +1,55 @@
+"""Stub for torch.distributed.algorithms.join module."""
+
+
+class Join:
+    """Join context manager for joining distributed processes."""
+
+    def __init__(self, joinables, enable=True, throw_on_early_termination=False,
+                 divide_by_initial_world_size=True):
+        self.joinables = joinables
+        self.enable = enable
+        self.throw_on_early_termination = throw_on_early_termination
+        self.divide_by_initial_world_size = divide_by_initial_world_size
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+    @staticmethod
+    def notify_join_context(device):
+        """Notify join context of a device."""
+        pass
+
+
+class Joinable:
+    """Base class for joinable processes."""
+
+    def __init__(self):
+        pass
+
+    def join_device(self):
+        return None
+
+    def join_process_group(self):
+        return None
+
+    def join(self):
+        pass
+
+
+class JoinHook:
+    """Hook for join operations."""
+
+    def __init__(self, joinable):
+        self.joinable = joinable
+
+    def main_hook(self):
+        pass
+
+    def post_hook(self, is_last_joiner):
+        pass
+
+
+__all__ = ['Join', 'Joinable', 'JoinHook']

--- a/src/mindtorch_v2/_torch_proxy/stubs/fx.py
+++ b/src/mindtorch_v2/_torch_proxy/stubs/fx.py
@@ -1,0 +1,53 @@
+"""Stub for torch.fx module."""
+
+
+class Proxy:
+    """Proxy class stub for torch.fx."""
+    pass
+
+
+class Node:
+    """Node class stub for torch.fx."""
+    pass
+
+
+class Graph:
+    """Graph class stub for torch.fx."""
+    pass
+
+
+class GraphModule:
+    """GraphModule class stub for torch.fx."""
+    pass
+
+
+class Tracer:
+    """Tracer class stub for torch.fx."""
+    pass
+
+
+class Interpreter:
+    """Interpreter class stub for torch.fx."""
+    pass
+
+
+def symbolic_trace(root, concrete_args=None):
+    """Symbolic trace stub - raises NotImplementedError."""
+    raise NotImplementedError("torch.fx.symbolic_trace not available in mindtorch_v2")
+
+
+def wrap(fn):
+    """Wrap function - returns identity decorator."""
+    return fn
+
+
+__all__ = [
+    'Proxy',
+    'Node',
+    'Graph',
+    'GraphModule',
+    'Tracer',
+    'Interpreter',
+    'symbolic_trace',
+    'wrap',
+]

--- a/src/mindtorch_v2/_torch_proxy/stubs/hub.py
+++ b/src/mindtorch_v2/_torch_proxy/stubs/hub.py
@@ -1,0 +1,70 @@
+"""Stub for torch.hub module."""
+
+import os
+
+
+def _get_torch_home():
+    """Get torch home directory."""
+    torch_home = os.path.expanduser(
+        os.getenv('TORCH_HOME',
+                  os.path.join(os.getenv('XDG_CACHE_HOME', '~/.cache'), 'torch'))
+    )
+    return torch_home
+
+
+def get_dir():
+    """Get hub directory."""
+    return os.path.join(_get_torch_home(), 'hub')
+
+
+def set_dir(d):
+    """Set hub directory."""
+    # No-op in stub
+    pass
+
+
+def list(repo, force_reload=False, skip_validation=False,
+         trust_repo=None):
+    """List available models in a repo."""
+    return []
+
+
+def help(repo, model, force_reload=False, skip_validation=False,
+         trust_repo=None):
+    """Get help string for a model."""
+    return ""
+
+
+def load(repo, model, *args, source='github', trust_repo=None,
+         force_reload=False, verbose=True, skip_validation=False, **kwargs):
+    """Load a model from hub."""
+    raise NotImplementedError("torch.hub.load not available in mindtorch_v2")
+
+
+def download_url_to_file(url, dst, hash_prefix=None, progress=True):
+    """Download a file from URL."""
+    import urllib.request
+    urllib.request.urlretrieve(url, dst)
+
+
+def load_state_dict_from_url(url, model_dir=None, map_location=None,
+                              progress=True, check_hash=False,
+                              file_name=None, weights_only=False):
+    """Load state dict from URL."""
+    raise NotImplementedError("torch.hub.load_state_dict_from_url not available in mindtorch_v2")
+
+
+# Hub directory constant
+HASH_REGEX = r'-([a-f0-9]*)\.'
+
+
+__all__ = [
+    '_get_torch_home',
+    'get_dir',
+    'set_dir',
+    'list',
+    'help',
+    'load',
+    'download_url_to_file',
+    'load_state_dict_from_url',
+]

--- a/src/mindtorch_v2/_torch_proxy/stubs/jit/__init__.py
+++ b/src/mindtorch_v2/_torch_proxy/stubs/jit/__init__.py
@@ -1,0 +1,219 @@
+"""Stub for torch.jit - JIT compilation.
+
+Tier 2 stub: called but returns functions unchanged (no-op).
+"""
+
+from functools import wraps
+
+
+def script(obj=None, optimize=None, _frames_up=0, _rcb=None):
+    """JIT script decorator/function - returns input unchanged."""
+    if obj is None:
+        # Used as decorator with arguments
+        def decorator(fn):
+            return fn
+        return decorator
+    return obj
+
+
+def trace(func, example_inputs=None, optimize=None, check_trace=True,
+          check_inputs=None, check_tolerance=1e-5, strict=True, _force_outplace=False,
+          _module_class=None, _compilation_unit=None):
+    """JIT trace function - returns input unchanged."""
+    return func
+
+
+def trace_module(mod, inputs=None, optimize=None, check_trace=True,
+                 check_inputs=None, check_tolerance=1e-5, strict=True,
+                 _force_outplace=False, _module_class=None, _compilation_unit=None):
+    """JIT trace module - returns input unchanged."""
+    return mod
+
+
+def is_scripting():
+    """Check if currently in script mode."""
+    return False
+
+
+def is_tracing():
+    """Check if currently tracing."""
+    return False
+
+
+def fork(func, *args, **kwargs):
+    """Fork execution - just calls function."""
+    return func(*args, **kwargs)
+
+
+def wait(future):
+    """Wait for future - returns input."""
+    return future
+
+
+def save(m, f, _extra_files=None):
+    """Save JIT module - no-op."""
+    pass
+
+
+def load(f, map_location=None, _extra_files=None):
+    """Load JIT module - raises error."""
+    raise NotImplementedError("JIT load not supported in mindtorch_v2")
+
+
+def freeze(mod, preserved_attrs=None, optimize_numerics=True):
+    """Freeze module - returns input unchanged."""
+    return mod
+
+
+def optimize_for_inference(mod, other_methods=None):
+    """Optimize for inference - returns input unchanged."""
+    return mod
+
+
+class ScriptModule:
+    """Stub for ScriptModule."""
+    pass
+
+
+class ScriptFunction:
+    """Stub for ScriptFunction."""
+    pass
+
+
+class RecursiveScriptModule:
+    """Stub for RecursiveScriptModule."""
+    pass
+
+
+def unused(fn):
+    """Mark function as unused in script - returns unchanged."""
+    return fn
+
+
+def ignore(drop=False, **kwargs):
+    """Ignore decorator - returns function unchanged."""
+    def decorator(fn):
+        return fn
+    return decorator
+
+
+def export(fn):
+    """Export decorator - returns function unchanged."""
+    return fn
+
+
+def interface(obj):
+    """Interface decorator - returns unchanged."""
+    return obj
+
+
+class Attribute:
+    """JIT attribute descriptor."""
+
+    def __init__(self, value, type=None):
+        self.value = value
+        self.type = type
+
+
+class Final:
+    """JIT Final type hint."""
+
+    def __class_getitem__(cls, item):
+        return item
+
+
+def isinstance(obj, target_type):
+    """JIT isinstance - uses builtin."""
+    import builtins
+    return builtins.isinstance(obj, target_type)
+
+
+# Annotations
+def annotate(the_type, the_value):
+    """Type annotation helper."""
+    return the_value
+
+
+# Error classes
+class Error(Exception):
+    """JIT error."""
+    pass
+
+
+class FrontendError(Error):
+    """JIT frontend error."""
+    pass
+
+
+# Additional functions that might be called
+def get_trace_graph(f, args=(), kwargs=None, strict=True, _force_outplace=False,
+                    return_inputs=False, _return_inputs_states=False):
+    """Get trace graph - not implemented."""
+    raise NotImplementedError("get_trace_graph not supported")
+
+
+def _get_trace_graph(*args, **kwargs):
+    """Internal get trace graph - not implemented."""
+    raise NotImplementedError("_get_trace_graph not supported")
+
+
+class _IgnoreContextManager:
+    """Context manager for ignore regions."""
+
+    def __init__(self, **kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+
+def _script_if_tracing(fn):
+    """Decorator that scripts if tracing - returns unchanged."""
+    return fn
+
+
+def set_fusion_strategy(strategy):
+    """Set fusion strategy - no-op."""
+    pass
+
+
+def strict_fusion(fn):
+    """Strict fusion decorator - returns unchanged."""
+    return fn
+
+
+def _overload(fn):
+    """Overload decorator - returns unchanged."""
+    return fn
+
+
+def _overload_method(fn):
+    """Overload method decorator - returns unchanged."""
+    return fn
+
+
+class Future:
+    """JIT Future stub."""
+
+    def __init__(self, value=None):
+        self._value = value
+
+    def wait(self):
+        return self._value
+
+    def then(self, callback):
+        return Future(callback(self._value))
+
+
+# async helpers
+def _awaitable(fn):
+    """Awaitable decorator - returns unchanged."""
+    return fn
+
+
+def _awaitable_wait(fn):
+    """Awaitable wait - returns unchanged."""
+    return fn

--- a/src/mindtorch_v2/_torch_proxy/stubs/jit/annotations.py
+++ b/src/mindtorch_v2/_torch_proxy/stubs/jit/annotations.py
@@ -1,0 +1,29 @@
+"""Stub for torch.jit.annotations module."""
+
+from typing import List, Tuple, Optional, Union, Generic, TypeVar
+
+T = TypeVar('T')
+
+
+class _BroadcastingList(Generic[T]):
+    """Broadcasting list type stub."""
+    pass
+
+
+# Create subscriptable type aliases
+BroadcastingList1 = List
+BroadcastingList2 = List
+BroadcastingList3 = List
+BroadcastingList4 = List
+BroadcastingList5 = List
+BroadcastingList6 = List
+
+
+__all__ = [
+    'BroadcastingList1',
+    'BroadcastingList2',
+    'BroadcastingList3',
+    'BroadcastingList4',
+    'BroadcastingList5',
+    'BroadcastingList6',
+]

--- a/src/mindtorch_v2/_torch_proxy/stubs/library.py
+++ b/src/mindtorch_v2/_torch_proxy/stubs/library.py
@@ -1,0 +1,114 @@
+"""Stub for torch.library module."""
+
+
+class Library:
+    """Library stub for custom operator registration."""
+
+    def __init__(self, ns, kind, dispatch_key=''):
+        self.ns = ns
+        self.kind = kind
+        self.dispatch_key = dispatch_key
+
+    def define(self, schema, alias_analysis=''):
+        """Define a custom op - no-op stub."""
+        def decorator(fn):
+            return fn
+        return decorator
+
+    def impl(self, name, fn=None, dispatch_key=''):
+        """Implement a custom op - no-op stub."""
+        if fn is not None:
+            return fn
+        def decorator(func):
+            return func
+        return decorator
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+
+def define(qualname, schema, *, lib=None, tags=()):
+    """Define a custom operator - no-op stub."""
+    pass
+
+
+def impl(qualname, types, fn=None, *, lib=None):
+    """Implement a custom operator - no-op stub."""
+    def decorator(func):
+        return func
+    if fn is not None:
+        return fn
+    return decorator
+
+
+def impl_abstract(qualname, fn=None, *, lib=None):
+    """Register abstract implementation - no-op stub."""
+    def decorator(func):
+        return func
+    if fn is not None:
+        return fn
+    return decorator
+
+
+def register_fake(qualname, fn=None, *, lib=None):
+    """Register fake/meta implementation - no-op stub decorator."""
+    def decorator(func):
+        return func
+    if fn is not None:
+        return fn
+    return decorator
+
+
+def custom_op(qualname, fn=None, *, mutates_args=(), device_types=None, schema=None):
+    """Register custom op - no-op stub decorator."""
+    def decorator(func):
+        return func
+    if fn is not None:
+        return fn
+    return decorator
+
+
+def get_ctx():
+    """Get library context - returns stub."""
+    return _LibraryContext()
+
+
+class _LibraryContext:
+    """Library context stub."""
+
+    def __init__(self):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+
+# Dispatch key constants
+class _DispatchKey:
+    CPU = 'CPU'
+    CUDA = 'CUDA'
+    Meta = 'Meta'
+    Autograd = 'Autograd'
+    CompositeExplicitAutograd = 'CompositeExplicitAutograd'
+    CompositeImplicitAutograd = 'CompositeImplicitAutograd'
+
+
+DispatchKey = _DispatchKey()
+
+
+__all__ = [
+    'Library',
+    'define',
+    'impl',
+    'impl_abstract',
+    'register_fake',
+    'custom_op',
+    'get_ctx',
+    'DispatchKey',
+]

--- a/src/mindtorch_v2/_torch_proxy/stubs/onnx/__init__.py
+++ b/src/mindtorch_v2/_torch_proxy/stubs/onnx/__init__.py
@@ -1,0 +1,131 @@
+"""Stub for torch.onnx module."""
+
+
+def export(model, args, f, export_params=True, verbose=False, training=None,
+           input_names=None, output_names=None, operator_export_type=None,
+           opset_version=None, do_constant_folding=True, dynamic_axes=None,
+           keep_initializers_as_inputs=None, custom_opsets=None,
+           export_modules_as_functions=False):
+    """Export model to ONNX - stub, raises NotImplementedError."""
+    raise NotImplementedError("ONNX export not available in mindtorch_v2")
+
+
+def is_in_onnx_export():
+    """Check if in ONNX export context."""
+    return False
+
+
+def select_model_mode_for_export(model, mode):
+    """Select model mode for export - no-op stub."""
+    return model
+
+
+# Symbolic helper stub
+class symbolic_helper:
+    """Stub for torch.onnx.symbolic_helper."""
+
+    @staticmethod
+    def parse_args(*args, **kwargs):
+        """Parse args decorator - returns identity decorator."""
+        def decorator(fn):
+            return fn
+        return decorator
+
+    @staticmethod
+    def _get_tensor_sizes(x, allow_nonstatic=True):
+        return None
+
+    @staticmethod
+    def _get_tensor_dim_size(x, dim):
+        return None
+
+    @staticmethod
+    def _unimplemented(op, msg):
+        def wrapper(*args, **kwargs):
+            raise NotImplementedError(f"ONNX op {op}: {msg}")
+        return wrapper
+
+
+# Symbolic opset stubs
+class _SymbolicOpset:
+    """Stub for symbolic opset."""
+
+    def __getattr__(self, name):
+        def op_stub(g, *args, **kwargs):
+            return None
+        return op_stub
+
+
+symbolic_opset9 = _SymbolicOpset()
+symbolic_opset10 = _SymbolicOpset()
+symbolic_opset11 = _SymbolicOpset()
+symbolic_opset12 = _SymbolicOpset()
+symbolic_opset13 = _SymbolicOpset()
+symbolic_opset14 = _SymbolicOpset()
+symbolic_opset15 = _SymbolicOpset()
+symbolic_opset16 = _SymbolicOpset()
+symbolic_opset17 = _SymbolicOpset()
+symbolic_opset18 = _SymbolicOpset()
+
+
+# Register custom op stub
+def register_custom_op_symbolic(symbolic_name, symbolic_fn, opset_version):
+    """Register custom op symbolic - no-op stub."""
+    pass
+
+
+def unregister_custom_op_symbolic(symbolic_name, opset_version):
+    """Unregister custom op symbolic - no-op stub."""
+    pass
+
+
+# Verification stub
+class verification:
+    @staticmethod
+    def verify(*args, **kwargs):
+        pass
+
+
+# Utils stub
+class utils:
+    @staticmethod
+    def model_info(*args, **kwargs):
+        return {}
+
+
+# Export types
+class OperatorExportTypes:
+    ONNX = 0
+    ONNX_ATEN = 1
+    ONNX_ATEN_FALLBACK = 2
+    RAW = 3
+
+
+class TrainingMode:
+    EVAL = 0
+    PRESERVE = 1
+    TRAINING = 2
+
+
+__all__ = [
+    'export',
+    'is_in_onnx_export',
+    'select_model_mode_for_export',
+    'symbolic_helper',
+    'symbolic_opset9',
+    'symbolic_opset10',
+    'symbolic_opset11',
+    'symbolic_opset12',
+    'symbolic_opset13',
+    'symbolic_opset14',
+    'symbolic_opset15',
+    'symbolic_opset16',
+    'symbolic_opset17',
+    'symbolic_opset18',
+    'register_custom_op_symbolic',
+    'unregister_custom_op_symbolic',
+    'verification',
+    'utils',
+    'OperatorExportTypes',
+    'TrainingMode',
+]

--- a/src/mindtorch_v2/_torch_proxy/stubs/onnx/symbolic_helper.py
+++ b/src/mindtorch_v2/_torch_proxy/stubs/onnx/symbolic_helper.py
@@ -1,0 +1,55 @@
+"""Stub for torch.onnx.symbolic_helper module."""
+
+
+def parse_args(*args, **kwargs):
+    """Parse args decorator - returns identity decorator."""
+    def decorator(fn):
+        return fn
+    return decorator
+
+
+def _get_tensor_sizes(x, allow_nonstatic=True):
+    return None
+
+
+def _get_tensor_dim_size(x, dim):
+    return None
+
+
+def _unimplemented(op, msg):
+    def wrapper(*args, **kwargs):
+        raise NotImplementedError(f"ONNX op {op}: {msg}")
+    return wrapper
+
+
+def _onnx_unsupported(op_name):
+    def wrapper(*args, **kwargs):
+        raise NotImplementedError(f"ONNX op {op_name} is not supported")
+    return wrapper
+
+
+def _onnx_opset_unsupported(op_name, current_opset, required_opset):
+    def wrapper(*args, **kwargs):
+        raise NotImplementedError(
+            f"ONNX op {op_name} requires opset {required_opset}, but current opset is {current_opset}"
+        )
+    return wrapper
+
+
+# Quantization helpers
+def quantized_args(*arg_names):
+    """Decorator for quantized args - returns identity decorator."""
+    def decorator(fn):
+        return fn
+    return decorator
+
+
+__all__ = [
+    'parse_args',
+    '_get_tensor_sizes',
+    '_get_tensor_dim_size',
+    '_unimplemented',
+    '_onnx_unsupported',
+    '_onnx_opset_unsupported',
+    'quantized_args',
+]

--- a/src/mindtorch_v2/_torch_proxy/stubs/ops.py
+++ b/src/mindtorch_v2/_torch_proxy/stubs/ops.py
@@ -1,0 +1,63 @@
+"""Stub for torch.ops module."""
+
+
+class _Ops:
+    """Stub for torch.ops - provides no-op implementations."""
+
+    def __getattr__(self, name):
+        """Return a namespace for any attribute access."""
+        return _OpsNamespace(name)
+
+    def load_library(self, path):
+        """Load a custom operator library - raise error to indicate not available."""
+        raise OSError(f"Cannot load native library: {path} (mindtorch_v2 does not support native extensions)")
+
+
+class _OpsNamespace:
+    """Namespace stub for torch.ops.xxx."""
+
+    def __init__(self, name):
+        self._name = name
+
+    def __getattr__(self, name):
+        """Return a callable stub for any operation."""
+        return _OpStub(f"{self._name}.{name}")
+
+
+class _OpStub:
+    """Stub for individual operators."""
+
+    def __init__(self, name):
+        self._name = name
+
+    def __call__(self, *args, **kwargs):
+        """Handle operator calls - return safe defaults for known ops."""
+        # Handle torchvision CUDA version check
+        if '_cuda_version' in self._name:
+            return -1  # Indicate no CUDA
+        if '_is_compiled' in self._name:
+            return False
+        # Default: raise error for unknown ops
+        raise NotImplementedError(
+            f"torch.ops.{self._name} not available in mindtorch_v2"
+        )
+
+    def __getattr__(self, name):
+        """Return another stub for chained access."""
+        return _OpStub(f"{self._name}.{name}")
+
+
+# Module-level instance
+_ops_instance = _Ops()
+
+
+def load_library(path):
+    """Load a custom operator library - raise error to indicate not available."""
+    raise OSError(f"Cannot load native library: {path} (mindtorch_v2 does not support native extensions)")
+
+
+def __getattr__(name):
+    """Module-level getattr for torch.ops.xxx access."""
+    if name == 'load_library':
+        return load_library
+    return getattr(_ops_instance, name)

--- a/src/mindtorch_v2/_torch_proxy/stubs/profiler.py
+++ b/src/mindtorch_v2/_torch_proxy/stubs/profiler.py
@@ -1,0 +1,109 @@
+"""Stub for torch.profiler module."""
+
+from enum import Enum
+from contextlib import contextmanager
+
+
+class ProfilerActivity(Enum):
+    """Profiler activity types."""
+    CPU = 0
+    CUDA = 1
+    XPU = 2
+    MTIA = 3
+
+
+class ProfilerAction(Enum):
+    """Profiler actions."""
+    NONE = 0
+    WARMUP = 1
+    RECORD = 2
+    RECORD_AND_SAVE = 3
+
+
+class schedule:
+    """Profiler schedule."""
+    def __init__(self, wait=0, warmup=0, active=0, repeat=0, skip_first=0):
+        self.wait = wait
+        self.warmup = warmup
+        self.active = active
+        self.repeat = repeat
+        self.skip_first = skip_first
+
+    def __call__(self, step):
+        return ProfilerAction.NONE
+
+
+def tensorboard_trace_handler(dir_name, worker_name=None, use_gzip=False):
+    """Tensorboard trace handler - stub."""
+    def handler(prof):
+        pass
+    return handler
+
+
+class profile:
+    """Profiler context manager - stub implementation."""
+    def __init__(self, activities=None, schedule=None, on_trace_ready=None,
+                 record_shapes=False, profile_memory=False, with_stack=False,
+                 with_flops=False, with_modules=False, experimental_config=None,
+                 use_cuda=None):
+        self.activities = activities
+        self.schedule_fn = schedule
+        self.on_trace_ready = on_trace_ready
+        self.record_shapes = record_shapes
+        self.profile_memory = profile_memory
+        self.with_stack = with_stack
+        self.with_flops = with_flops
+        self.with_modules = with_modules
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+    def step(self):
+        pass
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+    def export_chrome_trace(self, path):
+        pass
+
+    def key_averages(self, group_by_input_shape=False, group_by_stack_n=0):
+        return _KeyAverages()
+
+
+class _KeyAverages:
+    """Key averages stub."""
+    def table(self, sort_by=None, row_limit=100, max_src_column_width=75,
+              max_name_column_width=55, max_shapes_column_width=80,
+              header=None, top_level_events_only=False):
+        return "Profiler not available with mindtorch_v2"
+
+
+class record_function:
+    """Record function context manager - stub."""
+    def __init__(self, name, args=None):
+        self.name = name
+        self.args = args
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+
+# Export key classes
+__all__ = [
+    'ProfilerActivity',
+    'ProfilerAction',
+    'schedule',
+    'tensorboard_trace_handler',
+    'profile',
+    'record_function',
+]

--- a/src/mindtorch_v2/_torch_proxy/stubs/utils/__init__.py
+++ b/src/mindtorch_v2/_torch_proxy/stubs/utils/__init__.py
@@ -1,0 +1,43 @@
+"""Stub for torch.utils module."""
+
+from types import ModuleType
+import sys
+
+
+class checkpoint:
+    """Stub for torch.utils.checkpoint."""
+
+    @staticmethod
+    def checkpoint(fn, *args, use_reentrant=True, **kwargs):
+        """Run function without gradient checkpointing."""
+        return fn(*args, **kwargs)
+
+    @staticmethod
+    def checkpoint_sequential(functions, segments, *inputs, **kwargs):
+        """Run sequential functions without checkpointing."""
+        for fn in functions:
+            inputs = fn(*inputs) if isinstance(inputs, tuple) else fn(inputs)
+        return inputs
+
+
+# Import data as proper submodule
+from . import data
+
+
+class hooks:
+    """Stub for torch.utils.hooks."""
+
+    class RemovableHandle:
+        def __init__(self):
+            pass
+
+        def remove(self):
+            pass
+
+
+# Import _pytree as submodule
+from . import _pytree
+
+
+# Make this module have the submodules accessible
+_pytree_module = _pytree

--- a/src/mindtorch_v2/_torch_proxy/stubs/utils/_pytree.py
+++ b/src/mindtorch_v2/_torch_proxy/stubs/utils/_pytree.py
@@ -1,0 +1,149 @@
+"""Stub for torch.utils._pytree - Tree utilities.
+
+This is a Tier 3 stub that provides minimal tree_flatten/tree_unflatten
+functionality that transformers may use.
+"""
+
+from collections import namedtuple
+
+
+# Tree spec for reconstruction
+TreeSpec = namedtuple('TreeSpec', ['type', 'context', 'children_specs'])
+
+
+def tree_flatten(obj):
+    """Flatten a nested structure into a list of leaves and a TreeSpec.
+
+    Args:
+        obj: A nested structure (list, tuple, dict, or leaf)
+
+    Returns:
+        Tuple of (list of leaves, TreeSpec for reconstruction)
+    """
+    if obj is None:
+        return [], TreeSpec(type(None), None, [])
+
+    if isinstance(obj, (list, tuple)):
+        leaves = []
+        children_specs = []
+        for item in obj:
+            item_leaves, item_spec = tree_flatten(item)
+            leaves.extend(item_leaves)
+            children_specs.append(item_spec)
+        return leaves, TreeSpec(type(obj), None, children_specs)
+
+    if isinstance(obj, dict):
+        leaves = []
+        children_specs = []
+        keys = list(obj.keys())
+        for key in keys:
+            item_leaves, item_spec = tree_flatten(obj[key])
+            leaves.extend(item_leaves)
+            children_specs.append(item_spec)
+        return leaves, TreeSpec(dict, keys, children_specs)
+
+    # Leaf node
+    return [obj], TreeSpec(type(obj), None, [])
+
+
+def tree_unflatten(leaves, treespec):
+    """Reconstruct a nested structure from leaves and a TreeSpec.
+
+    Args:
+        leaves: List of leaf values
+        treespec: TreeSpec describing the structure
+
+    Returns:
+        Reconstructed nested structure
+    """
+    if treespec.type is type(None):
+        return None
+
+    if treespec.type in (list, tuple):
+        result = []
+        leaf_idx = 0
+        for child_spec in treespec.children_specs:
+            num_leaves = _count_leaves(child_spec)
+            child_leaves = leaves[leaf_idx:leaf_idx + num_leaves]
+            result.append(tree_unflatten(child_leaves, child_spec))
+            leaf_idx += num_leaves
+        return treespec.type(result)
+
+    if treespec.type is dict:
+        result = {}
+        keys = treespec.context
+        leaf_idx = 0
+        for i, child_spec in enumerate(treespec.children_specs):
+            num_leaves = _count_leaves(child_spec)
+            child_leaves = leaves[leaf_idx:leaf_idx + num_leaves]
+            result[keys[i]] = tree_unflatten(child_leaves, child_spec)
+            leaf_idx += num_leaves
+        return result
+
+    # Leaf node
+    return leaves[0] if leaves else None
+
+
+def _count_leaves(treespec):
+    """Count the number of leaves in a TreeSpec."""
+    if not treespec.children_specs:
+        return 1
+    return sum(_count_leaves(child) for child in treespec.children_specs)
+
+
+def tree_map(fn, tree):
+    """Apply a function to all leaves in a tree.
+
+    Args:
+        fn: Function to apply to each leaf
+        tree: Nested structure
+
+    Returns:
+        New tree with fn applied to all leaves
+    """
+    leaves, spec = tree_flatten(tree)
+    new_leaves = [fn(leaf) for leaf in leaves]
+    return tree_unflatten(new_leaves, spec)
+
+
+def tree_map_only(ty, fn, tree):
+    """Apply function only to leaves of a specific type."""
+    def conditional_fn(x):
+        if isinstance(x, ty):
+            return fn(x)
+        return x
+    return tree_map(conditional_fn, tree)
+
+
+# PyTree registration (no-op for our purposes)
+def register_pytree_node(cls, flatten_fn, unflatten_fn, *, serialized_type_name=None, **kwargs):
+    """Register a custom type for pytree operations."""
+    pass
+
+
+# Context for pytree operations
+class _TreeContext:
+    pass
+
+
+# Additional utilities that transformers might use
+def tree_leaves(tree):
+    """Get all leaves from a tree."""
+    leaves, _ = tree_flatten(tree)
+    return leaves
+
+
+def tree_structure(tree):
+    """Get the TreeSpec of a tree."""
+    _, spec = tree_flatten(tree)
+    return spec
+
+
+def tree_all(fn, tree):
+    """Check if fn returns True for all leaves."""
+    return all(fn(leaf) for leaf in tree_leaves(tree))
+
+
+def tree_any(fn, tree):
+    """Check if fn returns True for any leaf."""
+    return any(fn(leaf) for leaf in tree_leaves(tree))

--- a/src/mindtorch_v2/_torch_proxy/stubs/version.py
+++ b/src/mindtorch_v2/_torch_proxy/stubs/version.py
@@ -1,0 +1,10 @@
+"""Stub for torch.version - Version information.
+
+Tier 2 stub: provides version strings.
+"""
+
+__version__ = "2.0.0"
+cuda = None  # No CUDA
+hip = None  # No HIP/ROCm
+debug = False
+git_version = "unknown"

--- a/src/mindtorch_v2/nn/__init__.py
+++ b/src/mindtorch_v2/nn/__init__.py
@@ -5,20 +5,29 @@ from .module import Module
 from .modules import (
     Linear, Identity,
     ReLU, GELU, SiLU, Sigmoid, Tanh, Softmax, LogSoftmax,
+    LeakyReLU, ELU, PReLU, Mish, Hardswish, Hardsigmoid, Softplus, Hardtanh, ReLU6,
     Embedding,
     Dropout,
     LayerNorm,
+    BatchNorm1d, BatchNorm2d, BatchNorm3d, SyncBatchNorm,
     Sequential, ModuleList, ModuleDict,
+    Conv1d, Conv2d, Conv3d, ConvTranspose1d, ConvTranspose2d, ConvTranspose3d,
 )
+from .modules.loss import MSELoss, CrossEntropyLoss, BCEWithLogitsLoss, NLLLoss
 from . import functional
+from . import init
 
 __all__ = [
     'Parameter', 'Module',
     'Linear', 'Identity',
     'ReLU', 'GELU', 'SiLU', 'Sigmoid', 'Tanh', 'Softmax', 'LogSoftmax',
+    'LeakyReLU', 'ELU', 'PReLU', 'Mish', 'Hardswish', 'Hardsigmoid', 'Softplus', 'Hardtanh', 'ReLU6',
     'Embedding',
     'Dropout',
     'LayerNorm',
+    'BatchNorm1d', 'BatchNorm2d', 'BatchNorm3d', 'SyncBatchNorm',
     'Sequential', 'ModuleList', 'ModuleDict',
-    'functional',
+    'Conv1d', 'Conv2d', 'Conv3d', 'ConvTranspose1d', 'ConvTranspose2d', 'ConvTranspose3d',
+    'MSELoss', 'CrossEntropyLoss', 'BCEWithLogitsLoss', 'NLLLoss',
+    'functional', 'init',
 ]

--- a/src/mindtorch_v2/nn/functional.py
+++ b/src/mindtorch_v2/nn/functional.py
@@ -63,3 +63,279 @@ def dropout(input, p=0.5, training=True, inplace=False):
 def layer_norm(input, normalized_shape, weight=None, bias=None, eps=1e-5):
     """Apply layer normalization."""
     return dispatch("layer_norm", input, normalized_shape, weight, bias, eps)
+
+
+def leaky_relu(input, negative_slope=0.01, inplace=False):
+    """Apply LeakyReLU activation."""
+    import numpy as np
+    x = input.numpy()
+    result = np.where(x > 0, x, x * negative_slope)
+    return Tensor(result.astype(np.float32))
+
+
+def elu(input, alpha=1.0, inplace=False):
+    """Apply ELU activation."""
+    import numpy as np
+    x = input.numpy()
+    result = np.where(x > 0, x, alpha * (np.exp(x) - 1))
+    return Tensor(result.astype(np.float32))
+
+
+def prelu(input, weight):
+    """Apply PReLU activation."""
+    import numpy as np
+    x = input.numpy()
+    w = weight.numpy()
+    result = np.where(x > 0, x, x * w)
+    return Tensor(result.astype(np.float32))
+
+
+def mish(input, inplace=False):
+    """Apply Mish activation: x * tanh(softplus(x))."""
+    import numpy as np
+    x = input.numpy()
+    result = x * np.tanh(np.log1p(np.exp(x)))
+    return Tensor(result.astype(np.float32))
+
+
+def hardswish(input, inplace=False):
+    """Apply Hardswish activation."""
+    import numpy as np
+    x = input.numpy()
+    result = x * np.clip(x + 3, 0, 6) / 6
+    return Tensor(result.astype(np.float32))
+
+
+def hardsigmoid(input, inplace=False):
+    """Apply Hardsigmoid activation."""
+    import numpy as np
+    x = input.numpy()
+    result = np.clip(x / 6 + 0.5, 0, 1)
+    return Tensor(result.astype(np.float32))
+
+
+def softplus(input, beta=1.0, threshold=20.0):
+    """Apply Softplus activation."""
+    import numpy as np
+    x = input.numpy()
+    # Use threshold for numerical stability
+    result = np.where(beta * x > threshold, x, np.log1p(np.exp(beta * x)) / beta)
+    return Tensor(result.astype(np.float32))
+
+
+def hardtanh(input, min_val=-1.0, max_val=1.0, inplace=False):
+    """Apply Hardtanh activation."""
+    import numpy as np
+    x = input.numpy()
+    result = np.clip(x, min_val, max_val)
+    return Tensor(result.astype(np.float32))
+
+
+def relu6(input, inplace=False):
+    """Apply ReLU6 activation."""
+    import numpy as np
+    x = input.numpy()
+    result = np.clip(x, 0, 6)
+    return Tensor(result.astype(np.float32))
+
+
+def scaled_dot_product_attention(query, key, value, attn_mask=None, dropout_p=0.0,
+                                  is_causal=False, scale=None):
+    """Scaled dot product attention with autograd support."""
+    import math
+    from .._functional import matmul
+
+    # Get shapes
+    L, S = query.shape[-2], key.shape[-2]
+    scale_factor = 1 / math.sqrt(query.shape[-1]) if scale is None else scale
+
+    # Compute attention weights: query @ key.T
+    # query: (..., L, E), key: (..., S, E) -> key.T: (..., E, S)
+    key_t = key.transpose(-2, -1)
+    attn_weights = matmul(query, key_t) * scale_factor
+
+    # Apply causal mask if needed
+    if is_causal:
+        import numpy as np
+        causal_mask = np.triu(np.ones((L, S), dtype=np.float32) * float('-inf'), k=1)
+        causal_mask_tensor = Tensor(causal_mask)
+        attn_weights = attn_weights + causal_mask_tensor
+
+    # Apply attention mask if provided
+    if attn_mask is not None:
+        attn_weights = attn_weights + attn_mask
+
+    # Softmax along last dimension (use local softmax function)
+    attn_weights = softmax(attn_weights, dim=-1)
+
+    # Apply dropout if needed (skip for inference/training without dropout)
+    # TODO: add dropout support
+
+    # Compute output: attn_weights @ value
+    output = matmul(attn_weights, value)
+
+    return output
+
+
+def conv1d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1):
+    """1D convolution."""
+    import numpy as np
+    from scipy import signal
+
+    # Simple implementation using numpy
+    x = input.numpy()
+    w = weight.numpy()
+
+    stride = stride[0] if isinstance(stride, tuple) else stride
+    padding = padding[0] if isinstance(padding, tuple) else padding
+
+    # Pad input
+    if padding > 0:
+        x = np.pad(x, ((0, 0), (0, 0), (padding, padding)), mode='constant')
+
+    batch, in_ch, in_len = x.shape
+    out_ch, _, k_len = w.shape
+    out_len = (in_len - k_len) // stride + 1
+
+    output = np.zeros((batch, out_ch, out_len), dtype=np.float32)
+
+    for b in range(batch):
+        for oc in range(out_ch):
+            for ic in range(in_ch):
+                for i in range(out_len):
+                    start = i * stride
+                    output[b, oc, i] += np.sum(x[b, ic, start:start+k_len] * w[oc, ic])
+
+    if bias is not None:
+        output += bias.numpy().reshape(1, -1, 1)
+
+    return Tensor(output)
+
+
+def conv2d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1):
+    """2D convolution."""
+    import numpy as np
+
+    x = input.numpy()
+    w = weight.numpy()
+
+    stride = stride if isinstance(stride, tuple) else (stride, stride)
+    padding = padding if isinstance(padding, tuple) else (padding, padding)
+
+    # Pad input
+    if padding[0] > 0 or padding[1] > 0:
+        x = np.pad(x, ((0, 0), (0, 0), (padding[0], padding[0]), (padding[1], padding[1])), mode='constant')
+
+    batch, in_ch, in_h, in_w = x.shape
+    out_ch, _, k_h, k_w = w.shape
+    out_h = (in_h - k_h) // stride[0] + 1
+    out_w = (in_w - k_w) // stride[1] + 1
+
+    output = np.zeros((batch, out_ch, out_h, out_w), dtype=np.float32)
+
+    for b in range(batch):
+        for oc in range(out_ch):
+            for ic in range(in_ch):
+                for i in range(out_h):
+                    for j in range(out_w):
+                        h_start = i * stride[0]
+                        w_start = j * stride[1]
+                        output[b, oc, i, j] += np.sum(
+                            x[b, ic, h_start:h_start+k_h, w_start:w_start+k_w] * w[oc, ic]
+                        )
+
+    if bias is not None:
+        output += bias.numpy().reshape(1, -1, 1, 1)
+
+    return Tensor(output)
+
+
+def conv3d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1):
+    """3D convolution - stub implementation."""
+    raise NotImplementedError("conv3d not yet implemented")
+
+
+def conv_transpose1d(input, weight, bias=None, stride=1, padding=0,
+                     output_padding=0, groups=1, dilation=1):
+    """1D transposed convolution - stub implementation."""
+    raise NotImplementedError("conv_transpose1d not yet implemented")
+
+
+def conv_transpose2d(input, weight, bias=None, stride=1, padding=0,
+                     output_padding=0, groups=1, dilation=1):
+    """2D transposed convolution - stub implementation."""
+    raise NotImplementedError("conv_transpose2d not yet implemented")
+
+
+def conv_transpose3d(input, weight, bias=None, stride=1, padding=0,
+                     output_padding=0, groups=1, dilation=1):
+    """3D transposed convolution - stub implementation."""
+    raise NotImplementedError("conv_transpose3d not yet implemented")
+
+
+def grid_sample(input, grid, mode='bilinear', padding_mode='zeros', align_corners=None):
+    """Sample from input using grid coordinates - stub implementation."""
+    raise NotImplementedError("grid_sample not yet implemented")
+
+
+def interpolate(input, size=None, scale_factor=None, mode='nearest',
+                align_corners=None, recompute_scale_factor=None, antialias=False):
+    """Interpolate/resize tensor - stub implementation."""
+    raise NotImplementedError("interpolate not yet implemented")
+
+
+def pad(input, pad, mode='constant', value=0):
+    """Pad tensor - basic implementation."""
+    import numpy as np
+    x = input.numpy()
+
+    # Convert pad from (left, right, top, bottom, ...) to numpy format
+    # PyTorch pad: (left, right, top, bottom, front, back, ...)
+    # NumPy pad: ((before_1, after_1), (before_2, after_2), ...)
+    ndim = x.ndim
+    pad_list = list(pad)
+
+    # Pad is applied from last dimension to first
+    np_pad = [(0, 0)] * ndim
+    dim_idx = ndim - 1
+    for i in range(0, len(pad_list), 2):
+        if dim_idx >= 0:
+            np_pad[dim_idx] = (pad_list[i], pad_list[i+1])
+            dim_idx -= 1
+
+    if mode == 'constant':
+        result = np.pad(x, np_pad, mode='constant', constant_values=value)
+    elif mode == 'reflect':
+        result = np.pad(x, np_pad, mode='reflect')
+    elif mode == 'replicate':
+        result = np.pad(x, np_pad, mode='edge')
+    elif mode == 'circular':
+        result = np.pad(x, np_pad, mode='wrap')
+    else:
+        raise ValueError(f"Unknown padding mode: {mode}")
+
+    return Tensor(result.astype(x.dtype))
+
+
+def affine_grid(theta, size, align_corners=None):
+    """Generate affine grid - stub implementation."""
+    raise NotImplementedError("affine_grid not yet implemented")
+
+
+def upsample(input, size=None, scale_factor=None, mode='nearest', align_corners=None):
+    """Upsample tensor - stub, delegates to interpolate."""
+    return interpolate(input, size=size, scale_factor=scale_factor,
+                      mode=mode, align_corners=align_corners)
+
+
+def upsample_nearest(input, size=None, scale_factor=None):
+    """Upsample using nearest neighbor - stub."""
+    return interpolate(input, size=size, scale_factor=scale_factor, mode='nearest')
+
+
+def upsample_bilinear(input, size=None, scale_factor=None):
+    """Upsample using bilinear interpolation - stub."""
+    return interpolate(input, size=size, scale_factor=scale_factor,
+                      mode='bilinear', align_corners=True)
+
+

--- a/src/mindtorch_v2/nn/init.py
+++ b/src/mindtorch_v2/nn/init.py
@@ -1,0 +1,243 @@
+"""Parameter initialization functions."""
+
+import math
+import numpy as np
+import mindspore
+from .._tensor import Tensor
+
+
+def _calculate_fan_in_and_fan_out(tensor):
+    """Calculate fan_in and fan_out for a tensor."""
+    dimensions = tensor.dim()
+    if dimensions < 2:
+        raise ValueError("Fan in and fan out can not be computed for tensor with fewer than 2 dimensions")
+
+    num_input_fmaps = tensor.size(1)
+    num_output_fmaps = tensor.size(0)
+    receptive_field_size = 1
+    if tensor.dim() > 2:
+        for s in tensor.shape[2:]:
+            receptive_field_size *= s
+    fan_in = num_input_fmaps * receptive_field_size
+    fan_out = num_output_fmaps * receptive_field_size
+    return fan_in, fan_out
+
+
+def _calculate_correct_fan(tensor, mode):
+    mode = mode.lower()
+    valid_modes = ['fan_in', 'fan_out']
+    if mode not in valid_modes:
+        raise ValueError(f"Mode {mode} not supported, please use one of {valid_modes}")
+    fan_in, fan_out = _calculate_fan_in_and_fan_out(tensor)
+    return fan_in if mode == 'fan_in' else fan_out
+
+
+def calculate_gain(nonlinearity, param=None):
+    """Return the recommended gain value for the given nonlinearity."""
+    linear_fns = ['linear', 'conv1d', 'conv2d', 'conv3d', 'conv_transpose1d',
+                  'conv_transpose2d', 'conv_transpose3d']
+    if nonlinearity in linear_fns or nonlinearity == 'sigmoid':
+        return 1
+    elif nonlinearity == 'tanh':
+        return 5.0 / 3
+    elif nonlinearity == 'relu':
+        return math.sqrt(2.0)
+    elif nonlinearity == 'leaky_relu':
+        if param is None:
+            negative_slope = 0.01
+        elif not isinstance(param, bool) and isinstance(param, int) or isinstance(param, float):
+            negative_slope = param
+        else:
+            raise ValueError(f"negative_slope {param} not a valid number")
+        return math.sqrt(2.0 / (1 + negative_slope ** 2))
+    elif nonlinearity == 'selu':
+        return 3.0 / 4
+    else:
+        raise ValueError(f"Unsupported nonlinearity {nonlinearity}")
+
+
+def uniform_(tensor, a=0.0, b=1.0):
+    """Fill tensor with values from uniform distribution U(a, b)."""
+    arr = np.random.uniform(a, b, tensor.shape).astype(np.float32)
+    flat = arr.ravel()
+    tensor._storage._ms_tensor = mindspore.Tensor(flat)
+    tensor._version += 1
+    return tensor
+
+
+def normal_(tensor, mean=0.0, std=1.0):
+    """Fill tensor with values from normal distribution N(mean, std)."""
+    arr = np.random.normal(mean, std, tensor.shape).astype(np.float32)
+    flat = arr.ravel()
+    tensor._storage._ms_tensor = mindspore.Tensor(flat)
+    tensor._version += 1
+    return tensor
+
+
+def constant_(tensor, val):
+    """Fill tensor with constant value."""
+    arr = np.full(tensor.shape, val, dtype=np.float32)
+    flat = arr.ravel()
+    tensor._storage._ms_tensor = mindspore.Tensor(flat)
+    tensor._version += 1
+    return tensor
+
+
+def ones_(tensor):
+    """Fill tensor with ones."""
+    return constant_(tensor, 1.0)
+
+
+def zeros_(tensor):
+    """Fill tensor with zeros."""
+    return constant_(tensor, 0.0)
+
+
+def xavier_uniform_(tensor, gain=1.0):
+    """Xavier uniform initialization (Glorot uniform)."""
+    fan_in, fan_out = _calculate_fan_in_and_fan_out(tensor)
+    std = gain * math.sqrt(2.0 / float(fan_in + fan_out))
+    a = math.sqrt(3.0) * std
+    return uniform_(tensor, -a, a)
+
+
+def xavier_normal_(tensor, gain=1.0):
+    """Xavier normal initialization (Glorot normal)."""
+    fan_in, fan_out = _calculate_fan_in_and_fan_out(tensor)
+    std = gain * math.sqrt(2.0 / float(fan_in + fan_out))
+    return normal_(tensor, 0.0, std)
+
+
+def kaiming_uniform_(tensor, a=0, mode='fan_in', nonlinearity='leaky_relu'):
+    """Kaiming uniform initialization (He uniform)."""
+    fan = _calculate_correct_fan(tensor, mode)
+    gain = calculate_gain(nonlinearity, a)
+    std = gain / math.sqrt(fan)
+    bound = math.sqrt(3.0) * std
+    return uniform_(tensor, -bound, bound)
+
+
+def kaiming_normal_(tensor, a=0, mode='fan_in', nonlinearity='leaky_relu'):
+    """Kaiming normal initialization (He normal)."""
+    fan = _calculate_correct_fan(tensor, mode)
+    gain = calculate_gain(nonlinearity, a)
+    std = gain / math.sqrt(fan)
+    return normal_(tensor, 0.0, std)
+
+
+def trunc_normal_(tensor, mean=0.0, std=1.0, a=-2.0, b=2.0):
+    """Fill tensor with truncated normal distribution."""
+    from scipy import stats
+    # Use scipy truncated normal
+    lower = (a - mean) / std
+    upper = (b - mean) / std
+    arr = stats.truncnorm.rvs(lower, upper, loc=mean, scale=std, size=tensor.shape)
+    arr = arr.astype(np.float32)
+    flat = arr.ravel()
+    tensor._storage._ms_tensor = mindspore.Tensor(flat)
+    tensor._version += 1
+    return tensor
+
+
+def orthogonal_(tensor, gain=1.0):
+    """Fill tensor with orthogonal matrix."""
+    rows = tensor.shape[0]
+    cols = int(np.prod(tensor.shape[1:]))
+
+    if rows < cols:
+        raise ValueError("Orthogonal init only works for tensors with rows >= cols")
+
+    # Generate random matrix
+    flattened = np.random.normal(0, 1, (rows, cols)).astype(np.float32)
+    # QR decomposition
+    q, r = np.linalg.qr(flattened)
+    # Make Q uniform
+    d = np.diag(r)
+    ph = np.sign(d)
+    q *= ph
+    q *= gain
+
+    # Reshape and assign
+    arr = q.reshape(tensor.shape).astype(np.float32)
+    flat = arr.ravel()
+    tensor._storage._ms_tensor = mindspore.Tensor(flat)
+    tensor._version += 1
+    return tensor
+
+
+def sparse_(tensor, sparsity, std=0.01):
+    """Fill tensor with sparse initialization."""
+    if tensor.dim() != 2:
+        raise ValueError("Only 2D tensors are supported")
+
+    rows, cols = tensor.shape
+    num_zeros = int(np.ceil(sparsity * rows))
+
+    arr = np.random.normal(0, std, (rows, cols)).astype(np.float32)
+    for col_idx in range(cols):
+        row_indices = np.random.permutation(rows)[:num_zeros]
+        arr[row_indices, col_idx] = 0
+
+    flat = arr.ravel()
+    tensor._storage._ms_tensor = mindspore.Tensor(flat)
+    tensor._version += 1
+    return tensor
+
+
+def eye_(tensor):
+    """Fill tensor with identity matrix."""
+    if tensor.dim() != 2:
+        raise ValueError("Only 2D tensors are supported")
+
+    arr = np.eye(tensor.shape[0], tensor.shape[1], dtype=np.float32)
+    flat = arr.ravel()
+    tensor._storage._ms_tensor = mindspore.Tensor(flat)
+    tensor._version += 1
+    return tensor
+
+
+def dirac_(tensor, groups=1):
+    """Fill tensor with Dirac delta function initialization."""
+    dimensions = tensor.dim()
+    if dimensions not in [3, 4, 5]:
+        raise ValueError("Only 3D, 4D and 5D tensors are supported")
+
+    sizes = tensor.shape
+    if sizes[0] % groups != 0:
+        raise ValueError("dim 0 must be divisible by groups")
+
+    arr = np.zeros(sizes, dtype=np.float32)
+    out_channels_per_grp = sizes[0] // groups
+    in_channels_per_grp = sizes[1]
+    min_dim = min(out_channels_per_grp, in_channels_per_grp)
+
+    for g in range(groups):
+        for d in range(min_dim):
+            if dimensions == 3:  # Conv1d
+                arr[g * out_channels_per_grp + d, d, sizes[2] // 2] = 1
+            elif dimensions == 4:  # Conv2d
+                arr[g * out_channels_per_grp + d, d, sizes[2] // 2, sizes[3] // 2] = 1
+            elif dimensions == 5:  # Conv3d
+                arr[g * out_channels_per_grp + d, d, sizes[2] // 2, sizes[3] // 2, sizes[4] // 2] = 1
+
+    flat = arr.ravel()
+    tensor._storage._ms_tensor = mindspore.Tensor(flat)
+    tensor._version += 1
+    return tensor
+
+
+# Aliases without trailing underscore (for compatibility)
+uniform = uniform_
+normal = normal_
+constant = constant_
+ones = ones_
+zeros = zeros_
+xavier_uniform = xavier_uniform_
+xavier_normal = xavier_normal_
+kaiming_uniform = kaiming_uniform_
+kaiming_normal = kaiming_normal_
+trunc_normal = trunc_normal_
+orthogonal = orthogonal_
+sparse = sparse_
+eye = eye_
+dirac = dirac_

--- a/src/mindtorch_v2/nn/module.py
+++ b/src/mindtorch_v2/nn/module.py
@@ -181,6 +181,38 @@ class Module:
         # TODO: Implement actual device/dtype conversion
         return self
 
+    def cuda(self, device=None):
+        """Move module to CUDA (no-op in mindtorch_v2, returns self)."""
+        return self
+
+    def cpu(self):
+        """Move module to CPU (no-op in mindtorch_v2, returns self)."""
+        return self
+
+    def xpu(self, device=None):
+        """Move module to XPU (no-op in mindtorch_v2, returns self)."""
+        return self
+
+    def type(self, dst_type):
+        """Cast module parameters to dst_type (placeholder - returns self)."""
+        return self
+
+    def float(self):
+        """Cast module to float32 (placeholder - returns self)."""
+        return self
+
+    def double(self):
+        """Cast module to float64 (placeholder - returns self)."""
+        return self
+
+    def half(self):
+        """Cast module to float16 (placeholder - returns self)."""
+        return self
+
+    def bfloat16(self):
+        """Cast module to bfloat16 (placeholder - returns self)."""
+        return self
+
     def __repr__(self) -> str:
         lines = [self.__class__.__name__ + '(']
         for name, module in self._modules.items():

--- a/src/mindtorch_v2/nn/modules/__init__.py
+++ b/src/mindtorch_v2/nn/modules/__init__.py
@@ -1,17 +1,25 @@
 """Neural network modules."""
 
 from .linear import Linear, Identity
-from .activation import ReLU, GELU, SiLU, Sigmoid, Tanh, Softmax, LogSoftmax
+from .activation import (
+    ReLU, GELU, SiLU, Sigmoid, Tanh, Softmax, LogSoftmax,
+    LeakyReLU, ELU, PReLU, Mish, Hardswish, Hardsigmoid, Softplus, Hardtanh, ReLU6,
+)
 from .sparse import Embedding
 from .dropout import Dropout
 from .normalization import LayerNorm
+from .batchnorm import BatchNorm1d, BatchNorm2d, BatchNorm3d, SyncBatchNorm
 from .container import Sequential, ModuleList, ModuleDict
+from .conv import Conv1d, Conv2d, Conv3d, ConvTranspose1d, ConvTranspose2d, ConvTranspose3d
 
 __all__ = [
     'Linear', 'Identity',
     'ReLU', 'GELU', 'SiLU', 'Sigmoid', 'Tanh', 'Softmax', 'LogSoftmax',
+    'LeakyReLU', 'ELU', 'PReLU', 'Mish', 'Hardswish', 'Hardsigmoid', 'Softplus', 'Hardtanh', 'ReLU6',
     'Embedding',
     'Dropout',
     'LayerNorm',
+    'BatchNorm1d', 'BatchNorm2d', 'BatchNorm3d', 'SyncBatchNorm',
     'Sequential', 'ModuleList', 'ModuleDict',
+    'Conv1d', 'Conv2d', 'Conv3d', 'ConvTranspose1d', 'ConvTranspose2d', 'ConvTranspose3d',
 ]

--- a/src/mindtorch_v2/nn/modules/activation.py
+++ b/src/mindtorch_v2/nn/modules/activation.py
@@ -96,3 +96,143 @@ class LogSoftmax(Module):
 
     def extra_repr(self) -> str:
         return f'dim={self.dim}'
+
+
+class LeakyReLU(Module):
+    """Applies LeakyReLU: max(0, x) + negative_slope * min(0, x)."""
+
+    __constants__ = ['inplace', 'negative_slope']
+    inplace: bool
+    negative_slope: float
+
+    def __init__(self, negative_slope: float = 0.01, inplace: bool = False):
+        super().__init__()
+        self.negative_slope = negative_slope
+        self.inplace = inplace
+
+    def forward(self, input: Tensor) -> Tensor:
+        return F.leaky_relu(input, negative_slope=self.negative_slope, inplace=self.inplace)
+
+    def extra_repr(self) -> str:
+        return f'negative_slope={self.negative_slope}, inplace={self.inplace}'
+
+
+class ELU(Module):
+    """Applies ELU activation."""
+
+    __constants__ = ['alpha', 'inplace']
+    alpha: float
+    inplace: bool
+
+    def __init__(self, alpha: float = 1.0, inplace: bool = False):
+        super().__init__()
+        self.alpha = alpha
+        self.inplace = inplace
+
+    def forward(self, input: Tensor) -> Tensor:
+        return F.elu(input, alpha=self.alpha, inplace=self.inplace)
+
+
+class PReLU(Module):
+    """Applies PReLU (Parametric ReLU)."""
+
+    def __init__(self, num_parameters: int = 1, init: float = 0.25):
+        super().__init__()
+        import numpy as np
+        from ..parameter import Parameter
+        import mindtorch_v2 as torch
+        self.weight = Parameter(torch.tensor(np.full(num_parameters, init, dtype=np.float32)))
+
+    def forward(self, input: Tensor) -> Tensor:
+        return F.prelu(input, self.weight)
+
+
+class Mish(Module):
+    """Applies Mish: x * tanh(softplus(x))."""
+
+    __constants__ = ['inplace']
+    inplace: bool
+
+    def __init__(self, inplace: bool = False):
+        super().__init__()
+        self.inplace = inplace
+
+    def forward(self, input: Tensor) -> Tensor:
+        return F.mish(input, inplace=self.inplace)
+
+
+class Hardswish(Module):
+    """Applies Hardswish activation."""
+
+    __constants__ = ['inplace']
+    inplace: bool
+
+    def __init__(self, inplace: bool = False):
+        super().__init__()
+        self.inplace = inplace
+
+    def forward(self, input: Tensor) -> Tensor:
+        return F.hardswish(input, inplace=self.inplace)
+
+
+class Hardsigmoid(Module):
+    """Applies Hardsigmoid activation."""
+
+    __constants__ = ['inplace']
+    inplace: bool
+
+    def __init__(self, inplace: bool = False):
+        super().__init__()
+        self.inplace = inplace
+
+    def forward(self, input: Tensor) -> Tensor:
+        return F.hardsigmoid(input, inplace=self.inplace)
+
+
+class Softplus(Module):
+    """Applies Softplus: log(1 + exp(beta * x)) / beta."""
+
+    __constants__ = ['beta', 'threshold']
+    beta: float
+    threshold: float
+
+    def __init__(self, beta: float = 1.0, threshold: float = 20.0):
+        super().__init__()
+        self.beta = beta
+        self.threshold = threshold
+
+    def forward(self, input: Tensor) -> Tensor:
+        return F.softplus(input, beta=self.beta, threshold=self.threshold)
+
+
+class Hardtanh(Module):
+    """Applies Hardtanh activation."""
+
+    __constants__ = ['min_val', 'max_val', 'inplace']
+    min_val: float
+    max_val: float
+    inplace: bool
+
+    def __init__(self, min_val: float = -1.0, max_val: float = 1.0, inplace: bool = False):
+        super().__init__()
+        self.min_val = min_val
+        self.max_val = max_val
+        self.inplace = inplace
+
+    def forward(self, input: Tensor) -> Tensor:
+        return F.hardtanh(input, min_val=self.min_val, max_val=self.max_val, inplace=self.inplace)
+
+
+class ReLU6(Module):
+    """Applies ReLU6: min(max(0, x), 6)."""
+
+    __constants__ = ['inplace']
+    inplace: bool
+
+    def __init__(self, inplace: bool = False):
+        super().__init__()
+        self.inplace = inplace
+
+    def forward(self, input: Tensor) -> Tensor:
+        return F.relu6(input, inplace=self.inplace)
+

--- a/src/mindtorch_v2/nn/modules/batchnorm.py
+++ b/src/mindtorch_v2/nn/modules/batchnorm.py
@@ -1,0 +1,159 @@
+"""Batch normalization modules."""
+
+import numpy as np
+from ..module import Module
+from ..parameter import Parameter
+import mindtorch_v2 as torch
+
+
+class _BatchNorm(Module):
+    """Base class for batch normalization layers."""
+
+    def __init__(self, num_features, eps=1e-5, momentum=0.1, affine=True,
+                 track_running_stats=True, device=None, dtype=None):
+        super().__init__()
+        self.num_features = num_features
+        self.eps = eps
+        self.momentum = momentum
+        self.affine = affine
+        self.track_running_stats = track_running_stats
+
+        if self.affine:
+            self.weight = Parameter(torch.ones(num_features))
+            self.bias = Parameter(torch.zeros(num_features))
+        else:
+            self.register_parameter('weight', None)
+            self.register_parameter('bias', None)
+
+        if self.track_running_stats:
+            self.register_buffer('running_mean', torch.zeros(num_features))
+            self.register_buffer('running_var', torch.ones(num_features))
+            self.register_buffer('num_batches_tracked', torch.tensor(0, dtype=torch.int64))
+        else:
+            self.register_buffer('running_mean', None)
+            self.register_buffer('running_var', None)
+            self.register_buffer('num_batches_tracked', None)
+
+    def reset_running_stats(self):
+        if self.track_running_stats:
+            self.running_mean = torch.zeros(self.num_features)
+            self.running_var = torch.ones(self.num_features)
+            self.num_batches_tracked = torch.tensor(0, dtype=torch.int64)
+
+    def reset_parameters(self):
+        self.reset_running_stats()
+        if self.affine:
+            self.weight = Parameter(torch.ones(self.num_features))
+            self.bias = Parameter(torch.zeros(self.num_features))
+
+    def _check_input_dim(self, input):
+        raise NotImplementedError
+
+    def forward(self, input):
+        self._check_input_dim(input)
+        return self._batch_norm(input)
+
+    def _batch_norm(self, input):
+        """Apply batch normalization."""
+        x = input.numpy()
+
+        if self.training and self.track_running_stats:
+            # Calculate statistics over batch and spatial dimensions
+            axes = self._get_reduction_axes(x.ndim)
+            mean = np.mean(x, axis=axes, keepdims=True)
+            var = np.var(x, axis=axes, keepdims=True)
+
+            # Update running statistics
+            if self.running_mean is not None:
+                running_mean = self.running_mean.numpy()
+                running_var = self.running_var.numpy()
+                running_mean = (1 - self.momentum) * running_mean + self.momentum * mean.flatten()
+                running_var = (1 - self.momentum) * running_var + self.momentum * var.flatten()
+                self.running_mean = torch.tensor(running_mean)
+                self.running_var = torch.tensor(running_var)
+        else:
+            # Use running statistics
+            if self.running_mean is not None:
+                mean = self.running_mean.numpy().reshape(self._get_reshape_dims(x.ndim))
+                var = self.running_var.numpy().reshape(self._get_reshape_dims(x.ndim))
+            else:
+                axes = self._get_reduction_axes(x.ndim)
+                mean = np.mean(x, axis=axes, keepdims=True)
+                var = np.var(x, axis=axes, keepdims=True)
+
+        # Normalize
+        x_norm = (x - mean) / np.sqrt(var + self.eps)
+
+        # Scale and shift
+        if self.affine:
+            weight = self.weight.numpy().reshape(self._get_reshape_dims(x.ndim))
+            bias = self.bias.numpy().reshape(self._get_reshape_dims(x.ndim))
+            x_norm = x_norm * weight + bias
+
+        return torch.tensor(x_norm.astype(np.float32))
+
+    def _get_reduction_axes(self, ndim):
+        raise NotImplementedError
+
+    def _get_reshape_dims(self, ndim):
+        raise NotImplementedError
+
+
+class BatchNorm1d(_BatchNorm):
+    """Batch normalization for 2D or 3D input (N, C) or (N, C, L)."""
+
+    def _check_input_dim(self, input):
+        if input.dim() not in (2, 3):
+            raise ValueError(f"Expected 2D or 3D input, got {input.dim()}D")
+
+    def _get_reduction_axes(self, ndim):
+        if ndim == 2:
+            return (0,)  # (N, C)
+        return (0, 2)  # (N, C, L)
+
+    def _get_reshape_dims(self, ndim):
+        if ndim == 2:
+            return (1, -1)
+        return (1, -1, 1)
+
+
+class BatchNorm2d(_BatchNorm):
+    """Batch normalization for 4D input (N, C, H, W)."""
+
+    def _check_input_dim(self, input):
+        if input.dim() != 4:
+            raise ValueError(f"Expected 4D input, got {input.dim()}D")
+
+    def _get_reduction_axes(self, ndim):
+        return (0, 2, 3)  # (N, C, H, W)
+
+    def _get_reshape_dims(self, ndim):
+        return (1, -1, 1, 1)
+
+
+class BatchNorm3d(_BatchNorm):
+    """Batch normalization for 5D input (N, C, D, H, W)."""
+
+    def _check_input_dim(self, input):
+        if input.dim() != 5:
+            raise ValueError(f"Expected 5D input, got {input.dim()}D")
+
+    def _get_reduction_axes(self, ndim):
+        return (0, 2, 3, 4)  # (N, C, D, H, W)
+
+    def _get_reshape_dims(self, ndim):
+        return (1, -1, 1, 1, 1)
+
+
+class SyncBatchNorm(BatchNorm2d):
+    """Synchronized batch normalization - falls back to BatchNorm2d."""
+
+    def __init__(self, num_features, eps=1e-5, momentum=0.1, affine=True,
+                 track_running_stats=True, process_group=None, device=None, dtype=None):
+        super().__init__(num_features, eps, momentum, affine, track_running_stats,
+                        device, dtype)
+
+    @classmethod
+    def convert_sync_batchnorm(cls, module, process_group=None):
+        """Convert BatchNorm to SyncBatchNorm - returns module unchanged."""
+        return module

--- a/src/mindtorch_v2/nn/modules/conv.py
+++ b/src/mindtorch_v2/nn/modules/conv.py
@@ -1,0 +1,215 @@
+"""Convolutional layer modules."""
+
+import math
+import numpy as np
+from ..module import Module
+from ..parameter import Parameter
+from .. import functional as F
+import mindtorch_v2 as torch
+
+
+class Conv1d(Module):
+    """1D convolution layer."""
+
+    def __init__(self, in_channels, out_channels, kernel_size, stride=1,
+                 padding=0, dilation=1, groups=1, bias=True, padding_mode='zeros',
+                 device=None, dtype=None):
+        super().__init__()
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.kernel_size = kernel_size if isinstance(kernel_size, tuple) else (kernel_size,)
+        self.stride = stride if isinstance(stride, tuple) else (stride,)
+        self.padding = padding if isinstance(padding, tuple) else (padding,)
+        self.dilation = dilation if isinstance(dilation, tuple) else (dilation,)
+        self.groups = groups
+        self.padding_mode = padding_mode
+
+        # Initialize weight
+        k = groups / (in_channels * self.kernel_size[0])
+        bound = math.sqrt(k)
+        weight_shape = (out_channels, in_channels // groups, self.kernel_size[0])
+        weight_np = np.random.uniform(-bound, bound, weight_shape).astype(np.float32)
+        self.weight = Parameter(torch.tensor(weight_np))
+
+        if bias:
+            bias_np = np.random.uniform(-bound, bound, (out_channels,)).astype(np.float32)
+            self.bias = Parameter(torch.tensor(bias_np))
+        else:
+            self.register_parameter('bias', None)
+
+    def forward(self, input):
+        return F.conv1d(input, self.weight, self.bias, self.stride,
+                       self.padding, self.dilation, self.groups)
+
+
+class Conv2d(Module):
+    """2D convolution layer."""
+
+    def __init__(self, in_channels, out_channels, kernel_size, stride=1,
+                 padding=0, dilation=1, groups=1, bias=True, padding_mode='zeros',
+                 device=None, dtype=None):
+        super().__init__()
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.kernel_size = kernel_size if isinstance(kernel_size, tuple) else (kernel_size, kernel_size)
+        self.stride = stride if isinstance(stride, tuple) else (stride, stride)
+        self.padding = padding if isinstance(padding, tuple) else (padding, padding)
+        self.dilation = dilation if isinstance(dilation, tuple) else (dilation, dilation)
+        self.groups = groups
+        self.padding_mode = padding_mode
+
+        # Initialize weight
+        k = groups / (in_channels * self.kernel_size[0] * self.kernel_size[1])
+        bound = math.sqrt(k)
+        weight_shape = (out_channels, in_channels // groups, self.kernel_size[0], self.kernel_size[1])
+        weight_np = np.random.uniform(-bound, bound, weight_shape).astype(np.float32)
+        self.weight = Parameter(torch.tensor(weight_np))
+
+        if bias:
+            bias_np = np.random.uniform(-bound, bound, (out_channels,)).astype(np.float32)
+            self.bias = Parameter(torch.tensor(bias_np))
+        else:
+            self.register_parameter('bias', None)
+
+    def forward(self, input):
+        return F.conv2d(input, self.weight, self.bias, self.stride,
+                       self.padding, self.dilation, self.groups)
+
+
+class Conv3d(Module):
+    """3D convolution layer."""
+
+    def __init__(self, in_channels, out_channels, kernel_size, stride=1,
+                 padding=0, dilation=1, groups=1, bias=True, padding_mode='zeros',
+                 device=None, dtype=None):
+        super().__init__()
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.kernel_size = kernel_size if isinstance(kernel_size, tuple) else (kernel_size, kernel_size, kernel_size)
+        self.stride = stride if isinstance(stride, tuple) else (stride, stride, stride)
+        self.padding = padding if isinstance(padding, tuple) else (padding, padding, padding)
+        self.dilation = dilation if isinstance(dilation, tuple) else (dilation, dilation, dilation)
+        self.groups = groups
+        self.padding_mode = padding_mode
+
+        # Initialize weight
+        k = groups / (in_channels * self.kernel_size[0] * self.kernel_size[1] * self.kernel_size[2])
+        bound = math.sqrt(k)
+        weight_shape = (out_channels, in_channels // groups, *self.kernel_size)
+        weight_np = np.random.uniform(-bound, bound, weight_shape).astype(np.float32)
+        self.weight = Parameter(torch.tensor(weight_np))
+
+        if bias:
+            bias_np = np.random.uniform(-bound, bound, (out_channels,)).astype(np.float32)
+            self.bias = Parameter(torch.tensor(bias_np))
+        else:
+            self.register_parameter('bias', None)
+
+    def forward(self, input):
+        return F.conv3d(input, self.weight, self.bias, self.stride,
+                       self.padding, self.dilation, self.groups)
+
+
+class ConvTranspose1d(Module):
+    """1D transposed convolution layer."""
+
+    def __init__(self, in_channels, out_channels, kernel_size, stride=1,
+                 padding=0, output_padding=0, groups=1, bias=True, dilation=1,
+                 padding_mode='zeros', device=None, dtype=None):
+        super().__init__()
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.kernel_size = kernel_size if isinstance(kernel_size, tuple) else (kernel_size,)
+        self.stride = stride if isinstance(stride, tuple) else (stride,)
+        self.padding = padding if isinstance(padding, tuple) else (padding,)
+        self.output_padding = output_padding if isinstance(output_padding, tuple) else (output_padding,)
+        self.dilation = dilation if isinstance(dilation, tuple) else (dilation,)
+        self.groups = groups
+        self.padding_mode = padding_mode
+
+        # Initialize weight (note: shape is different from Conv1d)
+        k = groups / (out_channels * self.kernel_size[0])
+        bound = math.sqrt(k)
+        weight_shape = (in_channels, out_channels // groups, self.kernel_size[0])
+        weight_np = np.random.uniform(-bound, bound, weight_shape).astype(np.float32)
+        self.weight = Parameter(torch.tensor(weight_np))
+
+        if bias:
+            bias_np = np.random.uniform(-bound, bound, (out_channels,)).astype(np.float32)
+            self.bias = Parameter(torch.tensor(bias_np))
+        else:
+            self.register_parameter('bias', None)
+
+    def forward(self, input, output_size=None):
+        return F.conv_transpose1d(input, self.weight, self.bias, self.stride,
+                                  self.padding, self.output_padding, self.groups, self.dilation)
+
+
+class ConvTranspose2d(Module):
+    """2D transposed convolution layer."""
+
+    def __init__(self, in_channels, out_channels, kernel_size, stride=1,
+                 padding=0, output_padding=0, groups=1, bias=True, dilation=1,
+                 padding_mode='zeros', device=None, dtype=None):
+        super().__init__()
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.kernel_size = kernel_size if isinstance(kernel_size, tuple) else (kernel_size, kernel_size)
+        self.stride = stride if isinstance(stride, tuple) else (stride, stride)
+        self.padding = padding if isinstance(padding, tuple) else (padding, padding)
+        self.output_padding = output_padding if isinstance(output_padding, tuple) else (output_padding, output_padding)
+        self.dilation = dilation if isinstance(dilation, tuple) else (dilation, dilation)
+        self.groups = groups
+        self.padding_mode = padding_mode
+
+        # Initialize weight
+        k = groups / (out_channels * self.kernel_size[0] * self.kernel_size[1])
+        bound = math.sqrt(k)
+        weight_shape = (in_channels, out_channels // groups, self.kernel_size[0], self.kernel_size[1])
+        weight_np = np.random.uniform(-bound, bound, weight_shape).astype(np.float32)
+        self.weight = Parameter(torch.tensor(weight_np))
+
+        if bias:
+            bias_np = np.random.uniform(-bound, bound, (out_channels,)).astype(np.float32)
+            self.bias = Parameter(torch.tensor(bias_np))
+        else:
+            self.register_parameter('bias', None)
+
+    def forward(self, input, output_size=None):
+        return F.conv_transpose2d(input, self.weight, self.bias, self.stride,
+                                  self.padding, self.output_padding, self.groups, self.dilation)
+
+
+class ConvTranspose3d(Module):
+    """3D transposed convolution layer."""
+
+    def __init__(self, in_channels, out_channels, kernel_size, stride=1,
+                 padding=0, output_padding=0, groups=1, bias=True, dilation=1,
+                 padding_mode='zeros', device=None, dtype=None):
+        super().__init__()
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.kernel_size = kernel_size if isinstance(kernel_size, tuple) else (kernel_size, kernel_size, kernel_size)
+        self.stride = stride if isinstance(stride, tuple) else (stride, stride, stride)
+        self.padding = padding if isinstance(padding, tuple) else (padding, padding, padding)
+        self.output_padding = output_padding if isinstance(output_padding, tuple) else (output_padding, output_padding, output_padding)
+        self.dilation = dilation if isinstance(dilation, tuple) else (dilation, dilation, dilation)
+        self.groups = groups
+        self.padding_mode = padding_mode
+
+        # Initialize weight
+        k = groups / (out_channels * self.kernel_size[0] * self.kernel_size[1] * self.kernel_size[2])
+        bound = math.sqrt(k)
+        weight_shape = (in_channels, out_channels // groups, *self.kernel_size)
+        weight_np = np.random.uniform(-bound, bound, weight_shape).astype(np.float32)
+        self.weight = Parameter(torch.tensor(weight_np))
+
+        if bias:
+            bias_np = np.random.uniform(-bound, bound, (out_channels,)).astype(np.float32)
+            self.bias = Parameter(torch.tensor(bias_np))
+        else:
+            self.register_parameter('bias', None)
+
+    def forward(self, input, output_size=None):
+        return F.conv_transpose3d(input, self.weight, self.bias, self.stride,
+                                  self.padding, self.output_padding, self.groups, self.dilation)

--- a/src/mindtorch_v2/nn/modules/loss.py
+++ b/src/mindtorch_v2/nn/modules/loss.py
@@ -1,0 +1,138 @@
+"""Loss functions for neural networks."""
+
+import numpy as np
+from ..module import Module
+from ..._tensor import Tensor
+from ..._dispatch import dispatch
+
+
+class _Loss(Module):
+    """Base class for loss functions."""
+
+    def __init__(self, reduction='mean'):
+        super().__init__()
+        self.reduction = reduction
+
+    def _reduce(self, loss):
+        """Apply reduction to loss tensor."""
+        if self.reduction == 'none':
+            return loss
+        elif self.reduction == 'mean':
+            return loss.mean()
+        elif self.reduction == 'sum':
+            return loss.sum()
+        else:
+            raise ValueError(f"Invalid reduction mode: {self.reduction}")
+
+
+class MSELoss(_Loss):
+    """Mean Squared Error loss."""
+
+    def __init__(self, reduction='mean'):
+        super().__init__(reduction)
+
+    def forward(self, input, target):
+        diff = input - target
+        loss = diff * diff
+        return self._reduce(loss)
+
+
+class CrossEntropyLoss(_Loss):
+    """Cross Entropy loss combining log_softmax and nll_loss."""
+
+    def __init__(self, weight=None, ignore_index=-100, reduction='mean',
+                 label_smoothing=0.0):
+        super().__init__(reduction)
+        self.weight = weight
+        self.ignore_index = ignore_index
+        self.label_smoothing = label_smoothing
+
+    def forward(self, input, target):
+        """
+        Args:
+            input: (N, C) logits
+            target: (N,) class indices or (N, C) probabilities
+        """
+        input_np = input.numpy()
+        target_np = target.numpy()
+
+        # Log softmax
+        max_val = np.max(input_np, axis=-1, keepdims=True)
+        log_sum_exp = max_val + np.log(np.sum(np.exp(input_np - max_val), axis=-1, keepdims=True))
+        log_probs = input_np - log_sum_exp
+
+        # Handle class indices
+        if target_np.ndim == 1:
+            # Gather log probabilities at target indices
+            batch_size = input_np.shape[0]
+            loss_np = np.zeros(batch_size, dtype=np.float32)
+
+            for i in range(batch_size):
+                idx = int(target_np[i])
+                if idx == self.ignore_index:
+                    loss_np[i] = 0.0
+                else:
+                    loss_np[i] = -log_probs[i, idx]
+
+            loss = Tensor(loss_np)
+        else:
+            # Soft targets
+            loss_np = -np.sum(target_np * log_probs, axis=-1)
+            loss = Tensor(loss_np)
+
+        return self._reduce(loss)
+
+
+class BCEWithLogitsLoss(_Loss):
+    """Binary Cross Entropy with Logits loss."""
+
+    def __init__(self, weight=None, reduction='mean', pos_weight=None):
+        super().__init__(reduction)
+        self.weight = weight
+        self.pos_weight = pos_weight
+
+    def forward(self, input, target):
+        input_np = input.numpy()
+        target_np = target.numpy()
+
+        # Stable BCE: max(x, 0) - x * z + log(1 + exp(-abs(x)))
+        max_val = np.maximum(input_np, 0)
+        loss_np = max_val - input_np * target_np + np.log(1 + np.exp(-np.abs(input_np)))
+
+        if self.pos_weight is not None:
+            pw = self.pos_weight.numpy() if isinstance(self.pos_weight, Tensor) else self.pos_weight
+            loss_np = loss_np * (1 + (pw - 1) * target_np)
+
+        loss = Tensor(loss_np.astype(np.float32))
+        return self._reduce(loss)
+
+
+class NLLLoss(_Loss):
+    """Negative Log Likelihood loss."""
+
+    def __init__(self, weight=None, ignore_index=-100, reduction='mean'):
+        super().__init__(reduction)
+        self.weight = weight
+        self.ignore_index = ignore_index
+
+    def forward(self, input, target):
+        """
+        Args:
+            input: (N, C) log probabilities
+            target: (N,) class indices
+        """
+        input_np = input.numpy()
+        target_np = target.numpy().astype(np.int64)
+
+        batch_size = input_np.shape[0]
+        loss_np = np.zeros(batch_size, dtype=np.float32)
+
+        for i in range(batch_size):
+            idx = target_np[i]
+            if idx == self.ignore_index:
+                loss_np[i] = 0.0
+            else:
+                loss_np[i] = -input_np[i, idx]
+
+        loss = Tensor(loss_np)
+        return self._reduce(loss)

--- a/src/mindtorch_v2/optim/__init__.py
+++ b/src/mindtorch_v2/optim/__init__.py
@@ -1,0 +1,6 @@
+"""Optimizers for mindtorch_v2."""
+
+from .optimizer import Optimizer
+from .adamw import AdamW, SGD
+
+__all__ = ['Optimizer', 'AdamW', 'SGD']

--- a/src/mindtorch_v2/optim/adamw.py
+++ b/src/mindtorch_v2/optim/adamw.py
@@ -1,0 +1,196 @@
+"""AdamW optimizer implementation."""
+
+import math
+import numpy as np
+import mindspore
+from .optimizer import Optimizer
+
+
+class AdamW(Optimizer):
+    """AdamW optimizer with decoupled weight decay.
+
+    Args:
+        params: Iterable of parameters to optimize
+        lr: Learning rate (default: 1e-3)
+        betas: Coefficients for computing running averages (default: (0.9, 0.999))
+        eps: Term added to denominator for numerical stability (default: 1e-8)
+        weight_decay: Weight decay coefficient (default: 1e-2)
+        amsgrad: Whether to use AMSGrad variant (default: False)
+    """
+
+    def __init__(self, params, lr=1e-3, betas=(0.9, 0.999), eps=1e-8,
+                 weight_decay=1e-2, amsgrad=False):
+        if lr < 0.0:
+            raise ValueError(f"Invalid learning rate: {lr}")
+        if eps < 0.0:
+            raise ValueError(f"Invalid epsilon value: {eps}")
+        if not 0.0 <= betas[0] < 1.0:
+            raise ValueError(f"Invalid beta parameter at index 0: {betas[0]}")
+        if not 0.0 <= betas[1] < 1.0:
+            raise ValueError(f"Invalid beta parameter at index 1: {betas[1]}")
+        if weight_decay < 0.0:
+            raise ValueError(f"Invalid weight_decay value: {weight_decay}")
+
+        defaults = dict(lr=lr, betas=betas, eps=eps, weight_decay=weight_decay,
+                       amsgrad=amsgrad)
+        super().__init__(params, defaults)
+
+    def step(self, closure=None):
+        """Perform a single optimization step.
+
+        Args:
+            closure: A closure that reevaluates the model and returns the loss.
+        """
+        loss = None
+        if closure is not None:
+            loss = closure()
+
+        for group in self.param_groups:
+            lr = group['lr']
+            beta1, beta2 = group['betas']
+            eps = group['eps']
+            weight_decay = group['weight_decay']
+            amsgrad = group['amsgrad']
+
+            for p in group['params']:
+                if p.grad is None:
+                    continue
+
+                grad = p.grad
+
+                # Get state for this parameter
+                state = self.state[id(p)]
+
+                # State initialization
+                if len(state) == 0:
+                    state['step'] = 0
+                    # Exponential moving average of gradient values
+                    state['exp_avg'] = np.zeros(p.shape, dtype=np.float32)
+                    # Exponential moving average of squared gradient values
+                    state['exp_avg_sq'] = np.zeros(p.shape, dtype=np.float32)
+                    if amsgrad:
+                        # Max of exp_avg_sq
+                        state['max_exp_avg_sq'] = np.zeros(p.shape, dtype=np.float32)
+
+                exp_avg = state['exp_avg']
+                exp_avg_sq = state['exp_avg_sq']
+                state['step'] += 1
+                step = state['step']
+
+                # Get numpy arrays
+                p_np = p.numpy()
+                grad_np = grad.numpy()
+
+                # Decoupled weight decay
+                if weight_decay != 0:
+                    p_np = p_np * (1 - lr * weight_decay)
+
+                # Update biased first moment estimate
+                exp_avg = beta1 * exp_avg + (1 - beta1) * grad_np
+                state['exp_avg'] = exp_avg
+
+                # Update biased second raw moment estimate
+                exp_avg_sq = beta2 * exp_avg_sq + (1 - beta2) * (grad_np ** 2)
+                state['exp_avg_sq'] = exp_avg_sq
+
+                # Bias correction
+                bias_correction1 = 1 - beta1 ** step
+                bias_correction2 = 1 - beta2 ** step
+
+                if amsgrad:
+                    max_exp_avg_sq = state['max_exp_avg_sq']
+                    max_exp_avg_sq = np.maximum(max_exp_avg_sq, exp_avg_sq)
+                    state['max_exp_avg_sq'] = max_exp_avg_sq
+                    denom = (np.sqrt(max_exp_avg_sq) / math.sqrt(bias_correction2)) + eps
+                else:
+                    denom = (np.sqrt(exp_avg_sq) / math.sqrt(bias_correction2)) + eps
+
+                step_size = lr / bias_correction1
+
+                # Update parameters
+                p_np = p_np - step_size * (exp_avg / denom)
+
+                # Write back to tensor
+                flat = p_np.astype(np.float32).ravel()
+                p._storage._ms_tensor = mindspore.Tensor(flat)
+                p._version += 1
+
+        return loss
+
+
+class SGD(Optimizer):
+    """Stochastic Gradient Descent optimizer.
+
+    Args:
+        params: Iterable of parameters to optimize
+        lr: Learning rate
+        momentum: Momentum factor (default: 0)
+        weight_decay: Weight decay (L2 penalty) (default: 0)
+        dampening: Dampening for momentum (default: 0)
+        nesterov: Enables Nesterov momentum (default: False)
+    """
+
+    def __init__(self, params, lr, momentum=0, dampening=0,
+                 weight_decay=0, nesterov=False):
+        if lr < 0.0:
+            raise ValueError(f"Invalid learning rate: {lr}")
+        if momentum < 0.0:
+            raise ValueError(f"Invalid momentum value: {momentum}")
+        if weight_decay < 0.0:
+            raise ValueError(f"Invalid weight_decay value: {weight_decay}")
+        if nesterov and (momentum <= 0 or dampening != 0):
+            raise ValueError("Nesterov momentum requires a momentum and zero dampening")
+
+        defaults = dict(lr=lr, momentum=momentum, dampening=dampening,
+                       weight_decay=weight_decay, nesterov=nesterov)
+        super().__init__(params, defaults)
+
+    def step(self, closure=None):
+        """Perform a single optimization step."""
+        loss = None
+        if closure is not None:
+            loss = closure()
+
+        for group in self.param_groups:
+            lr = group['lr']
+            momentum = group['momentum']
+            dampening = group['dampening']
+            weight_decay = group['weight_decay']
+            nesterov = group['nesterov']
+
+            for p in group['params']:
+                if p.grad is None:
+                    continue
+
+                grad = p.grad
+                p_np = p.numpy()
+                grad_np = grad.numpy()
+
+                # Add weight decay
+                if weight_decay != 0:
+                    grad_np = grad_np + weight_decay * p_np
+
+                # Apply momentum
+                if momentum != 0:
+                    state = self.state[id(p)]
+                    if 'momentum_buffer' not in state:
+                        state['momentum_buffer'] = grad_np.copy()
+                    else:
+                        buf = state['momentum_buffer']
+                        buf = momentum * buf + (1 - dampening) * grad_np
+                        state['momentum_buffer'] = buf
+
+                    if nesterov:
+                        grad_np = grad_np + momentum * state['momentum_buffer']
+                    else:
+                        grad_np = state['momentum_buffer']
+
+                # Update parameters
+                p_np = p_np - lr * grad_np
+
+                # Write back to tensor
+                flat = p_np.astype(np.float32).ravel()
+                p._storage._ms_tensor = mindspore.Tensor(flat)
+                p._version += 1
+
+        return loss

--- a/src/mindtorch_v2/optim/optimizer.py
+++ b/src/mindtorch_v2/optim/optimizer.py
@@ -1,0 +1,64 @@
+"""Optimizer base class."""
+
+from collections import defaultdict
+
+
+class Optimizer:
+    """Base class for all optimizers."""
+
+    def __init__(self, params, defaults):
+        self.defaults = defaults
+        self.state = defaultdict(dict)
+        self.param_groups = []
+
+        # Convert params to list if needed
+        param_groups = list(params)
+        if len(param_groups) == 0:
+            raise ValueError("optimizer got an empty parameter list")
+
+        # Check if params is a list of dicts (param groups) or list of tensors
+        if not isinstance(param_groups[0], dict):
+            param_groups = [{'params': param_groups}]
+
+        for param_group in param_groups:
+            self.add_param_group(param_group)
+
+    def add_param_group(self, param_group):
+        """Add a param group to the optimizer."""
+        params = param_group['params']
+        if isinstance(params, (list, tuple)):
+            param_group['params'] = list(params)
+        else:
+            param_group['params'] = [params]
+
+        for name, default in self.defaults.items():
+            if name not in param_group:
+                param_group[name] = default
+
+        self.param_groups.append(param_group)
+
+    def zero_grad(self, set_to_none=True):
+        """Reset gradients of all parameters."""
+        for group in self.param_groups:
+            for p in group['params']:
+                if p.grad is not None:
+                    if set_to_none:
+                        p.grad = None
+                    else:
+                        p.grad.zero_()
+
+    def step(self, closure=None):
+        """Perform a single optimization step."""
+        raise NotImplementedError
+
+    def state_dict(self):
+        """Return the state of the optimizer as a dict."""
+        return {
+            'state': dict(self.state),
+            'param_groups': self.param_groups,
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state."""
+        self.state = defaultdict(dict, state_dict['state'])
+        self.param_groups = state_dict['param_groups']

--- a/tests/mindtorch_v2/models/__init__.py
+++ b/tests/mindtorch_v2/models/__init__.py
@@ -1,0 +1,1 @@
+"""Package marker for models."""

--- a/tests/mindtorch_v2/models/bert_simple.py
+++ b/tests/mindtorch_v2/models/bert_simple.py
@@ -1,0 +1,272 @@
+"""Simple BERT model implementation using mindtorch_v2.
+
+This is a minimal BERT-like model for testing forward/backward passes.
+Not intended for production use.
+"""
+
+import math
+import mindtorch_v2 as torch
+import mindtorch_v2.nn as nn
+
+
+class BertConfig:
+    """Configuration for BERT model."""
+
+    def __init__(
+        self,
+        vocab_size=30522,
+        hidden_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        intermediate_size=256,
+        hidden_act="gelu",
+        hidden_dropout_prob=0.1,
+        attention_probs_dropout_prob=0.1,
+        max_position_embeddings=512,
+        type_vocab_size=2,
+        layer_norm_eps=1e-12,
+    ):
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.intermediate_size = intermediate_size
+        self.hidden_act = hidden_act
+        self.hidden_dropout_prob = hidden_dropout_prob
+        self.attention_probs_dropout_prob = attention_probs_dropout_prob
+        self.max_position_embeddings = max_position_embeddings
+        self.type_vocab_size = type_vocab_size
+        self.layer_norm_eps = layer_norm_eps
+
+
+class BertEmbeddings(nn.Module):
+    """Token + position + segment embeddings."""
+
+    def __init__(self, config):
+        super().__init__()
+        self.word_embeddings = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.position_embeddings = nn.Embedding(config.max_position_embeddings, config.hidden_size)
+        self.token_type_embeddings = nn.Embedding(config.type_vocab_size, config.hidden_size)
+
+        self.LayerNorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+        self.dropout = nn.Dropout(config.hidden_dropout_prob)
+
+    def forward(self, input_ids, token_type_ids=None, position_ids=None):
+        seq_length = input_ids.shape[1]
+
+        if position_ids is None:
+            position_ids = torch.arange(seq_length)
+            # Expand to batch dimension
+            position_ids = position_ids.unsqueeze(0).expand(input_ids.shape[0], -1)
+
+        if token_type_ids is None:
+            token_type_ids = torch.zeros(input_ids.shape, dtype=torch.int64)
+
+        word_embeds = self.word_embeddings(input_ids)
+        position_embeds = self.position_embeddings(position_ids)
+        token_type_embeds = self.token_type_embeddings(token_type_ids)
+
+        embeddings = word_embeds + position_embeds + token_type_embeds
+        embeddings = self.LayerNorm(embeddings)
+        embeddings = self.dropout(embeddings)
+        return embeddings
+
+
+class BertSelfAttention(nn.Module):
+    """Multi-head self-attention."""
+
+    def __init__(self, config):
+        super().__init__()
+        self.num_attention_heads = config.num_attention_heads
+        self.attention_head_size = config.hidden_size // config.num_attention_heads
+        self.all_head_size = self.num_attention_heads * self.attention_head_size
+
+        self.query = nn.Linear(config.hidden_size, self.all_head_size)
+        self.key = nn.Linear(config.hidden_size, self.all_head_size)
+        self.value = nn.Linear(config.hidden_size, self.all_head_size)
+
+        self.dropout = nn.Dropout(config.attention_probs_dropout_prob)
+
+    def transpose_for_scores(self, x):
+        """Reshape from (batch, seq, hidden) to (batch, heads, seq, head_size)."""
+        batch_size, seq_length, _ = x.shape
+        x = x.view(batch_size, seq_length, self.num_attention_heads, self.attention_head_size)
+        return x.permute(0, 2, 1, 3)
+
+    def forward(self, hidden_states, attention_mask=None):
+        query_layer = self.transpose_for_scores(self.query(hidden_states))
+        key_layer = self.transpose_for_scores(self.key(hidden_states))
+        value_layer = self.transpose_for_scores(self.value(hidden_states))
+
+        # Attention scores: (batch, heads, seq, seq)
+        # Use contiguous() before view() since permute creates non-contiguous tensors
+        attention_scores = torch.bmm(
+            query_layer.contiguous().view(-1, query_layer.shape[2], query_layer.shape[3]),
+            key_layer.contiguous().view(-1, key_layer.shape[2], key_layer.shape[3]).transpose(1, 2)
+        )
+        attention_scores = attention_scores.view(
+            query_layer.shape[0], query_layer.shape[1], query_layer.shape[2], key_layer.shape[2]
+        )
+        attention_scores = attention_scores / math.sqrt(self.attention_head_size)
+
+        if attention_mask is not None:
+            # attention_mask: (batch, 1, 1, seq) with 0 for valid, large negative for masked
+            attention_scores = attention_scores + attention_mask
+
+        # Softmax and dropout
+        attention_probs = nn.functional.softmax(attention_scores, dim=-1)
+        attention_probs = self.dropout(attention_probs)
+
+        # Context: (batch, heads, seq, head_size)
+        context_layer = torch.bmm(
+            attention_probs.contiguous().view(-1, attention_probs.shape[2], attention_probs.shape[3]),
+            value_layer.contiguous().view(-1, value_layer.shape[2], value_layer.shape[3])
+        )
+        context_layer = context_layer.view(
+            query_layer.shape[0], query_layer.shape[1], query_layer.shape[2], self.attention_head_size
+        )
+
+        # Reshape back: (batch, seq, hidden)
+        context_layer = context_layer.permute(0, 2, 1, 3)
+        batch_size, seq_length, _, _ = context_layer.shape
+        context_layer = context_layer.contiguous().view(batch_size, seq_length, self.all_head_size)
+
+        return context_layer
+
+
+class BertSelfOutput(nn.Module):
+    """Self-attention output projection."""
+
+    def __init__(self, config):
+        super().__init__()
+        self.dense = nn.Linear(config.hidden_size, config.hidden_size)
+        self.LayerNorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+        self.dropout = nn.Dropout(config.hidden_dropout_prob)
+
+    def forward(self, hidden_states, input_tensor):
+        hidden_states = self.dense(hidden_states)
+        hidden_states = self.dropout(hidden_states)
+        hidden_states = self.LayerNorm(hidden_states + input_tensor)
+        return hidden_states
+
+
+class BertAttention(nn.Module):
+    """Full attention block: self-attention + output projection."""
+
+    def __init__(self, config):
+        super().__init__()
+        self.self = BertSelfAttention(config)
+        self.output = BertSelfOutput(config)
+
+    def forward(self, hidden_states, attention_mask=None):
+        self_outputs = self.self(hidden_states, attention_mask)
+        attention_output = self.output(self_outputs, hidden_states)
+        return attention_output
+
+
+class BertIntermediate(nn.Module):
+    """Feed-forward intermediate layer."""
+
+    def __init__(self, config):
+        super().__init__()
+        self.dense = nn.Linear(config.hidden_size, config.intermediate_size)
+        self.intermediate_act_fn = nn.GELU()
+
+    def forward(self, hidden_states):
+        hidden_states = self.dense(hidden_states)
+        hidden_states = self.intermediate_act_fn(hidden_states)
+        return hidden_states
+
+
+class BertOutput(nn.Module):
+    """Feed-forward output with residual."""
+
+    def __init__(self, config):
+        super().__init__()
+        self.dense = nn.Linear(config.intermediate_size, config.hidden_size)
+        self.LayerNorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+        self.dropout = nn.Dropout(config.hidden_dropout_prob)
+
+    def forward(self, hidden_states, input_tensor):
+        hidden_states = self.dense(hidden_states)
+        hidden_states = self.dropout(hidden_states)
+        hidden_states = self.LayerNorm(hidden_states + input_tensor)
+        return hidden_states
+
+
+class BertLayer(nn.Module):
+    """Full transformer layer."""
+
+    def __init__(self, config):
+        super().__init__()
+        self.attention = BertAttention(config)
+        self.intermediate = BertIntermediate(config)
+        self.output = BertOutput(config)
+
+    def forward(self, hidden_states, attention_mask=None):
+        attention_output = self.attention(hidden_states, attention_mask)
+        intermediate_output = self.intermediate(attention_output)
+        layer_output = self.output(intermediate_output, attention_output)
+        return layer_output
+
+
+class BertEncoder(nn.Module):
+    """Stack of transformer layers."""
+
+    def __init__(self, config):
+        super().__init__()
+        self.layer = nn.ModuleList([BertLayer(config) for _ in range(config.num_hidden_layers)])
+
+    def forward(self, hidden_states, attention_mask=None):
+        for layer_module in self.layer:
+            hidden_states = layer_module(hidden_states, attention_mask)
+        return hidden_states
+
+
+class BertPooler(nn.Module):
+    """Pool the first token for classification."""
+
+    def __init__(self, config):
+        super().__init__()
+        self.dense = nn.Linear(config.hidden_size, config.hidden_size)
+        self.activation = nn.Tanh()
+
+    def forward(self, hidden_states):
+        # Take [CLS] token
+        first_token_tensor = hidden_states[:, 0]
+        pooled_output = self.dense(first_token_tensor)
+        pooled_output = self.activation(pooled_output)
+        return pooled_output
+
+
+class BertModel(nn.Module):
+    """Full BERT model."""
+
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+
+        self.embeddings = BertEmbeddings(config)
+        self.encoder = BertEncoder(config)
+        self.pooler = BertPooler(config)
+
+    def get_extended_attention_mask(self, attention_mask):
+        """Create attention mask for self-attention."""
+        # attention_mask: (batch, seq) -> (batch, 1, 1, seq)
+        extended_attention_mask = attention_mask.unsqueeze(1).unsqueeze(2)
+        # Convert 0/1 mask to large negative values
+        # 1 -> 0, 0 -> -10000
+        extended_attention_mask = (1.0 - extended_attention_mask) * -10000.0
+        return extended_attention_mask
+
+    def forward(self, input_ids, attention_mask=None, token_type_ids=None):
+        if attention_mask is None:
+            attention_mask = torch.ones(input_ids.shape)
+
+        extended_attention_mask = self.get_extended_attention_mask(attention_mask)
+
+        embedding_output = self.embeddings(input_ids, token_type_ids)
+        encoder_output = self.encoder(embedding_output, extended_attention_mask)
+        pooled_output = self.pooler(encoder_output)
+
+        return encoder_output, pooled_output

--- a/tests/mindtorch_v2/run_bert_test.py
+++ b/tests/mindtorch_v2/run_bert_test.py
@@ -1,0 +1,50 @@
+"""Run BERT tests with mindtorch_v2 backend."""
+
+import sys
+import os
+
+# Add src to path
+project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+src_path = os.path.join(project_root, 'src')
+sys.path.insert(0, src_path)
+
+# Use the torch_proxy system to install mindtorch_v2 as torch
+from mindtorch_v2._torch_proxy import install
+install()
+
+print("mindtorch_v2 torch_proxy installed")
+
+# Now try to import transformers BERT
+if __name__ == "__main__":
+    print("\nTrying to import transformers BertModel...")
+    try:
+        from transformers import BertConfig, BertModel
+        print("Import successful!")
+
+        # Try to create a small model
+        config = BertConfig(
+            vocab_size=1000,
+            hidden_size=64,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            intermediate_size=128,
+        )
+        print(f"\nCreating BertModel with config: hidden_size={config.hidden_size}")
+        model = BertModel(config)
+        print(f"Model created successfully!")
+
+        # Try forward pass
+        import torch
+        input_ids = torch.randint(0, 1000, (2, 8))
+        attention_mask = torch.ones((2, 8))
+
+        print("\nRunning forward pass...")
+        outputs = model(input_ids, attention_mask=attention_mask)
+        print(f"Output shape: {outputs.last_hidden_state.shape}")
+
+        print("\n=== SUCCESS: transformers BERT works with mindtorch_v2! ===")
+
+    except Exception as e:
+        print(f"Error: {e}")
+        import traceback
+        traceback.print_exc()

--- a/tests/mindtorch_v2/test_nn_loss.py
+++ b/tests/mindtorch_v2/test_nn_loss.py
@@ -1,0 +1,113 @@
+"""Tests for loss functions and nn.init."""
+
+import numpy as np
+import mindtorch_v2 as torch
+import mindtorch_v2.nn as nn
+
+
+class TestMSELoss:
+    def test_mse_loss_mean(self):
+        loss_fn = nn.MSELoss(reduction='mean')
+        input = torch.tensor([1.0, 2.0, 3.0])
+        target = torch.tensor([1.0, 2.0, 4.0])
+        loss = loss_fn(input, target)
+        # (0 + 0 + 1) / 3 = 0.333...
+        expected = 1.0 / 3.0
+        np.testing.assert_almost_equal(loss.item(), expected, decimal=5)
+
+    def test_mse_loss_sum(self):
+        loss_fn = nn.MSELoss(reduction='sum')
+        input = torch.tensor([1.0, 2.0, 3.0])
+        target = torch.tensor([1.0, 2.0, 4.0])
+        loss = loss_fn(input, target)
+        expected = 1.0  # 0 + 0 + 1
+        np.testing.assert_almost_equal(loss.item(), expected, decimal=5)
+
+    def test_mse_loss_none(self):
+        loss_fn = nn.MSELoss(reduction='none')
+        input = torch.tensor([1.0, 2.0, 3.0])
+        target = torch.tensor([1.0, 2.0, 4.0])
+        loss = loss_fn(input, target)
+        expected = np.array([0.0, 0.0, 1.0])
+        np.testing.assert_array_almost_equal(loss.numpy(), expected)
+
+
+class TestCrossEntropyLoss:
+    def test_cross_entropy_basic(self):
+        loss_fn = nn.CrossEntropyLoss()
+        # 2 samples, 3 classes
+        input = torch.tensor([[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]])
+        target = torch.tensor([2, 0])  # correct class for first, wrong for second
+        loss = loss_fn(input, target)
+        assert loss.item() > 0  # Loss should be positive
+
+    def test_cross_entropy_perfect_prediction(self):
+        loss_fn = nn.CrossEntropyLoss()
+        # High logit for correct class
+        input = torch.tensor([[10.0, 0.0, 0.0]])
+        target = torch.tensor([0])
+        loss = loss_fn(input, target)
+        # Should be very small
+        assert loss.item() < 0.1
+
+
+class TestBCEWithLogitsLoss:
+    def test_bce_with_logits_basic(self):
+        loss_fn = nn.BCEWithLogitsLoss()
+        input = torch.tensor([0.0, 0.0, 0.0])
+        target = torch.tensor([1.0, 0.0, 1.0])
+        loss = loss_fn(input, target)
+        # At logit=0, sigmoid=0.5, BCE = -0.5*log(0.5) - 0.5*log(0.5) = log(2)
+        expected = np.log(2)
+        np.testing.assert_almost_equal(loss.item(), expected, decimal=5)
+
+
+class TestNNInit:
+    def test_uniform(self):
+        t = torch.zeros(10, 10)
+        nn.init.uniform_(t, a=-1.0, b=1.0)
+        arr = t.numpy()
+        assert arr.min() >= -1.0
+        assert arr.max() <= 1.0
+        assert arr.std() > 0  # Not all same value
+
+    def test_normal(self):
+        t = torch.zeros(100, 100)
+        nn.init.normal_(t, mean=0.0, std=1.0)
+        arr = t.numpy()
+        # Check mean and std are approximately correct
+        np.testing.assert_almost_equal(arr.mean(), 0.0, decimal=1)
+        np.testing.assert_almost_equal(arr.std(), 1.0, decimal=1)
+
+    def test_zeros(self):
+        t = torch.ones(10, 10)
+        nn.init.zeros_(t)
+        np.testing.assert_array_equal(t.numpy(), np.zeros((10, 10)))
+
+    def test_ones(self):
+        t = torch.zeros(10, 10)
+        nn.init.ones_(t)
+        np.testing.assert_array_equal(t.numpy(), np.ones((10, 10)))
+
+    def test_xavier_uniform(self):
+        t = torch.zeros(64, 32)
+        nn.init.xavier_uniform_(t)
+        arr = t.numpy()
+        # Check values are in reasonable range
+        fan_in, fan_out = 32, 64
+        std = np.sqrt(2.0 / (fan_in + fan_out))
+        bound = np.sqrt(3.0) * std
+        assert arr.min() >= -bound - 0.1
+        assert arr.max() <= bound + 0.1
+
+    def test_kaiming_uniform(self):
+        t = torch.zeros(64, 32)
+        nn.init.kaiming_uniform_(t)
+        arr = t.numpy()
+        assert arr.std() > 0  # Not all same
+
+    def test_kaiming_normal(self):
+        t = torch.zeros(64, 32)
+        nn.init.kaiming_normal_(t)
+        arr = t.numpy()
+        assert arr.std() > 0  # Not all same

--- a/tests/mindtorch_v2/test_optim.py
+++ b/tests/mindtorch_v2/test_optim.py
@@ -1,0 +1,140 @@
+"""Tests for optimizers."""
+
+import numpy as np
+import mindtorch_v2 as torch
+import mindtorch_v2.nn as nn
+import mindtorch_v2.optim as optim
+
+
+class TestAdamW:
+    def test_adamw_basic(self):
+        # Simple linear model
+        model = nn.Linear(10, 2)
+        optimizer = optim.AdamW(model.parameters(), lr=0.01)
+
+        # Create input
+        x = torch.randn(4, 10)
+
+        # Training loop
+        initial_params = [p.numpy().copy() for p in model.parameters()]
+
+        for _ in range(5):
+            output = model(x)
+            loss = output.sum()
+            loss.backward()
+            optimizer.step()
+            optimizer.zero_grad()
+
+        # Check that parameters have changed
+        for i, p in enumerate(model.parameters()):
+            assert not np.allclose(p.numpy(), initial_params[i]), \
+                f"Parameter {i} did not change after optimization"
+
+    def test_adamw_weight_decay(self):
+        # Test that weight decay is applied
+        model = nn.Linear(10, 2)
+        optimizer = optim.AdamW(model.parameters(), lr=0.01, weight_decay=0.1)
+
+        x = torch.randn(4, 10)
+
+        for _ in range(10):
+            output = model(x)
+            loss = output.sum()
+            loss.backward()
+            optimizer.step()
+            optimizer.zero_grad()
+
+        # Should complete without error
+        assert True
+
+    def test_adamw_zero_grad(self):
+        model = nn.Linear(10, 2)
+        optimizer = optim.AdamW(model.parameters(), lr=0.01)
+
+        x = torch.randn(4, 10)
+        output = model(x)
+        loss = output.sum()
+        loss.backward()
+
+        # Check gradients exist
+        for p in model.parameters():
+            assert p.grad is not None
+
+        # Zero gradients
+        optimizer.zero_grad()
+
+        # Check gradients are cleared
+        for p in model.parameters():
+            assert p.grad is None
+
+
+class TestSGD:
+    def test_sgd_basic(self):
+        model = nn.Linear(10, 2)
+        optimizer = optim.SGD(model.parameters(), lr=0.01)
+
+        x = torch.randn(4, 10)
+        initial_params = [p.numpy().copy() for p in model.parameters()]
+
+        for _ in range(5):
+            output = model(x)
+            loss = output.sum()
+            loss.backward()
+            optimizer.step()
+            optimizer.zero_grad()
+
+        # Check that parameters have changed
+        for i, p in enumerate(model.parameters()):
+            assert not np.allclose(p.numpy(), initial_params[i])
+
+    def test_sgd_momentum(self):
+        model = nn.Linear(10, 2)
+        optimizer = optim.SGD(model.parameters(), lr=0.01, momentum=0.9)
+
+        x = torch.randn(4, 10)
+
+        for _ in range(5):
+            output = model(x)
+            loss = output.sum()
+            loss.backward()
+            optimizer.step()
+            optimizer.zero_grad()
+
+        # Should complete without error
+        assert True
+
+
+class TestTrainingLoop:
+    def test_full_training_loop(self):
+        """Test a complete training loop with model, loss, and optimizer."""
+        # Create model
+        model = nn.Sequential(
+            nn.Linear(10, 32),
+            nn.ReLU(),
+            nn.Linear(32, 2)
+        )
+
+        # Create optimizer and loss
+        optimizer = optim.AdamW(model.parameters(), lr=0.001)
+        criterion = nn.MSELoss()
+
+        # Training data
+        x = torch.randn(8, 10)
+        y = torch.randn(8, 2)
+
+        losses = []
+        for _ in range(10):
+            # Forward
+            output = model(x)
+            loss = criterion(output, y)
+            losses.append(loss.item())
+
+            # Backward
+            loss.backward()
+
+            # Update
+            optimizer.step()
+            optimizer.zero_grad()
+
+        # Loss should generally decrease (or at least not explode)
+        assert all(np.isfinite(l) for l in losses), "Loss contains non-finite values"

--- a/tests/mindtorch_v2/test_tensor_ops.py
+++ b/tests/mindtorch_v2/test_tensor_ops.py
@@ -1,0 +1,180 @@
+"""Tests for tensor manipulation operations."""
+
+import numpy as np
+import mindtorch_v2 as torch
+
+
+class TestCat:
+    def test_cat_dim0(self):
+        a = torch.tensor([[1, 2], [3, 4]])
+        b = torch.tensor([[5, 6], [7, 8]])
+        result = torch.cat([a, b], dim=0)
+        expected = np.array([[1, 2], [3, 4], [5, 6], [7, 8]])
+        np.testing.assert_array_equal(result.numpy(), expected)
+
+    def test_cat_dim1(self):
+        a = torch.tensor([[1, 2], [3, 4]])
+        b = torch.tensor([[5, 6], [7, 8]])
+        result = torch.cat([a, b], dim=1)
+        expected = np.array([[1, 2, 5, 6], [3, 4, 7, 8]])
+        np.testing.assert_array_equal(result.numpy(), expected)
+
+
+class TestStack:
+    def test_stack_dim0(self):
+        a = torch.tensor([1, 2, 3])
+        b = torch.tensor([4, 5, 6])
+        result = torch.stack([a, b], dim=0)
+        expected = np.array([[1, 2, 3], [4, 5, 6]])
+        np.testing.assert_array_equal(result.numpy(), expected)
+
+    def test_stack_dim1(self):
+        a = torch.tensor([1, 2, 3])
+        b = torch.tensor([4, 5, 6])
+        result = torch.stack([a, b], dim=1)
+        expected = np.array([[1, 4], [2, 5], [3, 6]])
+        np.testing.assert_array_equal(result.numpy(), expected)
+
+
+class TestSplit:
+    def test_split_size(self):
+        x = torch.tensor([1, 2, 3, 4, 5, 6])
+        result = torch.split(x, 2)
+        assert len(result) == 3
+        np.testing.assert_array_equal(result[0].numpy(), [1, 2])
+        np.testing.assert_array_equal(result[1].numpy(), [3, 4])
+        np.testing.assert_array_equal(result[2].numpy(), [5, 6])
+
+    def test_split_sections(self):
+        x = torch.tensor([1, 2, 3, 4, 5, 6])
+        result = torch.split(x, [1, 2, 3])
+        assert len(result) == 3
+        np.testing.assert_array_equal(result[0].numpy(), [1])
+        np.testing.assert_array_equal(result[1].numpy(), [2, 3])
+        np.testing.assert_array_equal(result[2].numpy(), [4, 5, 6])
+
+
+class TestChunk:
+    def test_chunk(self):
+        x = torch.tensor([1, 2, 3, 4, 5, 6])
+        result = torch.chunk(x, 3)
+        assert len(result) == 3
+        np.testing.assert_array_equal(result[0].numpy(), [1, 2])
+        np.testing.assert_array_equal(result[1].numpy(), [3, 4])
+        np.testing.assert_array_equal(result[2].numpy(), [5, 6])
+
+
+class TestClone:
+    def test_clone(self):
+        x = torch.tensor([1.0, 2.0, 3.0])
+        y = torch.clone(x)
+        # Modify original
+        x_np = x.numpy()
+        # Clone should be independent
+        np.testing.assert_array_equal(y.numpy(), [1.0, 2.0, 3.0])
+
+    def test_clone_method(self):
+        x = torch.tensor([1.0, 2.0, 3.0])
+        y = x.clone()
+        np.testing.assert_array_equal(y.numpy(), [1.0, 2.0, 3.0])
+
+
+class TestWhere:
+    def test_where(self):
+        condition = torch.tensor([True, False, True])
+        x = torch.tensor([1, 2, 3])
+        y = torch.tensor([4, 5, 6])
+        result = torch.where(condition, x, y)
+        expected = np.array([1, 5, 3])
+        np.testing.assert_array_equal(result.numpy(), expected)
+
+
+class TestRepeat:
+    def test_repeat(self):
+        x = torch.tensor([1, 2, 3])
+        result = x.repeat(2)
+        expected = np.array([1, 2, 3, 1, 2, 3])
+        np.testing.assert_array_equal(result.numpy(), expected)
+
+    def test_repeat_2d(self):
+        x = torch.tensor([[1, 2], [3, 4]])
+        result = x.repeat(2, 3)
+        assert result.shape == (4, 6)
+
+
+class TestMaskedFill:
+    def test_masked_fill(self):
+        x = torch.tensor([1.0, 2.0, 3.0, 4.0])
+        mask = torch.tensor([True, False, True, False])
+        result = x.masked_fill(mask, 0.0)
+        expected = np.array([0.0, 2.0, 0.0, 4.0])
+        np.testing.assert_array_equal(result.numpy(), expected)
+
+    def test_masked_fill_inplace(self):
+        x = torch.tensor([1.0, 2.0, 3.0, 4.0])
+        mask = torch.tensor([True, False, True, False])
+        x.masked_fill_(mask, 0.0)
+        expected = np.array([0.0, 2.0, 0.0, 4.0])
+        np.testing.assert_array_equal(x.numpy(), expected)
+
+
+class TestVarStd:
+    def test_var(self):
+        x = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0])
+        result = torch.var(x)
+        # With Bessel's correction (default)
+        expected = np.var([1.0, 2.0, 3.0, 4.0, 5.0], ddof=1)
+        np.testing.assert_almost_equal(result.item(), expected)
+
+    def test_std(self):
+        x = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0])
+        result = torch.std(x)
+        expected = np.std([1.0, 2.0, 3.0, 4.0, 5.0], ddof=1)
+        np.testing.assert_almost_equal(result.item(), expected)
+
+
+class TestClamp:
+    def test_clamp(self):
+        x = torch.tensor([-1.0, 0.0, 1.0, 2.0, 3.0])
+        result = torch.clamp(x, min=0.0, max=2.0)
+        expected = np.array([0.0, 0.0, 1.0, 2.0, 2.0])
+        np.testing.assert_array_equal(result.numpy(), expected)
+
+    def test_clamp_min_only(self):
+        x = torch.tensor([-1.0, 0.0, 1.0])
+        result = torch.clamp(x, min=0.0)
+        expected = np.array([0.0, 0.0, 1.0])
+        np.testing.assert_array_equal(result.numpy(), expected)
+
+
+class TestRsqrt:
+    def test_rsqrt(self):
+        x = torch.tensor([1.0, 4.0, 9.0, 16.0])
+        result = torch.rsqrt(x)
+        expected = np.array([1.0, 0.5, 1/3, 0.25])
+        np.testing.assert_array_almost_equal(result.numpy(), expected)
+
+
+class TestReciprocal:
+    def test_reciprocal(self):
+        x = torch.tensor([1.0, 2.0, 4.0, 5.0])
+        result = torch.reciprocal(x)
+        expected = np.array([1.0, 0.5, 0.25, 0.2])
+        np.testing.assert_array_almost_equal(result.numpy(), expected)
+
+
+class TestBmm:
+    def test_bmm(self):
+        a = torch.randn(10, 3, 4)
+        b = torch.randn(10, 4, 5)
+        result = torch.bmm(a, b)
+        assert result.shape == (10, 3, 5)
+
+
+class TestBaddbmm:
+    def test_baddbmm(self):
+        M = torch.randn(10, 3, 5)
+        batch1 = torch.randn(10, 3, 4)
+        batch2 = torch.randn(10, 4, 5)
+        result = torch.baddbmm(M, batch1, batch2)
+        assert result.shape == (10, 3, 5)


### PR DESCRIPTION
## Summary
- Add torch_proxy system for import redirection (makes mindtorch_v2 available as 'torch')
- Add nn modules: Conv1d, BatchNorm1d, CrossEntropyLoss, MSELoss, BCEWithLogitsLoss
- Add optimizers: AdamW, SGD with momentum support
- Add tensor ops: cat, stack, split, chunk, clone, repeat, masked_fill, where, var, std, clamp, rsqrt, reciprocal, bmm, baddbmm
- Fix transpose() to return a view sharing storage (not a copy)
- Fix scaled_dot_product_attention to use autograd-compatible operations
- BERT forward/backward pass and training loop now work with transformers BertModel

## Test plan
- [x] All 266 mindtorch_v2 unit tests pass
- [x] BERT forward pass produces correct output shapes
- [x] BERT backward pass produces gradients for all parameters
- [x] BERT training loop with AdamW completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)