### PR TITLE
fix(mindtorch_v2): autograd fixes for contiguous() and parameter loading

### DIFF
--- a/src/mindtorch_v2/_tensor.py
+++ b/src/mindtorch_v2/_tensor.py
@@ -349,6 +349,7 @@ class Tensor:
                     grad_fn._next_functions = ((acc_grad, 0),)
 
                 result._grad_fn = grad_fn
+                result._requires_grad = True  # Propagate requires_grad
 
         return result
 

--- a/src/mindtorch_v2/nn/module.py
+++ b/src/mindtorch_v2/nn/module.py
@@ -442,11 +442,13 @@ class Module:
                         continue
                     if assign:
                         # Update both _parameters and __dict__ to handle tied weights
+                        new_value._skip_init = True  # Mark tensor to skip reinitialization
                         module._parameters[param_name] = new_value
                         if param_name in module.__dict__:
                             module.__dict__[param_name] = new_value
                     else:
                         param.data = new_value
+                        param._skip_init = True  # Mark tensor to skip reinitialization
                     # Mark the module as having loaded weights
                     loaded_modules.add(id(module))
                 elif param_name in module._buffers and module._buffers[param_name] is not None:


### PR DESCRIPTION
## Summary
- Fix requires_grad propagation in `contiguous()` method - the backward node was created but `_requires_grad` was not set on the result tensor
- Set `_skip_init` on loaded parameters in `load_state_dict()` to prevent reinitialization

## Test plan
- [x] `test_retain_grad_hidden_states_attentions` now passes (was failing before)
- [x] ALBERT tests: 97 passed, 7 failed (improved from 96 passed, 8 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)