### PR TITLE
Autograd dispatch wrappers and redispatch

### DIFF
--- a/src/mindtorch_v2/_backends/__init__.py
+++ b/src/mindtorch_v2/_backends/__init__.py
@@ -1,5 +1,6 @@
 from . import cpu
 from . import meta
 from . import npu
+from . import autograd
 
-__all__ = ["cpu", "meta", "npu"]
+__all__ = ["cpu", "meta", "npu", "autograd"]

--- a/src/mindtorch_v2/_dispatch/dispatcher.py
+++ b/src/mindtorch_v2/_dispatch/dispatcher.py
@@ -3,7 +3,44 @@ import inspect
 from .registry import registry
 from .pipeline import current_pipeline
 from .keys import DispatchKey, DispatchKeySet
+import threading
+
 from .._autograd.grad_mode import is_grad_enabled
+
+
+_DISPATCH_STATE = threading.local()
+
+
+def _state_stack():
+    stack = getattr(_DISPATCH_STATE, "stack", None)
+    if stack is None:
+        stack = []
+        _DISPATCH_STATE.stack = stack
+    return stack
+
+
+def current_dispatch_keyset():
+    stack = _state_stack()
+    if not stack:
+        return None
+    return stack[-1][0]
+
+
+def current_dispatch_key():
+    stack = _state_stack()
+    if not stack:
+        return None
+    return stack[-1][1]
+
+
+def _push_dispatch_context(keyset, key):
+    _state_stack().append((keyset, key))
+
+
+def _pop_dispatch_context():
+    stack = _state_stack()
+    if stack:
+        stack.pop()
 
 
 def _accepts_device(func):
@@ -35,18 +72,33 @@ def _prepare_kwargs(func, kwargs, device):
 
 
 class _PendingOp:
-    def __init__(self, impl, args, kwargs, out):
+    def __init__(self, impl, args, kwargs, out, keyset, key):
         self.impl = impl
         self.args = args
         self.kwargs = kwargs
         self.out = out
+        self.keyset = keyset
+        self.key = key
 
     def execute(self):
-        result = self.impl(*self.args, **self.kwargs)
+        prev_requires_grad = self.out.requires_grad
+        _push_dispatch_context(self.keyset, self.key)
+        try:
+            result = self.impl(*self.args, **self.kwargs)
+        finally:
+            _pop_dispatch_context()
         self.out._storage = result.storage()
         self.out.shape = result.shape
         self.out.stride = result.stride
         self.out.offset = result.offset
+        self.out.requires_grad = prev_requires_grad or result.requires_grad
+        if result.grad_fn is not None:
+            self.out.grad_fn = result.grad_fn
+        elif not self.out.requires_grad:
+            self.out.grad_fn = None
+        self.out._base = result._base
+        self.out._view_meta = result._view_meta
+        self.out._version_counter = result._version_counter
         self.out._pending = False
 
 
@@ -87,6 +139,57 @@ def _extract_tensors(args, kwargs):
     return tensors
 
 
+def _infer_dispatch_device(dispatch_device, tensors, keyset):
+    if dispatch_device is not None:
+        return dispatch_device
+    for tensor in tensors:
+        if hasattr(tensor, "device"):
+            return tensor.device
+    if DispatchKey.Meta in keyset:
+        return "meta"
+    if DispatchKey.NPU in keyset:
+        return "npu"
+    return "cpu"
+
+
+def dispatch_with_keyset(name, keyset, dispatch_device, *args, **kwargs):
+    tensors = _extract_tensors(args, kwargs)
+    pipe = current_pipeline()
+    dispatch_device = _infer_dispatch_device(dispatch_device, tensors, keyset)
+    entry = registry.get(name)
+
+    def _run_kernel():
+        kernel, key = _kernel_for_entry(entry, _key_order(keyset))
+        if kernel is None:
+            raise RuntimeError(
+                f"could not find kernel for op {name} with keys {sorted(k.name for k in keyset)}"
+            )
+        impl_kwargs = _prepare_kwargs(kernel, kwargs, dispatch_device)
+        _push_dispatch_context(keyset, key)
+        try:
+            return kernel(*args, **impl_kwargs)
+        finally:
+            _pop_dispatch_context()
+    if pipe is not None and DispatchKey.Pipeline in keyset:
+        meta = entry.kernels.get(DispatchKey.Meta)
+        if meta is None:
+            raise RuntimeError(f"pipeline requires meta kernel for op {name}")
+        meta_kwargs = _prepare_kwargs(meta, kwargs, dispatch_device)
+        spec = meta(*args, **meta_kwargs)
+        out = _pending_tensor_from_spec(spec, dispatch_device)
+        out._pending = True
+        backend_keys = [key for key in _key_order(keyset) if key != DispatchKey.Pipeline]
+        impl, impl_key = _kernel_for_entry(entry, backend_keys)
+        if impl is None:
+            raise RuntimeError(f"pipeline requires backend kernel for op {name}")
+        impl_kwargs = _prepare_kwargs(impl, kwargs, dispatch_device)
+        pipe.record(_PendingOp(impl, args, impl_kwargs, out, keyset.without(DispatchKey.Pipeline), impl_key), pending=out)
+        return out
+    if pipe is not None and DispatchKey.Pipeline in keyset:
+        pipe.flush()
+    return _run_kernel()
+
+
 def dispatch(name, dispatch_device, *args, **kwargs):
     tensors = _extract_tensors(args, kwargs)
     pipe = current_pipeline()
