### PR TITLE
Derive NPU device properties from SoC

### DIFF
--- a/src/mindtorch_v2/npu.py
+++ b/src/mindtorch_v2/npu.py
@@ -249,39 +249,49 @@ def set_per_process_memory_fraction(fraction, device=None):
     _MEMORY_FRACTION = float(fraction)
 
 
-def _get_device_name(device=None):
+_SOC_NAME = None
+
+
+def _get_soc_name():
+    global _SOC_NAME
+    if _SOC_NAME:
+        return _SOC_NAME
+    from ._backends.npu.acl_loader import ensure_acl
     try:
-        import mindspore
+        acl = ensure_acl()
+        soc = acl.get_soc_name()
+    except Exception as exc:
+        raise RuntimeError(f"Failed to query NPU SoC name: {exc}") from exc
+    if isinstance(soc, (bytes, bytearray)):
+        soc = soc.decode()
+    if not soc:
+        raise RuntimeError("Failed to query NPU SoC name")
+    _SOC_NAME = str(soc)
+    return _SOC_NAME
 
-        if mindspore.get_context("device_target") != "Ascend":
-            return "Ascend"
-        from mindspore._c_expression import MSContext
 
-        soc = MSContext.get_instance().get_ascend_soc_version()
-        if soc:
-            return f"Ascend {soc}"
-    except Exception:
-        pass
-    return "Ascend"
+def _get_device_name(device=None):
+    soc = _get_soc_name()
+    if soc.lower().startswith("ascend"):
+        return soc
+    return f"Ascend {soc}"
 
 
 def _get_device_capability(device=None):
-    try:
-        from mindspore._c_expression import MSContext
-
-        soc = MSContext.get_instance().get_ascend_soc_version() or ""
-    except Exception:
-        soc = ""
-    soc = soc.lower()
+    soc = _get_soc_name().lower()
     if "910b" in soc:
         return (9, 1)
+    if "910a" in soc:
+        return (9, 0)
     if "910" in soc:
         return (9, 0)
     if "310p" in soc:
         return (3, 1)
     if "310" in soc:
         return (3, 0)
-    return (0, 0)
+    raise RuntimeError(f"Unknown Ascend SoC: {soc}")
+
+
 
 
 def get_device_name(device=None):
@@ -311,7 +321,6 @@ def get_device_properties(device=None):
     name = get_device_name(device)
     major, minor = get_device_capability(device)
     return _DeviceProperties(name=name, major=major, minor=minor)
-
 
 def can_device_access_peer(device, peer_device):
     return False

--- a/tests/mindtorch_v2/test_npu_device_api.py
+++ b/tests/mindtorch_v2/test_npu_device_api.py
@@ -3,36 +3,12 @@ import mindtorch_v2 as torch
 
 
 def test_get_device_name_from_soc(monkeypatch):
-    import mindspore
-
-    class DummyMSContext:
-        @staticmethod
-        def get_instance():
-            return DummyMSContext()
-
-        def get_ascend_soc_version(self):
-            return "ascend910b"
-
-    monkeypatch.setattr(mindspore, "get_context", lambda key=None: "Ascend")
-    monkeypatch.setattr(mindspore._c_expression, "MSContext", DummyMSContext, raising=False)
-
-    assert torch.npu.get_device_name("npu:0") == "Ascend ascend910b"
+    monkeypatch.setattr(torch.npu, "_get_soc_name", lambda: "Ascend910B")
+    assert torch.npu.get_device_name("npu:0") == "Ascend910B"
 
 
 def test_get_device_capability_from_soc(monkeypatch):
-    import mindspore
-
-    class DummyMSContext:
-        @staticmethod
-        def get_instance():
-            return DummyMSContext()
-
-        def get_ascend_soc_version(self):
-            return "ascend910b"
-
-    monkeypatch.setattr(mindspore, "get_context", lambda key=None: "Ascend")
-    monkeypatch.setattr(mindspore._c_expression, "MSContext", DummyMSContext, raising=False)
-
+    monkeypatch.setattr(torch.npu, "_get_soc_name", lambda: "Ascend910B")
     assert torch.npu.get_device_capability("npu:0") == (9, 1)
 
 


### PR DESCRIPTION
## Summary
- derive NPU device name from Ascend SoC version
- map SoC to capability tuple for torch-aligned device queries
- update tests for SoC-derived device info

## Test Plan
- [x] pytest -q tests/mindtorch_v2