### PR TITLE
Align NPU stream and event APIs with torch.cuda

### DIFF
--- a/src/mindtorch_v2/_backends/npu/streams.py
+++ b/src/mindtorch_v2/_backends/npu/streams.py
@@ -28,6 +28,12 @@ class Stream:
         self.wait_event(event)
         self._event = event
 
+    def record_event(self, event=None):
+        if event is None:
+            event = Event()
+        event.record(self)
+        return event
+
 
 class Event:
     def __init__(self, enable_timing=False, blocking=False, interprocess=False):
@@ -56,6 +62,13 @@ class Event:
             stream = npu_state.current_stream()
         runtime = npu_runtime.get_runtime(stream.device.index or 0)
         runtime.record_event(self._event, stream.stream)
+
+    def wait(self, stream=None):
+        if stream is None:
+            from . import state as npu_state
+
+            stream = npu_state.current_stream()
+        stream.wait_event(self)
 
     def synchronize(self):
         runtime = npu_runtime.get_runtime(self.device.index or 0)


### PR DESCRIPTION
## Summary
- add Stream.record_event and Event.wait helpers
- wire event-based non_blocking NPU->CPU copies
- extend stream/event tests and non_blocking copy coverage

## Test Plan
- [x] pytest -q tests/mindtorch_v2