@@ -96,30 +199,8 @@ def dispatch(name, dispatch_device, *args, **kwargs):
         pipeline_enabled=pipe is not None,
         device=dispatch_device,
     )
-    entry = registry.get(name)
-    def _run_kernel():
-        kernel, _ = _kernel_for_entry(entry, _key_order(keyset))
-        if kernel is None:
-            raise RuntimeError(
-                f"could not find kernel for op {name} with keys {sorted(k.name for k in keyset)}"
-            )
-        impl_kwargs = _prepare_kwargs(kernel, kwargs, dispatch_device)
-        return kernel(*args, **impl_kwargs)
-    if pipe is not None and DispatchKey.Pipeline in keyset:
-        meta = entry.kernels.get(DispatchKey.Meta)
-        if meta is None:
-            raise RuntimeError(f"pipeline requires meta kernel for op {name}")
-        meta_kwargs = _prepare_kwargs(meta, kwargs, dispatch_device)
-        spec = meta(*args, **meta_kwargs)
-        out = _pending_tensor_from_spec(spec, dispatch_device)
-        out._pending = True
-        backend_keys = [key for key in (DispatchKey.NPU, DispatchKey.CPU) if key in keyset]
-        impl, _ = _kernel_for_entry(entry, backend_keys)
-        if impl is None:
-            raise RuntimeError(f"pipeline requires backend kernel for op {name}")
-        impl_kwargs = _prepare_kwargs(impl, kwargs, dispatch_device)
-        pipe.record(_PendingOp(impl, args, impl_kwargs, out))
-        return out
-    if pipe is not None:
-        pipe.flush()
-    return _run_kernel()
+    return dispatch_with_keyset(name, keyset, dispatch_device, *args, **kwargs)
+
+
+def redispatch(name, keyset, *args, **kwargs):
+    return dispatch_with_keyset(name, keyset, None, *args, **kwargs)

--- a/src/mindtorch_v2/_dispatch/keys.py
+++ b/src/mindtorch_v2/_dispatch/keys.py
@@ -10,6 +10,11 @@ class DispatchKey(Enum):
 
 
 class DispatchKeySet(set):
+    def without(self, keys):
+        if isinstance(keys, (set, list, tuple)):
+            return DispatchKeySet({key for key in self if key not in keys})
+        return DispatchKeySet({key for key in self if key != keys})
+
     @classmethod
     def from_tensors(cls, tensors, *, grad_enabled=False, pipeline_enabled=False, device=None):
         keys = cls()

--- a/src/mindtorch_v2/_dispatch/pipeline.py
+++ b/src/mindtorch_v2/_dispatch/pipeline.py
@@ -7,14 +7,20 @@ _CURRENT = None
 class Pipeline:
     def __init__(self):
         self.queue = []
+        self.outputs = {}
 
-    def record(self, entry):
+    def record(self, entry, *, pending=None):
         self.queue.append(entry)
+        if pending is not None:
+            self.outputs[id(pending)] = pending
+            entry.out = pending
 
     def flush(self):
-        for entry in self.queue:
-            entry.execute()
+        pending = list(self.queue)
         self.queue.clear()
+        for entry in pending:
+            entry.execute()
+        self.outputs.clear()
 
 
 @contextlib.contextmanager

--- a/src/mindtorch_v2/_functional.py
+++ b/src/mindtorch_v2/_functional.py
@@ -1,98 +1,31 @@
 from ._dispatch.dispatcher import dispatch
 from ._autograd.grad_mode import GradMode, no_grad
-from ._autograd.node import Node
-from ._autograd.utils import reduce_grad
 from ._device import device as Device, get_default_device
 from ._dtype import to_numpy_dtype
 
 
 def add(a, b):
