### PR TITLE
refactor(mindtorch_v2): remove transformers-specific code, use generic PyTorch APIs

### DIFF
--- a/src/mindtorch_v2/_dynamo/__init__.py
+++ b/src/mindtorch_v2/_dynamo/__init__.py
@@ -1,7 +1,7 @@
 """Stub _dynamo module for compatibility.
 
 This provides dummy implementations for torch._dynamo APIs
-that are checked by libraries like accelerate and transformers.
+that are checked by various PyTorch-based libraries.
 """
 
 from .eval_frame import OptimizedModule

--- a/src/mindtorch_v2/_torch_proxy/__init__.py
+++ b/src/mindtorch_v2/_torch_proxy/__init__.py
@@ -1,14 +1,14 @@
 """Torch proxy system for mindtorch_v2.
 
 This module provides a proxy loader that intercepts `import torch`
-and returns mindtorch_v2 instead, enabling HuggingFace transformers
+and returns mindtorch_v2 instead, enabling PyTorch-based libraries
 to work with mindtorch_v2 as the backend.
 
 Usage:
     from mindtorch_v2._torch_proxy import install
     install()  # Now `import torch` returns mindtorch_v2
 
-    from transformers import BertModel  # Uses mindtorch_v2
+    # PyTorch-based libraries now use mindtorch_v2
 """
 
 from .finder import MindTorchV2Finder

--- a/src/mindtorch_v2/_torch_proxy/stubs/_C.py
+++ b/src/mindtorch_v2/_torch_proxy/stubs/_C.py
@@ -1,7 +1,7 @@
 """Stub for torch._C - PyTorch's C++ extension module.
 
-This is a Tier 3 stub - imported by transformers but not actually
-used for BERT forward/backward passes.
+This is a Tier 3 stub - imported by PyTorch-based libraries but not
+actually used for model forward/backward passes.
 """
 
 from types import ModuleType
@@ -19,13 +19,13 @@ class _CStub(ModuleType):
         return None
 
 
-# Create module-level attributes that transformers might check
+# Create module-level attributes that libraries might check
 _C = _CStub('torch._C')
 
 # Common attributes that might be accessed - set directly on __dict__ to bypass __getattr__
 _C.__dict__['_get_tracing_state'] = lambda: None
 _C.__dict__['_is_tracing'] = lambda: False
-_C.__dict__['_jit_clear_class_registry'] = lambda: None  # Used by transformers tests for cleanup
+_C.__dict__['_jit_clear_class_registry'] = lambda: None  # Used by some test frameworks for cleanup
 _C.__dict__['ScriptModule'] = type('ScriptModule', (), {})
 _C.__dict__['ScriptFunction'] = type('ScriptFunction', (), {})
 _C.__dict__['Graph'] = type('Graph', (), {})

--- a/src/mindtorch_v2/_torch_proxy/stubs/__init__.py
+++ b/src/mindtorch_v2/_torch_proxy/stubs/__init__.py
@@ -1,1 +1,1 @@
-"""Stub modules for torch internals that transformers imports but doesn't use."""
+"""Stub modules for torch internals that PyTorch-based libraries may import."""

--- a/src/mindtorch_v2/_torch_proxy/stubs/_pytree.py
+++ b/src/mindtorch_v2/_torch_proxy/stubs/_pytree.py
@@ -1,7 +1,7 @@
 """Stub for torch.utils._pytree - Tree utilities.
 
 This is a Tier 3 stub that provides minimal tree_flatten/tree_unflatten
-functionality that transformers may use.
+functionality that PyTorch-based libraries may use.
 """
 
 from collections import namedtuple
@@ -126,7 +126,7 @@ class _TreeContext:
     pass
 
 
-# Additional utilities that transformers might use
+# Additional utilities for pytree operations
 def tree_leaves(tree):
     """Get all leaves from a tree."""
     leaves, _ = tree_flatten(tree)

--- a/src/mindtorch_v2/_torch_proxy/stubs/fx/__init__.py
+++ b/src/mindtorch_v2/_torch_proxy/stubs/fx/__init__.py
@@ -1,7 +1,7 @@
 """Stub for torch.fx module.
 
-This provides a minimal FX implementation that passes HuggingFace tests
-by wrapping the original model rather than doing true symbolic tracing.
+This provides a minimal FX implementation that wraps the original model
+rather than doing true symbolic tracing.
 """
 
 from . import node
@@ -204,7 +204,7 @@ class Tracer:
     """
 
     def __init__(self, autowrap_modules=(), autowrap_functions=(), param_shapes_constant=False):
-        """Initialize Tracer with HuggingFace-compatible signature."""
+        """Initialize Tracer with PyTorch-compatible signature."""
         self.autowrap_modules = autowrap_modules
         self.autowrap_functions = autowrap_functions
         self.param_shapes_constant = param_shapes_constant

--- a/src/mindtorch_v2/_torch_proxy/stubs/utils/_pytree.py
+++ b/src/mindtorch_v2/_torch_proxy/stubs/utils/_pytree.py
@@ -1,7 +1,7 @@
 """Stub for torch.utils._pytree - Tree utilities.
 
 This is a Tier 3 stub that provides minimal tree_flatten/tree_unflatten
