### PR TITLE
Add saved tensor hooks API

### DIFF
--- a/src/mindtorch_v2/_autograd/__init__.py
+++ b/src/mindtorch_v2/_autograd/__init__.py
@@ -1,3 +1,4 @@
 from .engine import grad
+from . import graph
 
-__all__ = ["grad"]
+__all__ = ["grad", "graph"]

--- a/src/mindtorch_v2/_autograd/graph.py
+++ b/src/mindtorch_v2/_autograd/graph.py
@@ -1,0 +1,32 @@
+import contextlib
+import threading
+
+
+_STATE = threading.local()
+
+
+def _stack():
+    stack = getattr(_STATE, "hooks", None)
+    if stack is None:
+        stack = []
+        _STATE.hooks = stack
+    return stack
+
+
+def current_saved_tensors_hooks():
+    stack = _stack()
+    if not stack:
+        return None
+    return stack[-1]
+
+
+@contextlib.contextmanager
+def saved_tensors_hooks(pack_hook, unpack_hook):
+    if not callable(pack_hook) or not callable(unpack_hook):
+        raise TypeError("saved_tensors_hooks expects callable pack and unpack")
+    stack = _stack()
+    stack.append((pack_hook, unpack_hook))
+    try:
+        yield
+    finally:
+        stack.pop()

--- a/src/mindtorch_v2/_autograd/node.py
+++ b/src/mindtorch_v2/_autograd/node.py
@@ -1,14 +1,27 @@
+from .graph import current_saved_tensors_hooks
+
+
 class SavedTensor:
     def __init__(self, tensor):
-        self.tensor = tensor
+        self._tensor_ref = tensor
         self._saved_version = tensor._version_counter.value
+        hooks = current_saved_tensors_hooks()
+        self._hooks = hooks
+        if hooks is None:
+            self._packed = None
+        else:
+            pack, _ = hooks
+            self._packed = pack(tensor)
 
     def materialize(self):
-        if self.tensor._version_counter.value != self._saved_version:
+        if self._tensor_ref._version_counter.value != self._saved_version:
             raise RuntimeError(
                 "one of the variables needed for gradient computation has been modified by an inplace operation"
             )
-        return self.tensor
+        if self._hooks is None:
+            return self._tensor_ref
+        _, unpack = self._hooks
+        return unpack(self._packed)
 
 
 class Node:

--- a/tests/mindtorch_v2/test_saved_tensor_hooks.py
+++ b/tests/mindtorch_v2/test_saved_tensor_hooks.py
@@ -1,0 +1,51 @@
+import pytest
+import mindtorch_v2 as torch
+
+
+def test_saved_tensor_hooks_basic_roundtrip():
+    packed = []
+
+    def pack(tensor):
+        packed.append(tensor)
+        return tensor.numpy().copy()
+
+    def unpack(data):
+        return torch.tensor(data)
+
+    x = torch.tensor([1.0, 2.0])
+    x.requires_grad = True
+    with torch.autograd.graph.saved_tensors_hooks(pack, unpack):
+        y = torch.mul(x, x)
+        y.sum().backward()
+    assert len(packed) >= 1
+    assert x.grad is not None
+
+
+def test_saved_tensor_hooks_disallow_no_grad():
+    def pack(tensor):
+        return tensor
+
+    def unpack(tensor):
+        return tensor
+
+    x = torch.tensor([1.0, 2.0])
+    x.requires_grad = True
+    with torch.autograd.graph.saved_tensors_hooks(pack, unpack):
+        y = torch.mul(x, x)
+        y.sum().backward()
+    assert x.grad is not None
+
+
+def test_saved_tensor_hooks_pack_raises():
+    def pack(_tensor):
+        raise RuntimeError("pack failed")
+
+    def unpack(tensor):
+        return tensor
+
+    x = torch.tensor([1.0, 2.0])
+    x.requires_grad = True
+    with torch.autograd.graph.saved_tensors_hooks(pack, unpack):
+        with pytest.raises(RuntimeError):
+            y = torch.mul(x, x)
+            y.sum().backward()


### PR DESCRIPTION
## Summary
- add torch.autograd.graph.saved_tensors_hooks API
- integrate saved tensor hooks into autograd SavedTensor
- update autograd kernels to use saved tensors for backward
- add unit tests for hooks

## Test Plan
- [x] pytest -q tests/mindtorch_v2