-    out = dispatch("add", a.device.type, a, b)
-    if GradMode.enabled and (a.requires_grad or b.requires_grad):
-        def _backward(grad):
-            grad_a = reduce_grad(grad, a.shape) if a.requires_grad else None
-            grad_b = reduce_grad(grad, b.shape) if b.requires_grad else None
-            return grad_a, grad_b
-        node = Node(_backward, (a, b))
-        node.save_for_backward(a, b)
-        out.grad_fn = node
-        out.requires_grad = True
-    return out
+    return dispatch("add", a.device.type, a, b)
 
 
 def mul(a, b):
-    out = dispatch("mul", a.device.type, a, b)
-    if GradMode.enabled and (a.requires_grad or b.requires_grad):
-        def _backward(grad):
-            saved_a, saved_b = out.grad_fn.saved_tensors()
-            with no_grad():
-                grad_a = dispatch("mul", saved_a.device.type, grad, saved_b) if saved_a.requires_grad else None
-                grad_b = dispatch("mul", saved_b.device.type, grad, saved_a) if saved_b.requires_grad else None
-            grad_a = reduce_grad(grad_a, saved_a.shape) if grad_a is not None else None
-            grad_b = reduce_grad(grad_b, saved_b.shape) if grad_b is not None else None
-            return grad_a, grad_b
-        node = Node(_backward, (a, b))
-        node.save_for_backward(a, b)
-        out.grad_fn = node
-        out.requires_grad = True
-    return out
+    return dispatch("mul", a.device.type, a, b)
 
 
 def matmul(a, b):
-    out = dispatch("matmul", a.device.type, a, b)
-    if GradMode.enabled and (a.requires_grad or b.requires_grad):
-        def _backward(grad):
-            saved_a, saved_b = out.grad_fn.saved_tensors()
-            with no_grad():
-                grad_a = dispatch("matmul", saved_a.device.type, grad, saved_b.transpose(0, 1)) if saved_a.requires_grad else None
-                grad_b = dispatch("matmul", saved_a.device.type, saved_a.transpose(0, 1), grad) if saved_b.requires_grad else None
-            return grad_a, grad_b
-        node = Node(_backward, (a, b))
-        node.save_for_backward(a, b)
-        out.grad_fn = node
-        out.requires_grad = True
-    return out
+    return dispatch("matmul", a.device.type, a, b)
 
 
 def relu(a):
-    out = dispatch("relu", a.device.type, a)
-    if GradMode.enabled and a.requires_grad and a.device.type == "cpu":
-        def _backward(grad):
-            (saved_a,) = out.grad_fn.saved_tensors()
-            with no_grad():
-                mask = saved_a._ones_like()
-                mask.storage()._data = (saved_a.storage().data > 0).astype(to_numpy_dtype(saved_a.dtype))
-                return (dispatch("mul", saved_a.device.type, grad, mask),)
-        node = Node(_backward, (a,))
-        node.save_for_backward(a)
-        out.grad_fn = node
-        out.requires_grad = True
-    return out
+    return dispatch("relu", a.device.type, a)
 
 
 def sum(a, dim=None, keepdim=False):
-    out = dispatch("sum", a.device.type, a, dim=dim, keepdim=keepdim)
-    if GradMode.enabled and a.requires_grad:
-        def _backward(grad):
-            (saved_a,) = out.grad_fn.saved_tensors()
-            with no_grad():
-                ones = saved_a._ones_like()
-                return (dispatch("mul", saved_a.device.type, grad, ones),)
-        node = Node(_backward, (a,))
-        node.save_for_backward(a)
-        out.grad_fn = node
-        out.requires_grad = True
-    return out
+    return dispatch("sum", a.device.type, a, dim=dim, keepdim=keepdim)
 
 
 def reshape(a, shape):
-    out = dispatch("reshape", a.device.type, a, shape)
-    if GradMode.enabled and a.requires_grad:
-        def _backward(grad):
-            return (dispatch("reshape", grad.device.type, grad, a.shape),)
-        out.grad_fn = Node(_backward, (a,))
-        out.requires_grad = True
-    return out
+    return dispatch("reshape", a.device.type, a, shape)
 
 
 def view(a, shape):
@@ -100,13 +33,7 @@ def view(a, shape):
 
 
 def transpose(a, dim0, dim1):
-    out = dispatch("transpose", a.device.type, a, dim0, dim1)
-    if GradMode.enabled and a.requires_grad:
-        def _backward(grad):
-            return (dispatch("transpose", grad.device.type, grad, dim0, dim1),)
-        out.grad_fn = Node(_backward, (a,))
-        out.requires_grad = True
-    return out
+    return dispatch("transpose", a.device.type, a, dim0, dim1)
 
 
 def tensor(data, dtype=None, device=None):