-functionality that transformers may use.
+functionality that PyTorch-based libraries may use.
 """
 
 from collections import namedtuple
@@ -126,7 +126,7 @@ class _TreeContext:
     pass
 
 
-# Additional utilities that transformers might use
+# Additional utilities for pytree operations
 def tree_leaves(tree):
     """Get all leaves from a tree."""
     leaves, _ = tree_flatten(tree)
@@ -150,10 +150,7 @@ def tree_any(fn, tree):
 
 
 def _dict_flatten(d):
-    """Flatten a dictionary into (values, keys) tuple.
-
-    This is used by diffusers/transformers internally.
-    """
+    """Flatten a dictionary into (values, keys) tuple."""
     keys = list(d.keys())
     values = [d[k] for k in keys]
     return values, keys

--- a/src/mindtorch_v2/nn/modules/attention.py
+++ b/src/mindtorch_v2/nn/modules/attention.py
@@ -9,7 +9,7 @@ from ...import zeros, empty
 class MultiheadAttention(Module):
     """Multi-head attention module (stub implementation).
 
-    This is a minimal implementation for compatibility with transformers
+    This is a minimal implementation for compatibility with libraries
     that check isinstance(module, nn.MultiheadAttention).
 
     For actual attention computations in transformer models, the models

--- a/src/mindtorch_v2/npu/__init__.py
+++ b/src/mindtorch_v2/npu/__init__.py
@@ -1,0 +1,119 @@
+"""NPU (Ascend) device support module for mindtorch_v2.
+
+Provides torch.npu compatibility for libraries that check for NPU
+availability via torch_npu conventions.
+"""
+
+from ..configs import DEVICE_TARGET, SOC
+
+_npu_available = DEVICE_TARGET == 'Ascend'
+
+
+def is_available() -> bool:
+    """Check if NPU (Ascend) is available."""
+    return _npu_available
+
+
+def device_count() -> int:
+    """Return the number of NPU devices available."""
+    if not _npu_available:
+        return 0
+    # For now, assume 1 device; can be extended to query actual device count
+    return 1
+
+
+def current_device() -> int:
+    """Return the index of the current NPU device."""
+    if not _npu_available:
+        raise RuntimeError("NPU is not available")
+    return 0
+
+
+def get_device_name(device=None) -> str:
+    """Return the name of the NPU device."""
+    if not _npu_available:
+        raise RuntimeError("NPU is not available")
+    return f"Ascend {SOC}" if SOC else "Ascend NPU"
+
+
+def get_device_capability(device=None):
+    """Return device capability (placeholder for compatibility)."""
+    if not _npu_available:
+        raise RuntimeError("NPU is not available")
+    # Return a tuple similar to CUDA capability format
+    return (9, 0)  # Ascend 910
+
+
+def set_device(device):
+    """Set the current NPU device (placeholder for single-device setup)."""
+    if not _npu_available:
+        raise RuntimeError("NPU is not available")
+    # Currently single-device, so this is a no-op
+    pass
+
+
+def synchronize(device=None):
+    """Synchronize the NPU device."""
+    if not _npu_available:
+        raise RuntimeError("NPU is not available")
+    # MindSpore handles synchronization internally
+    pass
+
+
+class device:
+    """Context manager for NPU device."""
+    def __init__(self, device_id):
+        self.device_id = device_id
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+
+# Memory management stubs
+def memory_allocated(device=None) -> int:
+    """Return memory allocated on NPU (placeholder)."""
+    return 0
+
+
+def memory_reserved(device=None) -> int:
+    """Return memory reserved on NPU (placeholder)."""
+    return 0
+
+
+def max_memory_allocated(device=None) -> int:
+    """Return max memory allocated on NPU (placeholder)."""
+    return 0
+
+
+def empty_cache():
+    """Empty NPU cache (placeholder)."""
+    pass
+
+
+def reset_peak_memory_stats(device=None):
+    """Reset peak memory stats (placeholder)."""
+    pass
+
+
+def manual_seed(seed):
+    """Set the random seed for NPU (placeholder)."""
+    import numpy as np
+    np.random.seed(seed)
+
+
+def manual_seed_all(seed):
+    """Set the random seed for all NPU devices (placeholder)."""
+    manual_seed(seed)
+
+
+# Flash attention stubs (some libraries check for these)
+def npu_fusion_attention(*args, **kwargs):
+    """NPU fusion attention (stub - not implemented)."""
+    raise NotImplementedError("npu_fusion_attention is not implemented in mindtorch_v2")
+
+
+# Version info
+__version__ = "2.0.0"

--- a/src/mindtorch_v2/optim/lr_scheduler.py
+++ b/src/mindtorch_v2/optim/lr_scheduler.py
@@ -7,7 +7,7 @@ import math
 class LRScheduler:
     """Base class for learning rate schedulers.
 
-    This is a minimal implementation to allow transformers to inherit from it.
+    This is a minimal implementation following PyTorch's interface.
     """
 
     def __init__(self, optimizer, last_epoch=-1, verbose="deprecated"):


### PR DESCRIPTION
## Summary

- Replace `_is_hf_initialized` with generic `_skip_init` flag for skipping tensor reinitialization when loading from checkpoints
- Update all comments to reference "PyTorch-based libraries" instead of specific libraries like transformers/HuggingFace
- Add design principle to CLAUDE.md: mindtorch must remain a general-purpose PyTorch compatibility layer without library-specific customizations
- Add npu module with generic NPU device compatibility

## Changes

| File | Change |
|------|--------|
| `nn/init.py` | `_is_hf_initialized` → `_skip_init`, add `guard_torch_init_functions` |
| `nn/module.py` | `_is_hf_initialized` → `_skip_init` in `load_state_dict` |
| `_tensor.py` | Preserve `_skip_init` flag in data property |
| `_torch_proxy/*` | Generic comments throughout |
| `npu/__init__.py` | NPU device support module |
| `CLAUDE.md` | Add "No Transformers-Specific Customization" principle |

## Test plan

- [x] Run Albert model tests: 96 passed, 8 failed (same as before, no regression)
- [x] Verified `_skip_init` mechanism works correctly
- [x] All transformers-specific references removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)