### PR TITLE
Align device default, streams, and memory fraction

### DIFF
--- a/src/mindtorch_v2/__init__.py
+++ b/src/mindtorch_v2/__init__.py
@@ -1,7 +1,7 @@
 __version__ = "0.1.0"
 
 from ._dtype import DType, float32, float16, int64
-from ._device import device as Device, _default_device
+from ._device import device as Device, _default_device, get_default_device, set_default_device
 from ._tensor import Tensor
 from ._creation import tensor, zeros, ones
 from ._storage import UntypedStorage, TypedStorage
@@ -16,3 +16,28 @@ from . import _C
 
 def pipeline():
     return pipeline_context()
+
+
+__all__ = [
+    "Device",
+    "Tensor",
+    "DType",
+    "float32",
+    "float16",
+    "int64",
+    "tensor",
+    "zeros",
+    "ones",
+    "add",
+    "mul",
+    "matmul",
+    "relu",
+    "sum",
+    "set_printoptions",
+    "get_printoptions",
+    "pipeline",
+    "pipeline_context",
+    "get_default_device",
+    "set_default_device",
+    "npu",
+]

--- a/src/mindtorch_v2/_backends/npu/allocator.py
+++ b/src/mindtorch_v2/_backends/npu/allocator.py
@@ -394,6 +394,9 @@ class NpuAllocator:
         self._maybe_collect_garbage()
         block = self._find_cached(allocated, pool)
         if block is None:
+            from ... import npu
+
+            npu._enforce_memory_fraction(allocated, device=self.device_id)
             try:
                 ptr, _ = self._raw_malloc(allocated)
             except RuntimeError:

--- a/src/mindtorch_v2/_backends/npu/streams.py
+++ b/src/mindtorch_v2/_backends/npu/streams.py
@@ -22,6 +22,12 @@ class Stream:
         runtime = npu_runtime.get_runtime(self.device.index or 0)
         runtime.stream_wait_event(self._stream, event.event)
 
+    def wait_stream(self, stream):
+        event = Event()
+        event.record(stream)
+        self.wait_event(event)
+        self._event = event
+
 
 class Event:
     def __init__(self, enable_timing=False, blocking=False, interprocess=False):

--- a/src/mindtorch_v2/_device.py
+++ b/src/mindtorch_v2/_device.py
@@ -14,8 +14,31 @@ class device:
 
     def __repr__(self):
         if self.index is None:
+            return f"device(type='{self.type}')"
+        return f"device(type='{self.type}', index={self.index})"
+
+    def __str__(self):
+        if self.index is None:
             return f"{self.type}"
         return f"{self.type}:{self.index}"
 
+    def __eq__(self, other):
+        if not isinstance(other, device):
+            return NotImplemented
+        return self.type == other.type and self.index == other.index
+
+    def __hash__(self):
+        return hash((self.type, self.index))
+
 
 _default_device = device("cpu")
+
+
+def get_default_device():
+    return _default_device
+
+
+def set_default_device(dev):
+    global _default_device
+    _default_device = device(dev)
+    return _default_device

--- a/src/mindtorch_v2/_functional.py
+++ b/src/mindtorch_v2/_functional.py
@@ -2,7 +2,7 @@ from ._dispatch.dispatcher import dispatch
 from ._autograd.grad_mode import GradMode, no_grad
 from ._autograd.node import Node
 from ._autograd.utils import reduce_grad
-from ._device import device as Device
+from ._device import device as Device, get_default_device
 from ._dtype import to_numpy_dtype
 
 
@@ -122,7 +122,7 @@ def to(a, device):
 
 def _as_device(dev):
     if dev is None:
-        return Device("cpu")
+        return get_default_device()
     if isinstance(dev, str):
         return Device(dev)
     return dev

--- a/src/mindtorch_v2/_printing.py
+++ b/src/mindtorch_v2/_printing.py
@@ -77,7 +77,7 @@ def format_tensor(tensor):
     if tensor.device.type != _default_device.type:
         device_label = tensor.device.type
         if tensor.device.type == "npu":
-            device_label = repr(tensor.device)
+            device_label = str(tensor.device)
         suffixes.append(f"device='{device_label}'")
     if tensor.requires_grad:
         suffixes.append("requires_grad=True")