--- a/tests/mindtorch_v2/test_dispatch_autograd_wrappers.py
+++ b/tests/mindtorch_v2/test_dispatch_autograd_wrappers.py
@@ -1,0 +1,64 @@
+import mindtorch_v2 as torch
+from mindtorch_v2._dispatch.dispatcher import dispatch
+
+
+def test_autograd_dispatch_add_sets_grad_fn():
+    x = torch.tensor([1.0, 2.0])
+    y = torch.tensor([3.0, 4.0])
+    x.requires_grad = True
+    y.requires_grad = True
+    out = dispatch("add", x.device.type, x, y)
+    assert out.requires_grad is True
+    assert out.grad_fn is not None
+
+
+def test_autograd_dispatch_mul_sets_grad_fn():
+    x = torch.tensor([1.0, 2.0])
+    y = torch.tensor([3.0, 4.0])
+    x.requires_grad = True
+    y.requires_grad = True
+    out = dispatch("mul", x.device.type, x, y)
+    assert out.requires_grad is True
+    assert out.grad_fn is not None
+
+
+def test_autograd_dispatch_matmul_sets_grad_fn():
+    x = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    y = torch.tensor([[1.0], [2.0]])
+    x.requires_grad = True
+    y.requires_grad = True
+    out = dispatch("matmul", x.device.type, x, y)
+    assert out.requires_grad is True
+    assert out.grad_fn is not None
+
+
+def test_autograd_dispatch_sum_sets_grad_fn():
+    x = torch.tensor([1.0, 2.0])
+    x.requires_grad = True
+    out = dispatch("sum", x.device.type, x)
+    assert out.requires_grad is True
+    assert out.grad_fn is not None
+
+
+def test_autograd_dispatch_relu_sets_grad_fn_cpu():
+    x = torch.tensor([1.0, -2.0])
+    x.requires_grad = True
+    out = dispatch("relu", x.device.type, x)
+    assert out.requires_grad is True
+    assert out.grad_fn is not None
+
+
+def test_autograd_dispatch_reshape_sets_grad_fn():
+    x = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    x.requires_grad = True
+    out = dispatch("reshape", x.device.type, x, (4,))
+    assert out.requires_grad is True
+    assert out.grad_fn is not None
+
+
+def test_autograd_dispatch_transpose_sets_grad_fn():
+    x = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    x.requires_grad = True
+    out = dispatch("transpose", x.device.type, x, 0, 1)
+    assert out.requires_grad is True
+    assert out.grad_fn is not None

--- a/tests/mindtorch_v2/test_dispatch_keys.py
+++ b/tests/mindtorch_v2/test_dispatch_keys.py
@@ -32,3 +32,10 @@ def test_keyset_includes_pipeline_when_enabled():
     a = torch.ones((2,))
     keyset = DispatchKeySet.from_tensors((a,), grad_enabled=False, pipeline_enabled=True)
     assert DispatchKey.Pipeline in keyset
+
+
+def test_dispatch_keyset_without_removes_keys():
+    keyset = DispatchKeySet({DispatchKey.CPU, DispatchKey.Autograd})
+    trimmed = keyset.without(DispatchKey.Autograd)
+    assert DispatchKey.CPU in trimmed
+    assert DispatchKey.Autograd not in trimmed

--- a/tests/mindtorch_v2/test_dispatch_redispatch.py
+++ b/tests/mindtorch_v2/test_dispatch_redispatch.py
@@ -1,0 +1,17 @@
+from mindtorch_v2._dispatch.dispatcher import dispatch, redispatch, current_dispatch_keyset
+from mindtorch_v2._dispatch.keys import DispatchKey
+from mindtorch_v2._dispatch.registry import registry
+
+
+def test_redispatch_drops_autograd_key():
+    def cpu_impl(a):
+        return f"cpu:{a}"
+
+    def autograd_impl(a):
+        keyset = current_dispatch_keyset().without(DispatchKey.Autograd)
+        return redispatch("test_redispatch", keyset, a)
+
+    registry.register_kernel("test_redispatch", DispatchKey.CPU, cpu_impl)
+    registry.register_kernel("test_redispatch", DispatchKey.Autograd, autograd_impl)
+    out = dispatch("test_redispatch", "cpu", "x")
+    assert out == "cpu:x"


### PR DESCRIPTION
## Summary
- add dispatcher redispatch/keyset support and pipeline-safe pending execution
- register Autograd kernels for core ops (add/mul/matmul/sum/relu/reshape/transpose)
- remove manual grad_fn wiring from functional ops; add dispatch tests

## Test Plan
- [x] pytest -q tests/mindtorch_v2
