### PR TITLE
Autograd wrappers for inplace and view ops

### DIFF
--- a/tests/mindtorch_v2/test_dispatch_autograd_wrappers.py
+++ b/tests/mindtorch_v2/test_dispatch_autograd_wrappers.py
@@ -62,3 +62,43 @@ def test_autograd_dispatch_transpose_sets_grad_fn():
     out = dispatch("transpose", x.device.type, x, 0, 1)
     assert out.requires_grad is True
     assert out.grad_fn is not None
+
+
+def test_autograd_dispatch_view_sets_grad_fn():
+    x = torch.tensor([1.0, 2.0, 3.0, 4.0])
+    x.requires_grad = True
+    out = dispatch("view", x.device.type, x, (2, 2))
+    assert out.requires_grad is True
+    assert out.grad_fn is not None
+
+
+def test_autograd_dispatch_add_inplace_sets_grad_fn():
+    x = torch.tensor([1.0, 2.0])
+    x.requires_grad = True
+    out = dispatch("add_", x.device.type, x, torch.tensor([1.0, 1.0]))
+    assert out.requires_grad is True
+    assert out.grad_fn is not None
+
+
+def test_autograd_dispatch_mul_inplace_sets_grad_fn():
+    x = torch.tensor([1.0, 2.0])
+    x.requires_grad = True
+    out = dispatch("mul_", x.device.type, x, torch.tensor([2.0, 3.0]))
+    assert out.requires_grad is True
+    assert out.grad_fn is not None
+
+
+def test_autograd_dispatch_relu_inplace_sets_grad_fn():
+    x = torch.tensor([1.0, -2.0])
+    x.requires_grad = True
+    out = dispatch("relu_", x.device.type, x)
+    assert out.requires_grad is True
+    assert out.grad_fn is not None
+
+
+def test_autograd_dispatch_zero_inplace_sets_grad_fn():
+    x = torch.tensor([1.0, -2.0])
+    x.requires_grad = True
+    out = dispatch("zero_", x.device.type, x)
+    assert out.requires_grad is True
+    assert out.grad_fn is not None


### PR DESCRIPTION
## Summary
- add Autograd kernels for view and inplace ops (add_/mul_/relu_/zero_)
- extend dispatch autograd wrapper tests

## Test Plan
- [x] pytest -q tests/mindtorch_v2