--- a/src/mindtorch_v2/npu.py
+++ b/src/mindtorch_v2/npu.py
@@ -25,6 +25,7 @@ __all__ = [
     "default_stream",
     "current_stream",
     "stream",
+    "set_stream",
     "stream_priority_range",
     "empty_cache",
     "reset_accumulated_memory_stats",
@@ -40,6 +41,7 @@ __all__ = [
     "set_per_process_memory_fraction",
     "get_device_name",
     "get_device_capability",
+    "get_device_properties",
     "can_device_access_peer",
     "enable_peer_access",
     "disable_peer_access",
@@ -110,6 +112,10 @@ def default_stream(device=None):
 def current_stream(device=None):
     dev = _normalize_npu_device(device)
     return npu_state.current_stream(dev.index or 0)
+
+
+def set_stream(stream):
+    npu_state.set_current_stream(stream)
 
 
 class stream:
@@ -224,6 +230,25 @@ def get_device_name(device=None):
 def get_device_capability(device=None):
     dev = _normalize_npu_device(device)
     return _get_device_capability(dev.index or 0)
+
+
+class _DeviceProperties:
+    def __init__(self, name, major, minor):
+        self.name = name
+        self.major = int(major)
+        self.minor = int(minor)
+
+    def __repr__(self):
+        return (
+            f"DeviceProperties(name='{self.name}', "
+            f"major={self.major}, minor={self.minor})"
+        )
+
+
+def get_device_properties(device=None):
+    name = get_device_name(device)
+    major, minor = get_device_capability(device)
+    return _DeviceProperties(name=name, major=major, minor=minor)
 
 
 def can_device_access_peer(device, peer_device):

--- a/tests/mindtorch_v2/test_device_index.py
+++ b/tests/mindtorch_v2/test_device_index.py
@@ -5,25 +5,25 @@ def test_device_parsing_and_repr():
     dev = torch.Device("npu:1")
     assert dev.type == "npu"
     assert dev.index == 1
-    assert repr(dev) == "npu:1"
+    assert repr(dev) == "device(type='npu', index=1)"
 
     dev = torch.Device("cpu")
     assert dev.type == "cpu"
     assert dev.index is None
-    assert repr(dev) == "cpu"
+    assert repr(dev) == "device(type='cpu')"
 
     dev = torch.Device("meta:1")
     assert dev.type == "meta"
     assert dev.index == 1
-    assert repr(dev) == "meta:1"
+    assert repr(dev) == "device(type='meta', index=1)"
 
     dev = torch.Device("cpu", 1)
     assert dev.type == "cpu"
     assert dev.index == 1
-    assert repr(dev) == "cpu:1"
+    assert repr(dev) == "device(type='cpu', index=1)"
 
 
 def test_device_npu_default_index_zero():
     dev = torch.Device("npu")
     assert dev.index == 0
-    assert repr(dev) == "npu:0"
+    assert repr(dev) == "device(type='npu', index=0)"

--- a/tests/mindtorch_v2/test_dtype_device.py
+++ b/tests/mindtorch_v2/test_dtype_device.py
@@ -5,3 +5,26 @@ def test_default_dtype_and_device():
     x = torch.tensor([1, 2, 3])
     assert x.dtype == torch.float32
     assert x.device.type == "cpu"
+
+
+def test_default_device_set_get_affects_creation():
+    prev = torch.get_default_device()
+    try:
+        torch.set_default_device("meta")
+        assert str(torch.get_default_device()) == "meta"
+        x = torch.zeros((2, 2))
+        assert x.device.type == "meta"
+    finally:
+        torch.set_default_device(prev)
+
+
+def test_device_str_repr_eq_hash():
+    d1 = torch.Device("npu:0")
+    d2 = torch.Device("npu", 0)
+    d3 = torch.Device("npu", 1)
+
+    assert str(d1) == "npu:0"
+    assert repr(d1) == "device(type='npu', index=0)"
+    assert d1 == d2
+    assert d1 != d3
+    assert hash(d1) == hash(d2)

--- a/tests/mindtorch_v2/test_npu_device_api.py
+++ b/tests/mindtorch_v2/test_npu_device_api.py
@@ -18,6 +18,13 @@ def test_peer_access_unsupported():
         torch.npu.enable_peer_access(1)
 
 
+def test_get_device_properties_schema():
+    props = torch.npu.get_device_properties(0)
+    assert props.name
+    assert hasattr(props, "major")
+    assert hasattr(props, "minor")
+
+
 def test_stream_priority_range_fallback():
     assert torch.npu.stream_priority_range() == (0, 0)
 

--- a/tests/mindtorch_v2/test_npu_streams.py
+++ b/tests/mindtorch_v2/test_npu_streams.py
@@ -198,3 +198,18 @@ def test_npu_stream_wait_event(monkeypatch):
     evt = torch.npu.Event()
     s.wait_event(evt)
     assert runtime.wait_calls == [(s.stream, evt.event)]
+
+
+def test_npu_set_stream_changes_current(monkeypatch):
+    _stub_runtime(monkeypatch)
+    s = torch.npu.Stream()
+    torch.npu.set_stream(s)
+    assert torch.npu.current_stream() is s
+
+
+def test_npu_stream_wait_stream(monkeypatch):
+    runtime = _stub_runtime(monkeypatch)
+    s0 = torch.npu.Stream()
+    s1 = torch.npu.Stream()
+    s0.wait_stream(s1)
+    assert runtime.wait_calls == [(s0.stream, s0._event.event)]


### PR DESCRIPTION
## Summary
- add torch-style default device API and Device repr/eq/hash
- add NPU stream controls (set_stream, wait_stream) and get_device_properties
- enforce per-process memory fraction in allocator with updated tests

## Test Plan
- [x] pytest -q tests/mindtorch_v2