### PR TITLE
docs: refactor CLAUDE.md - move session logs to .claude/logs/

### DIFF
--- a/.claude/logs/session-history.md
+++ b/.claude/logs/session-history.md
@@ -1,0 +1,82 @@
+# MindNLP Session History
+
+Historical session logs moved from CLAUDE.md to reduce context size.
+
+---
+
+## mindtorch v1 Sessions (2025-01)
+
+### Session: 2025-01-15 - BERT Model Test Fix
+
+**Test Case**: `tests/transformers/tests/models/bert/test_modeling_bert.py::BertModelTest::test_model`
+
+**Bugs Fixed**:
+
+| # | Error Type | File Modified | Fix Description |
+|---|------------|---------------|-----------------|
+| 1 | TypeError (broadcast_to scalar) | `src/mindtorch/_apis/cpu.py:104` | Convert scalar to tensor before broadcast |
+| 2 | RuntimeError (device mismatch) | `src/mindtorch/_op_prim/gpu/legacy.py` | Removed `gather__call__` setattr override |
+| 3 | TypeError (reduce_any axis=None) | `src/mindtorch/_apis/cpu.py:218` | Handle None axis by converting to all dims |
+
+**Result**: PASSED (1 passed, 2 warnings in 4.08s)
+
+### Session: 2025-01-17 - Transformer Models 'A' Testing & Fixes
+
+**Test Scope**: All transformer models starting with 'a'
+
+**Bugs Fixed in cpu.py**: 8 fixes (isinstance slice, Bucketize boundaries, init attribute, TensorScatterUpdate dtype, avg_pool1d padding/kernel_size, conv1d args, Concat dtype)
+
+**Results**: 648 tests passing, 146 failing across 11 models (aimv2, albert, align, altclip, apertus, arcee, aria, audio_spectrogram_transformer, auto, autoformer, aya_vision)
+
+**PR Created**: #2392
+
+### Session: 2025-01-19 - 'A' Class Models Round 2
+
+**Bugs Fixed in cpu.py**: 10 fixes (GetitemFunction init, avg_pool1d padding, strided_slice_update, reduce_any, concat dtype, tensor_scatter_update, bucketize, isinstance slice, inplace_copy, split_tensor)
+
+**Total**: 648 tests passing, 146 tests failing
+
+### Session: 2025-01-19 - Qwen Model Series Testing
+
+**Test Scope**: All 12 qwen model variants
+
+**Bugs Fixed**: 8 in cpu.py + 1 in _tensor.py (inplace_sub, CloneFunction, isinf, avg_pool1d, conv1d/conv3d training, repeat_interleave_tensor, _as_index, .data property)
+
+**Total**: 100+ test failures fixed. PR #2393 created.
+
+### Session: 2025-01-21 - Qwen Models Round 3
+
+**Bugs Fixed in cpu.py**: 4 fixes (strided_slice_update bounds, split_tensor num=0, multi-dim boolean indexing, NumPy-based setitem)
+
+**Key Achievement**: qwen3_vl pass rate improved from 44.9% to 89.7%
+
+---
+
+## mindtorch_v2 Sessions (2026-01 to 2026-02)
+
+### Session: 2026-01-27 - mindtorch_v2 A-Class Models Testing
+
+**Infrastructure Created**: `tests/run_test_v2.py` with torch_proxy
+
+**APIs Added**: 20 new APIs/modules (cumsum, padding modules, dtype functions, LRScheduler, loss functions, etc.)
+
+**Results**: AlbertModel and ASTModel forward passes working. AltCLIP/Align partial. Aria/AyaVision/Autoformer blocked.
+
+### Session: 2026-02-06 - mindtorch_v2 Comprehensive Testing (Albert, BERT, GPT-2)
+
+**Results**:
+
+| Model | Architecture | Pass Rate | Status |
+|-------|-------------|-----------|--------|
+| Albert | Encoder | 98.2% (54/55) | Excellent |
+| BERT | Encoder | 79.1% (110/139) | Good |
+| GPT-2 | Decoder | 44.3% (62/140) | Functional |
+
+**Bugs Fixed**: `torch.addmm`, `Tensor.view()` contiguity, Ascend `where()` boolean condition
+
+**Commits**: `0db45246`, `85cb15d2`
+
+**Key Findings**:
+- Encoder-only models: production-ready (79-98%)
+- Decoder-only models: functional for non-generation workloads (44%)
+- Main gaps: text generation, gradient checkpointing, model offloading, SafeTensors edge cases

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,14 +4,62 @@
 
 MindNLP is a NLP/LLM library based on MindSpore, aiming to support HuggingFace Transformers and Diffusers on Ascend/GPU/CPU devices.
 
-## Multi-Agent System
+## Directory Structure
 
-This project uses Claude Code's multi-agent system with three specialized agents for automated testing, code review, and git operations.
+```
+mindnlp/
+├── .claude/
+│   ├── settings.json          # Permissions and hooks configuration
+│   ├── agents/
+│   │   ├── test-runner.md     # Test execution agent
+│   │   ├── code-reviewer.md   # Code review agent
+│   │   └── git-agent.md       # Git operations agent
+│   ├── hooks/
+│   │   ├── validate-command.sh    # Pre-execution command validation
+│   │   └── post-edit-check.sh     # Post-edit code quality check
+│   └── logs/
+│       └── session-history.md # Historical session logs
+├── src/
+│   ├── mindnlp/               # MindNLP source code (editable)
+│   ├── mindtorch/             # MindTorch v1 source code (editable)
+│   └── mindtorch_v2/          # MindTorch v2 source code (editable)
+├── tests/
+│   ├── run_test.py            # Test runner (mindtorch v1)
+│   ├── run_test_v2.py         # Test runner (mindtorch v2, uses torch_proxy)
+│   └── transformers/          # HuggingFace transformers tests (read-only)
+│       └── tests/models/      # Model-specific tests
+└── CLAUDE.md                  # This file
+```
+
+## Current Status (as of 2026-02-06)
+
+### mindtorch v1
+- Tested on A-class and Qwen model families
+- Known limitations: Clone kernel, meta device, model loading issues
+- PRs: #2392, #2393
+
+### mindtorch_v2
+| Model | Architecture | Pass Rate | Status |
+|-------|-------------|-----------|--------|
+| Albert | Encoder | 98.2% (54/55) | Production-ready |
+| BERT | Encoder | 79.1% (110/139) | Good |
+| GPT-2 | Decoder | 44.3% (62/140) | Functional (non-generation) |
+
+**Remaining gaps** (priority order):
+1. Text generation utilities (`generate()`, beam search, sampling)
+2. Gradient checkpointing (`torch.utils.checkpoint`)
+3. Model serialization (SafeTensors edge cases, tied weights)
+4. Model offloading (CPU/disk)
+
+> Full session history: `.claude/logs/session-history.md`
+
+---
+
+## Multi-Agent System
 
 ### Agent 1: Test Runner (`test-runner`)
 
 **Purpose**: Execute tests, analyze failures, and fix bugs automatically.
-
 **Location**: `.claude/agents/test-runner.md`
 
 **Usage**:
@@ -26,16 +74,15 @@ and fix any failures."
 
 **Workflow**:
 1. Activate conda: `source ~/miniconda3/bin/activate mindnlp`
-2. Run: `python tests/run_test.py -vs {test_file}`
+2. Run: `python tests/run_test.py -vs {test_file}` (v1) or `python tests/run_test_v2.py -vs {test_file}` (v2)
 3. Analyze test output for failures
-4. Locate bug source in `./src/mindnlp/` or `./src/mindtorch/`
+4. Locate bug source in `./src/mindnlp/`, `./src/mindtorch/`, or `./src/mindtorch_v2/`
 5. Apply targeted fixes
 6. Re-run tests to verify
 
 ### Agent 2: Code Reviewer (`code-reviewer`)
 
 **Purpose**: Scan and analyze code for quality, security, and best practices.
-
 **Location**: `.claude/agents/code-reviewer.md`
 
 **Usage**:
@@ -47,17 +94,9 @@ Example prompt:
 review the changes in src/mindnlp/transformers/models/bert/modeling_bert.py"
 ```
 
-**Review Checklist**:
-- Code quality and style
-- MindSpore API compatibility
-- Security vulnerabilities
-- Performance issues
-- Documentation
-
 ### Agent 3: Git Agent (`git-agent`)
 
 **Purpose**: Handle git operations including push to origin and pull from upstream.
-
 **Location**: `.claude/agents/git-agent.md`
 
 **Usage**:
@@ -69,75 +108,74 @@ Example prompt:
 push the current changes to origin and then pull latest from ms master."
 ```
 
-**Operations**:
-- `git push origin {branch}` - Push to your remote
-- `git pull --rebase ms master` - Pull from upstream MindSpore repo
-- `git commit -m "message"` - Create commits
+---
 
-## Directory Structure
+## Important Constraints
 
-```
-mindnlp/
-├── .claude/
-│   ├── settings.json          # Permissions and hooks configuration
-│   ├── agents/
-│   │   ├── test-runner.md     # Test execution agent
-│   │   ├── code-reviewer.md   # Code review agent
-│   │   └── git-agent.md       # Git operations agent
-│   ├── hooks/
-│   │   ├── validate-command.sh    # Pre-execution command validation
-│   │   └── post-edit-check.sh     # Post-edit code quality check
-│   └── logs/                  # Agent operation logs
-├── src/
-│   ├── mindnlp/               # MindNLP source code (editable)
-│   └── mindtorch/             # MindTorch source code (editable)
-├── tests/
-│   ├── run_test.py            # Test runner script
-│   └── transformers/          # HuggingFace transformers tests (read-only)
-│       └── tests/models/      # Model-specific tests
-└── CLAUDE.md                  # This file
-```
+### Core Design Principle: No Transformers-Specific Customization
 
-## Automated Pipeline Workflow
+**CRITICAL**: MindTorch (both v1 and v2) must remain a **general-purpose PyTorch compatibility layer**.
 
-### Complete Pipeline Execution
+- **NEVER** add transformers-specific hacks, workarounds, or special cases to mindtorch code
+- **NEVER** check for `transformers` or model-specific classes in mindtorch implementations
+- All fixes must be generic PyTorch API implementations, not transformers accommodations
+- If a test fails due to transformers-specific behavior, document it as "not supported" rather than adding special cases
 
-To run the full automated pipeline:
+### For Test Runner Agent
+- Only modify files in `./src/mindnlp/`, `./src/mindtorch/`, or `./src/mindtorch_v2/`
+- **NEVER** modify test files in `./tests/transformers/`
+- Always re-run tests after fixes
 
-1. **Run Tests and Fix Bugs**:
-   ```
-   Invoke test-runner agent with specific test file
-   ```
+### For Code Reviewer Agent
+- Read-only access
+- Generate reports, don't modify code
 
-2. **Review Generated Code**:
-   ```
-   Invoke code-reviewer agent on modified files
+### For Git Agent
+- Never force push to main/master directly
+- Never reset commits
+- Always pull before pushing
+- Report conflicts, don't auto-resolve
+- Exception: `--force-with-lease` is allowed after rebase during PR creation (see PR workflow below)
+
+### For Pull Request Creation (MANDATORY)
+
+When asked to create a PR, **ALWAYS** follow these steps in order:
+
+1. **Rebase onto upstream ms/master**:
+   ```bash
+   git fetch ms
+   git rebase ms/master
    ```
 
-3. **Push and Sync with Upstream**:
-   ```
-   Invoke git-agent to push origin and pull from ms
+2. **Squash all commits into ONE single commit**:
+   ```bash
+   git reset --soft ms/master
+   git commit -m "commit message"
    ```
 
-### Example Full Pipeline Command
+3. **Push to origin** (force-with-lease is required after rebase):
+   ```bash
+   git push -u origin <branch-name> --force-with-lease
+   ```
 
-```
-"Execute the full MindNLP pipeline:
-1. Run tests/transformers/tests/models/bert/test_modeling_bert.py and fix failures
-2. Review all modified files for code quality
-3. Commit changes and push to origin
-4. Pull latest from ms master"
-```
+4. **Create PR to ms remote**:
+   ```bash
+   gh pr create --repo mindspore-lab/mindnlp --base master --head lvyufeng:<branch-name>
+   ```
+
+**Key Rules**:
+- Each PR must contain exactly ONE commit
+- The commit must be rebased on top of the latest ms/master
+- Use `--force-with-lease` (not `--force`) after rebasing
+
+---
 
 ## Git Remotes Configuration
 
 - **origin**: Your fork/development repository (push target)
 - **ms**: Upstream MindSpore repository (pull source)
 
-Verify remotes:
-```bash
-git remote -v
-```
+---
 
 ## Test Execution
 
@@ -154,8 +192,15 @@ git checkout tags/v4.57.5 -b v4.57.5-branch
 ```
 
 ### Run Tests
+
+mindtorch v1:
 ```bash
 python tests/run_test.py -vs {test_file_path}
+```
+
+mindtorch v2:
+```bash
+python tests/run_test_v2.py -vs {test_file_path}
 ```
 
 Example:
@@ -163,81 +208,13 @@ Example:
 python tests/run_test.py -vs tests/transformers/tests/models/bert/test_modeling_bert.py::BertModelTest::test_model
 ```
 
-The test runner:
-- Sets up MindSpore environment
-- Configures device (Ascend/GPU/CPU)
-- Skips unsupported tests (SDPA, TorchScript, etc.)
-- Provides detailed output
-
-## Important Constraints
-
-### Core Design Principle: No Transformers-Specific Customization
-
-**CRITICAL**: MindTorch (both v1 and v2) must remain a **general-purpose PyTorch compatibility layer**.
-
-- **NEVER** add transformers-specific hacks, workarounds, or special cases to mindtorch code
-- **NEVER** check for `transformers` or model-specific classes in mindtorch implementations
-- All fixes must be generic PyTorch API implementations, not transformers accommodations
-- If a test fails due to transformers-specific behavior, document it as "not supported" rather than adding special cases
-- The goal is PyTorch compatibility, not transformers compatibility
-
-**Why**: Coupling mindtorch to transformers creates maintenance burden and breaks other PyTorch codebases. Keep mindtorch clean and general.
-
-### For Test Runner Agent
-- Only modify files in `./src/mindnlp/` or `./src/mindtorch/`
-- **NEVER** modify test files in `./tests/transformers/`
-- Always re-run tests after fixes
-
-### For Code Reviewer Agent
-- Read-only access
-- Generate reports, don't modify code
-
-### For Git Agent
-- Never force push
-- Never reset commits
-- Always pull before pushing
-- Report conflicts, don't auto-resolve
-
-### For Pull Request Creation (MANDATORY)
-When asked to create a PR, **ALWAYS** follow these steps in order:
-
-1. **Rebase onto upstream ms/master**:
-   ```bash
-   git fetch ms
-   git rebase ms/master
-   ```
-
-2. **Squash all commits into ONE single commit**:
-   ```bash
-   # If multiple commits exist, squash them
-   git rebase -i ms/master
-   # Or reset and recommit
-   git reset --soft ms/master
-   git commit -m "commit message"
-   ```
-
-3. **Push to origin with force (after rebase)**:
-   ```bash
-   git push -u origin <branch-name> --force-with-lease
-   ```
-
-4. **Create PR to ms remote**:
-   ```bash
-   gh pr create --repo mindspore-lab/mindnlp --base master --head lvyufeng:<branch-name>
-   ```
-
-**Key Rules**:
-- Each PR must contain exactly ONE commit
-- The commit must be rebased on top of the latest ms/master
-- Use `--force-with-lease` after rebasing to update the branch safely
+---
 
 ## mindtorch_v2 Development Rules
 
 ### CRITICAL: Never Use mindspore.ops or mindspore.mint Directly
 
-**Rule**: In mindtorch_v2 code, NEVER use `mindspore.ops.*` or `mindspore.mint.*` directly. Only use PyBoost primitives or gen_ops_prim because they support `set_device()` for our dispatch mechanism.
-
-**Why**: The dispatch system needs to set device targets (CPU/GPU/Ascend). `mindspore.ops` and `mindspore.mint` don't support device targeting, but primitives from `gen_ops_prim` do via `.set_device('CPU')`.
+In mindtorch_v2 code, NEVER use `mindspore.ops.*` or `mindspore.mint.*` directly. Only use PyBoost primitives or gen_ops_prim because they support `set_device()` for our dispatch mechanism.
 
 **Correct Pattern**:
 ```python
@@ -264,7 +241,6 @@ def maximum(input, other):
 # NEVER do this in mindtorch_v2:
 result = mindspore.ops.maximum(a, b)  # NO!
 result = mindspore.mint.maximum(a, b)  # NO!
-result = mindspore.ops.ones_like(x)   # NO!
 ```
 
 **Allowed Exceptions**:
@@ -275,86 +251,28 @@ result = mindspore.ops.ones_like(x)   # NO!
 
 ### CRITICAL: Kernel Implementation Priority
 
-**Rule**: For GPU/NPU devices, NEVER use numpy for computation. Follow this priority order:
+For GPU/NPU devices, NEVER use numpy for computation. Follow this priority order:
 
 1. **PyBoost kernels** (gen_ops_prim with `.set_device()`) - Best performance, device-aware
 2. **Legacy primitives** (mindspore.nn.Cell based) - Fallback for missing PyBoost ops
 3. **Composite of existing kernels** - Build complex ops from simpler dispatched ops
 4. **NumPy fallback** - ONLY for CPU backend when no MindSpore kernel exists
 
-**Example - Correct**:
-```python
-# In ascend.py - use pyboost primitive
-@register_op("relu", DispatchKey.Backend_Ascend)
-def relu_ascend(a):
-    return _wrap_result(relu_op(_get_ms_data(a)))
-```
-
-**Example - Wrong**:
-```python
-# NEVER use numpy on NPU/GPU:
-def relu(input):
-    result = np.maximum(input.numpy(), 0)  # NO! This runs on CPU!
-    return Tensor(result)
-```
-
 ### Ascend NPU Backend Migration Guide
 
-When adding support for a new device (e.g., migrating from CPU to Ascend), follow these steps:
+When adding support for a new device (e.g., migrating from CPU to Ascend):
 
-**1. Create `pyboost_<device>.py`**:
-```python
-# src/mindtorch_v2/_backends/pyboost_ascend.py
-from mindspore.ops.auto_generate.gen_ops_prim import Add, Sub, ...
+1. **Create `pyboost_<device>.py`**: Instantiate primitives with `.set_device('<Device>')`
+2. **Create `<device>.py`**: Register ops using `@register_op("op_name", DispatchKey.Backend_<Device>)`
+3. **Update `configs.py`**: Detect device from MindSpore context
+4. **Update `__init__.py`**: Conditionally import backend
 
-add_op = Add().set_device('Ascend')
-sub_op = Sub().set_device('Ascend')
-# ... instantiate all needed primitives
-```
-
-**2. Create `<device>.py` with op registrations**:
-```python
-# src/mindtorch_v2/_backends/ascend.py
-from .._dispatch import register_op, DispatchKey
-from .pyboost_ascend import add_op, _get_ms_data, _wrap_result
-
-@register_op("add", DispatchKey.Backend_Ascend)
-def add_ascend(a, b):
-    return _wrap_result(add_op(_get_ms_data(a), _get_ms_data(b)))
-```
-
-**3. Update `configs.py`** to detect device from MindSpore context:
-```python
-DEVICE_TARGET = mindspore.get_context('device_target')
-SOC = MSContext.get_instance().get_ascend_soc_version()
-```
-
-**4. Update `__init__.py`** to conditionally import backend:
-```python
-from .configs import DEVICE_TARGET
-from ._backends import cpu
-if DEVICE_TARGET == 'Ascend':
-    from ._backends import ascend
-```
-
-**5. Device naming convention**:
+**Device naming convention**:
 - Use `"npu"` as device.type (matches torch_npu convention)
 - MindSpore uses `"Ascend"` for context and `.set_device()`
 - Dispatch keys: `DispatchKey.Backend_Ascend`
 
-**6. Test on target device**:
-```bash
-source ~/miniconda3/bin/activate mindspore  # Ascend environment
-python -c "import mindtorch_v2 as torch; print(torch.get_default_device())"  # Should print: npu
-```
-
-## Hooks
-
-### Pre-Tool Hooks
-- `validate-command.sh`: Blocks dangerous bash commands
-
-### Post-Tool Hooks
-- `post-edit-check.sh`: Checks for common code issues after edits
+---
 
 ## Common MindSpore vs PyTorch Patterns
 
@@ -366,935 +284,17 @@ python -c "import mindtorch_v2 as torch; print(torch.get_default_device())"  # S
 | `x.float()` | `x.astype(mindspore.float32)` |
 | `torch.no_grad()` | `ops.stop_gradient()` |
 
+---
+
+## Hooks
+
+- **Pre-Tool**: `validate-command.sh` - Blocks dangerous bash commands
+- **Post-Tool**: `post-edit-check.sh` - Checks for common code issues after edits
+
+---
+
 ## Troubleshooting
 
-### Tests Not Running
-- Check MindSpore installation
-- Verify device context
-- Check PYTHONPATH
-- Ensure conda environment is activated
-
-### Version Mismatch Errors
-- Checkout matching transformers version tag
-- `cd tests/transformers && git checkout tags/v4.57.5`
-
-### Git Push Fails
-- Ensure you have push access to origin
-- Check for uncommitted changes
-- Verify branch exists on remote
-
-### Code Review Issues
-- Ensure files exist and are readable
-- Check file paths are correct
-
----
-
-## Session Logs
-
-### Session: 2025-01-15 - BERT Model Test Fix
-
-**Test Case**: `tests/transformers/tests/models/bert/test_modeling_bert.py::BertModelTest::test_model`
-
-**Bugs Fixed**:
-
-| # | Error Type | File Modified | Fix Description |
-|---|------------|---------------|-----------------|
-| 1 | TypeError (broadcast_to scalar) | `src/mindtorch/_apis/cpu.py:104` | Convert scalar to tensor before broadcast |
-| 2 | RuntimeError (device mismatch) | `src/mindtorch/_op_prim/gpu/legacy.py` | Removed `gather__call__` setattr override |
-| 3 | TypeError (reduce_any axis=None) | `src/mindtorch/_apis/cpu.py:218` | Handle None axis by converting to all dims |
-
-**Result**: ✅ PASSED (1 passed, 2 warnings in 4.08s)
-
-### Session: 2025-01-17 - Transformer Models 'A' Testing & Fixes
-
-**Test Scope**: All transformer models starting with 'a' (aimv2, albert, align, altclip, apertus, arcee, aria, audio_spectrogram_transformer, auto, autoformer, aya_vision)
-
-**Bugs Fixed in cpu.py**:
-
-| # | Error Type | File Modified | Fix Description |
-|---|------------|---------------|-----------------|
-| 1 | TypeError (isinstance slice) | `cpu.py:2160` | Changed shadowed `slice` to `py_slice` in `_as_spec_tuple` |
-| 2 | TypeError (Bucketize boundaries) | `cpu.py:1507-1512` | Convert tensor boundaries to list of floats using `tolist()` |
-| 3 | KeyError: None | `cpu.py:144-148` | Preserve `init` attribute in `inplace_copy` |
-| 4 | TypeError (TensorScatterUpdate dtype) | `cpu.py:630-634` | Cast updates to input dtype in `tensor_scatter_update` |
-| 5 | IndexError (avg_pool1d padding) | `cpu.py:844` | Fixed padding tuple indexing `padding[0], padding[0]` |
-| 6 | TypeError (avg_pool1d kernel_size) | `cpu.py:853-856` | Handle kernel_size tuple by extracting first element |
-| 7 | TypeError (conv1d args) | `cpu.py:871` | Added missing `training=True` parameter |
-| 8 | RuntimeError (Concat dtype) | `cpu.py:324-330` | Cast all tensors to first tensor's dtype before concat |
-
-**Environment Fixes**:
-- Installed `sentencepiece` for albert pipeline tests
-- Installed `git-lfs` for auto model tests
-- Installed `diffusers` for pipeline compatibility
-
-**Final Results Summary**:
-| Model | Passed | Failed | Notes |
-|-------|--------|--------|-------|
-| aimv2 | 86 | 20 | Clone kernel, meta device issues |
-| albert | 54 | 13 | Clone kernel, model loading issues |
-| align | 86 | 20 | Clone kernel, meta device issues |
-| altclip | 89 | 17 | Clone kernel, meta device issues |
-| apertus | 72 | 10 | Clone kernel, meta device issues |
-| arcee | 77 | 12 | Clone kernel, meta device issues |
-| aria | 59 | 9 | Clone kernel, meta device issues (improved from 39 failed) |
-| audio_spectrogram_transformer | 35 | 8 | Clone kernel, meta device issues |
-| auto | 11 | 14 | Network/git-lfs issues |
-| autoformer | 25 | 10 | SliceGrad Complex64, meta device issues |
-| aya_vision | 59 | 8 | Clone kernel, meta device issues |
-
-**Remaining Unfixable Issues (Not cpu.py)**:
-1. **MindSpore Kernel Limitations**:
-   - `Clone` kernel unregistered (affects backward pass)
-   - `SliceGrad` doesn't support Complex64 dtype
-
-2. **Model Loading Issues**:
-   - Reshape failures during `param[...]` with mismatched weight shapes
-   - Weight tying/shared tensor issues during from_pretrained()
-
-3. **MindTorch Implementation Gaps**:
-   - Meta device context manager not fully implemented
-
-### Session: 2025-01-19 - Comprehensive 'A' Class Models Testing & Bug Fixes (Round 2)
-
-**Test Scope**: Re-tested all transformer models starting with 'a' using parallel sub-agents
-
-**Methodology**: Launched 10 parallel sub-agents to systematically test and fix bugs across all 'a' class models
-
-**Bugs Fixed in cpu.py**:
-
-| # | Error Type | File Modified | Fix Description |
-|---|------------|---------------|-----------------|
-| 1 | GetitemFunction init attribute | `cpu.py:61, 83` | Removed copying of `init` attribute that caused shape mismatches during model loading |
-| 2 | avg_pool1d padding IndexError | `cpu.py:847` | Fixed `padding[1]` to `padding[0]` for single-element tuples |
-| 3 | strided_slice_update bit shifting | `cpu.py:2243, 2315` | Added conditional check before bit shifting when `remaining_dims <= 1` |
-| 4 | reduce_any axis=None | `cpu.py:321` | Convert None axis to tuple of all dimensions |
-| 5 | concat dtype mismatch | `cpu.py:327-332` | Cast all tensors to first tensor's dtype before concatenation |
-| 6 | tensor_scatter_update dtype | `cpu.py:633-637` | Cast updates to input dtype to avoid type mismatch |
-| 7 | bucketize tensor boundaries | `cpu.py:1503-1507` | Convert tensor boundaries to list using `tolist()` |
-| 8 | isinstance with shadowed slice | `cpu.py:2158` | Changed `slice` to `py_slice` in isinstance check |
-| 9 | inplace_copy init preservation | `cpu.py:144-151` | Preserve `init` attribute during inplace copy |
-| 10 | split_tensor list/tuple support | `cpu.py:783-786` | Added support for list/tuple split sizes |
-
-**Additional Changes**:
-- Added `cpu` module (`src/mindtorch/cpu/__init__.py`) with `get_device_properties` function
-- Added `FunctionCtx` class (`src/mindtorch/autograd/function.py`) for diffusers compatibility
-- Removed diffusers patching code from `mindtorch/__init__.py` to keep mindtorch clean
-
-**Final Results Summary**:
-| Model | Passed | Failed | Improvement | Key Fixes |
-|-------|--------|--------|-------------|-----------|
-| aya_vision | 59 | 8 | +15 tests | isinstance slice, init preservation |
-| audio_spectrogram_transformer | 35 | 8 | N/A | split_tensor list/tuple |
-| aimv2 | 86 | 20 | N/A | No fixable bugs (unfixable limitations) |
-| align | 86 | 20 | N/A | No fixable bugs (unfixable limitations) |
-| apertus | 72 | 10 | N/A | GetitemFunction init attribute |
-| autoformer | 20 | 15 | N/A | avg_pool1d padding |
-| albert | 54 | 13 | N/A | Complex safetensors loading issue |
-| auto | 11 | 14 | N/A | strided_slice_update bit shifting |
-| altclip | 89 | 17 | N/A | No fixable bugs (unfixable limitations) |
-| aria | 59 | 9 | +32 tests | reduce_any, concat, tensor_scatter_update, bucketize |
-| arcee | 77 | 12 | N/A | Identified Tensor.view() bug (not applied) |
-
-**Total**: 648 tests passing, 146 tests failing
-
-**Critical Bug Identified (Not Applied)**:
-- **Tensor.view() dtype reinterpretation** (`src/mindtorch/_tensor.py:2523-2528`): When safetensors calls `tensor.view(torch.float32)`, it's treated as a shape parameter instead of dtype conversion. This affects 10+ tests in arcee and likely many other models. Fix ready but requires user approval.
-
-**PR Created**: #2392 - "Fix multiple tensor operation bugs and add FunctionCtx for compatibility"
-- Single squashed commit with all 10 bug fixes
-- Rebased onto upstream master (ms/master)
-- Ready for review and merge
-
-**Remaining Unfixable Issues**:
-1. **MindSpore Kernel Limitations** (~20% of failures):
-   - Clone kernel unregistered for backward pass
-   - SliceGrad doesn't support Complex64 dtype
-
-2. **Model Loading Issues** (~60% of failures):
-   - Reshape failures during `param[...]` with mismatched weight shapes
-   - Weight tying/shared tensor issues during `from_pretrained()`
-   - Related to unfixed `Tensor.view()` bug above
-
-3. **MindTorch Implementation Gaps** (~20% of failures):
-   - Meta device context manager not fully implemented
-   - Some dtype validation issues with transformers library
-
-### Session: 2025-01-19 - Qwen Model Series Testing & Bug Fixes
-
-**Test Scope**: All transformer models starting with 'q' (qwen2, qwen2_5_omni, qwen2_5_vl, qwen2_audio, qwen2_moe, qwen2_vl, qwen3, qwen3_moe, qwen3_next, qwen3_omni_moe, qwen3_vl, qwen3_vl_moe)
-
-**Methodology**: Launched 12 parallel sub-agents to systematically test and fix bugs across all 'q' class models
-
-**Bugs Fixed in cpu.py, npu.py, npu_310b.py**:
-
-| # | Error Type | File Modified | Fix Description |
-|---|------------|---------------|-----------------|
-| 1 | Missing inplace_sub | `cpu.py:154`, `npu.py`, `npu_310b.py` | Added inplace_sub function for in-place subtraction operations |
-| 2 | Clone kernel unregistered | `cpu.py:238-270` | Implemented NumPy-based CloneFunction with custom backward to avoid MindSpore Clone kernel |
-| 3 | isinf integer tensor | `cpu.py:682-687` | Added check to handle integer tensors (return all False) |
-| 4 | avg_pool1d dimensions | `cpu.py:908-917` | Fixed to handle both 2D and 3D input tensors correctly |
-| 5 | conv1d missing training | `cpu.py:928`, `npu.py`, `npu_310b.py` | Added training=True parameter to function signature |
-| 6 | Missing repeat_interleave_tensor | `cpu.py:1183` | Added function delegating to repeat_interleave_int |
-| 7 | conv3d missing training | `cpu.py:1317`, `npu.py`, `npu_310b.py` | Added training=True parameter to function signature |
-| 8 | _as_index tuple handling | `cpu.py:1909-1911` | Fixed to handle tuple returned by non_zero_ext |
-
-**Bug Fixed in _tensor.py**:
-
-| # | Error Type | File Modified | Fix Description |
-|---|------------|---------------|-----------------|
-| 1 | .data property | `_tensor.py:930-934` | Changed to return self instead of separate tensor for proper inplace operations |
-
-**Final Results Summary**:
-| Model | Passed | Failed | Improvement | Key Fixes |
-|-------|--------|--------|-------------|-----------|
-| qwen2 | 84 | 2 | N/A | Fixed .data property |
-| qwen2_5_omni | 62 | 2 | +31 tests | Fixed conv1d, avg_pool1d |
-| qwen2_5_vl | - | - | N/A | Identified inplace_sub missing |
-| qwen2_audio | 66 | 2 | +31 tests | Fixed 7 bugs (conv1d, conv3d, avg_pool1d, CloneFunction, inplace_sub, isinf, repeat_interleave_tensor, _as_index) |
-| qwen2_moe | 78 | 11 | N/A | No fixable bugs (transformers issue) |
-| qwen2_vl | 121 | 6 | +50 tests | Fixed 5 bugs (conv3d, repeat_interleave_tensor, inplace_sub, non_zero_ext, isinf) |
-| qwen3 | 83 | 3 | N/A | No fixable bugs (all unfixable) |
-| qwen3_moe | 81 | 3 | N/A | Attempted Clone kernel fix |
-| qwen3_next | 74 | 3 | +41 tests | Fixed conv1d training parameter |
-| qwen3_omni_moe | 29 | 31 | N/A | Identified split_tensor bug (needs manual fix) |
-| qwen3_vl | - | - | N/A | Identified repeat_interleave_tensor missing |
-| qwen3_vl_moe | 33 | 42 | N/A | Fixed 3 bugs (conv3d, repeat_interleave_tensor, inplace_sub) |
-
-**Total**: 100+ test failures fixed across all qwen models
-
-**Critical Bugs Identified (Not Applied)**:
-- **split_tensor num=0 handling** (`cpu.py:826-832`): When split_size_or_sections is larger than dimension size, num becomes 0 causing ValueError. Fix: Add check `if num == 0: return (input,)`
-- **strided_slice_update bounds checking** (`cpu.py:2406-2428`): End indices may exceed tensor dimensions. Fix: Add bounds clamping after line 2421
-
-**PR Created**: #2393 (pending) - "Fix qwen model series bugs and improve MindTorch API compatibility"
-- Single commit with all 8 bug fixes
-- Pushed to origin/master
-- Ready for review and merge
-
-**Remaining Unfixable Issues**:
-1. **MindSpore Kernel Limitations** (~15% of failures):
-   - Clone kernel unregistered for backward pass (partially mitigated with NumPy-based implementation)
-   - Some gradient computation issues in complex models
-
-2. **Model Loading Issues** (~50% of failures):
-   - Reshape failures during `param[...]` with mismatched weight shapes
-   - Weight tying/shared tensor issues during `from_pretrained()`
-   - Model-specific initialization issues in transformers library
-
-3. **MindTorch Implementation Gaps** (~35% of failures):
-   - Meta device context manager not fully implemented
-   - Some gradient checkpointing modes not fully compatible
-   - Autograd engine issues with null tensor pointers in complex scenarios
-
----
-
-### Session: 2025-01-21 - Qwen Models Comprehensive Testing & Critical Bug Fixes (Round 3)
-
-**Test Scope**: Re-tested all transformer models starting with 'q' (qwen2, qwen2_5_omni, qwen2_5_vl, qwen2_audio, qwen2_moe, qwen2_vl, qwen3, qwen3_moe, qwen3_next, qwen3_omni_moe, qwen3_vl, qwen3_vl_moe)
-
-**Methodology**: Launched 12 parallel sub-agents to systematically test and fix bugs across all 'q' class models
-
-**Bugs Fixed in cpu.py**:
-
-| # | Error Type | File Modified | Fix Description |
-|---|------------|---------------|-----------------|
-| 1 | strided_slice_update bounds | `cpu.py:2343-2351, 2417-2425` | Added bounds clamping to prevent index out of bounds errors |
-| 2 | split_tensor num=0 | `cpu.py:826-832` | Added check to return (input,) when split_size > dimension size |
-| 3 | Multi-dimensional boolean indexing | `cpu.py:1908-1915` | Removed restriction, flatten multi-dim boolean masks before converting to indices |
-| 4 | **setitem function (NumPy-based)** | `cpu.py:2277-2308` | **Complete rewrite using NumPy for correct boolean indexing behavior** |
-
-**Final Results Summary**:
-| Model | Before | After | Improvement | Key Fixes |
-|-------|--------|-------|-------------|-----------|
-| **qwen3_vl** | 35 passed, 43 failed | **70 passed, 8 failed** | **+35 tests (89.7% pass rate)** | NumPy-based setitem fix |
-| qwen3_vl_moe | 33 passed, 42 failed | 33 passed, 42 failed | No change | Model loading issues (unfixable) |
-| qwen3_omni_moe | 29 passed, 31 failed | 30 passed, 30 failed | +1 test | split_tensor fix |
-| qwen2 | 83 passed, 3 failed | - | Already good | All unfixable |
-| qwen2_5_omni | 61 passed, 3 failed | - | Already good | All unfixable |
-| qwen2_5_vl | 74 passed, 8 failed | - | Already good | All unfixable |
-| qwen2_audio | 65 passed, 3 failed | - | Already good | All unfixable |
-| qwen2_moe | 78 passed, 10 failed | - | Already good | Gradient checkpointing issues |
-| qwen2_vl | 75 passed, 7 failed | - | Already good | All unfixable |
-| qwen3 | 83 passed, 3 failed | - | Already good | qa_outputs.bias init issue |
-| qwen3_moe | 81 passed, 3 failed | - | Already good | qa_outputs.bias init issue |
-| qwen3_next | 74 passed, 3 failed | - | Already good | qa_outputs.bias init issue |
-
-**Total**: 36 additional tests passing across qwen models
-
-**Critical Achievement**:
-- **qwen3_vl pass rate improved from 44.9% to 89.7%** with NumPy-based setitem fix
-- This fix resolved all boolean indexing issues for vision-language models
-
-**PR Status**: Ready to create PR with 4 bug fixes
-
-**Remaining Unfixable Issues**:
-1. **MindSpore Kernel Limitations** (~10% of failures):
-   - Clone kernel unregistered for backward pass
-   - Gradient computation issues in complex models
-
-2. **Model Loading Issues** (~60% of failures):
-   - Weight tying/shared tensor issues during `from_pretrained()`
-   - Model-specific initialization issues in transformers library (qa_outputs.bias)
-
-3. **MindTorch Implementation Gaps** (~30% of failures):
-   - Meta device context manager not fully implemented
-   - Gradient checkpointing with None gradients (SGD optimizer issue)
-   - Autograd engine null pointer issues
-
-### Session: 2026-01-27 - mindtorch_v2 A-Class Models Testing
-
-**Test Scope**: Testing 'a' class transformer models with mindtorch_v2 backend
-
-**Methodology**: Created new test runner (run_test_v2.py) that uses mindtorch_v2's torch_proxy to intercept `import torch` and redirect to mindtorch_v2
-
-**Infrastructure Created**:
-1. `tests/run_test_v2.py` - Test runner for mindtorch_v2 with torch proxy
-2. Mock for peft library to avoid import chain issues
-
-**Bugs Fixed / APIs Added in mindtorch_v2**:
-
-| # | API/Module | File | Description |
-|---|------------|------|-------------|
-| 1 | cumsum, cumprod | `_functional.py` | Cumulative sum/product operations |
-| 2 | floor, ceil, trunc, round, sign | `_functional.py` | Rounding operations |
-| 3 | fmod, remainder | `_functional.py` | Modular arithmetic |
-| 4 | log10, log2, log1p, expm1 | `_functional.py` | Log variants |
-| 5 | acos, asin, atan, atan2 | `_functional.py` | Trigonometric functions |
-| 6 | cosh, sinh, acosh, asinh, atanh | `_functional.py` | Hyperbolic functions |
-| 7 | get_default_dtype, set_default_dtype | `__init__.py` | Default dtype management |
-| 8 | ZeroPad1d/2d/3d | `nn/modules/padding.py` | Zero padding modules |
-| 9 | ConstantPad1d/2d/3d | `nn/modules/padding.py` | Constant padding modules |
-| 10 | ReflectionPad1d/2d/3d | `nn/modules/padding.py` | Reflection padding modules |
-| 11 | ReplicationPad1d/2d/3d | `nn/modules/padding.py` | Replication padding modules |
-| 12 | Tensor.type_as() | `_tensor.py` | Cast to same dtype as other tensor |
-| 13 | Tensor.type() | `_tensor.py` | Get/set tensor type |
-| 14 | LRScheduler and variants | `optim/lr_scheduler.py` | Learning rate schedulers |
-| 15 | L1Loss, SmoothL1Loss, etc. | `nn/modules/loss.py` | Additional loss functions |
-| 16 | one_hot | `nn/functional.py` | One-hot encoding |
-| 17 | batch_norm, group_norm, etc. | `nn/functional.py` | Normalization functions |
-| 18 | DistributedSampler | `_torch_proxy/stubs/utils/data/` | Data sampler stub |
-| 19 | DataParallel | `nn/parallel/` | Parallel training stub |
-| 20 | _dynamo module | `_dynamo/` | torch.compile stubs |
-
-**Model Test Results**:
-
-| Model | Status | Notes |
-|-------|--------|-------|
-| AlbertModel | SUCCESS | Forward pass works |
-| ASTModel | SUCCESS | Forward pass works |
-| AltCLIPModel | PARTIAL | Model creates, needs `sigmoid` at module level |
-| AlignModel | PARTIAL | Needs `AdaptiveAvgPool2d` |
-| AriaModel | BLOCKED | Needs more APIs |
-| AyaVisionModel | BLOCKED | Needs more APIs |
-| AutoformerModel | BLOCKED | Needs `torch.distributions` module |
-
-**Remaining APIs Needed for Full Support**:
-1. `torch.sigmoid` (module-level, not just Tensor method)
-2. `nn.AdaptiveAvgPool2d`, `nn.AdaptiveAvgPool1d`
-3. `torch.distributions` module (for time series models)
-4. `torch.fft` module (for signal processing)
-
-**Commits Created**:
-1. `fa18c68b` - fix(mindtorch_v2): add tensor methods for aimv2 model compatibility
-2. `3ae9e2d8` - feat(mindtorch_v2): add test infrastructure and stub expansions
-3. `c7a0dcd8` - feat(mindtorch_v2): add cumsum, padding modules, dtype functions
-
-**Key Achievement**: mindtorch_v2 now successfully runs AlbertModel and ASTModel forward passes using the torch_proxy system, demonstrating the viability of the approach.
-
----
-
-### Session: 2026-02-06 - mindtorch_v2 Albert Model Comprehensive Testing
-
-**Test Scope**: Full HuggingFace Transformers test suite for Albert models using mindtorch_v2 backend
-
-**Methodology**: Used `run_test_v2.py` with torch_proxy to run the complete Albert test suite (102 tests)
-
-**Test Execution Summary**:
-- **Date**: 2026-02-06
-- **Model**: Albert (all variants: base, PreTraining, MaskedLM, SequenceClassification, TokenClassification, QuestionAnswering, MultipleChoice)
-- **Backend**: mindtorch_v2 with torch_proxy
-- **Device**: Ascend NPU (910B)
-
-**Results Overview**:
-
-| Metric | Count | Percentage |
-|--------|-------|------------|
-| **PASSED** | 54 | 98.2% (of runnable) |
-| **FAILED** | 1 | 1.8% (of runnable) |
-| **SKIPPED** | 47 | 46.1% (of total) |
-| **TOTAL** | 102 | 100% |
-
-**Pass Rate Analysis**:
-- **Runnable tests**: 55 (54 passed + 1 failed)
-- **Pass rate**: 54/55 = **98.2%**
-- **Overall coverage**: 54/102 = 52.9% (many tests skipped due to network/environment)
-
-**Test Categories**:
-
-✅ **Passing Tests (54)** - All core functionality:
-- Model initialization and configuration
-- Forward pass (all model variants)
-- Backward pass and gradient computation
-- Model saving and loading (basic)
-- Attention mechanisms
-- Hidden states and outputs
-- Model resizing and pruning
-- Gradient checkpointing
-- PEFT integration
-- Parameter initialization
-- Buffer handling
-
-⏭️ **Skipped Tests (47)**:
-- **Network issues** (25 tests): Cannot download models from HuggingFace
-- **Multi-GPU tests** (10 tests): Not applicable in single-device environment
-- **Unsupported features** (12 tests): TorchScript, SDPA, etc.
-
-❌ **Failed Tests (1)**:
-- `test_can_load_with_global_device_set` - Subprocess test that verifies model loading with `torch.set_default_device()`
-- **Status**: Global device functionality works correctly in isolation (verified separately)
-- **Root cause**: Subprocess environment setup issue with torch_proxy
-- **Impact**: Low - core functionality works, only affects edge case testing
-
-**Comparison with mindtorch v1**:
-
-| Metric | mindtorch v1 | mindtorch_v2 | Improvement |
-|--------|--------------|--------------|-------------|
-| Pass rate | ~80-85% | 98.2% | +13-18% |
-| Failed tests | 10-13 | 1 | -9 to -12 tests |
-| Core bugs | Multiple | None | Significant |
-
-**Key Achievements**:
-1. **98.2% pass rate** - Only 1 test failing out of 55 runnable tests
-2. **All core functionality working** - Forward/backward pass, model loading, training
-3. **Clean implementation** - No transformers-specific hacks in mindtorch_v2
-4. **NPU support** - All tests run on Ascend NPU with proper device handling
-5. **torch_proxy system validated** - Successfully intercepts PyTorch imports
-
-**Global Device Functionality Verification**:
-Verified that mindtorch_v2 correctly implements:
-```python
-torch.set_default_device(device)  # ✅ Works
-torch.get_default_device()        # ✅ Returns correct device
-torch.tensor([1, 2, 3])          # ✅ Created on default device
-```
-
-**Remaining Issues**:
-1. **test_can_load_with_global_device_set** - Subprocess test failure (low priority, edge case only)
-
-**Next Steps**:
-1. ✅ Document results in CLAUDE.md session logs
-2. 🔄 Test other model families (B-class, C-class, etc.) with mindtorch_v2
-3. 🔄 Investigate subprocess test failure (low priority)
-4. 🔄 Add missing APIs as needed for other models
-
-**Conclusion**: mindtorch_v2 demonstrates **excellent compatibility** with HuggingFace Transformers Albert models, achieving a 98.2% pass rate. The torch_proxy system successfully intercepts PyTorch imports and provides a clean, general-purpose compatibility layer without any transformers-specific customizations. This represents a significant improvement over mindtorch v1.
-
----
-
-### Session: 2026-02-06 - mindtorch_v2 BERT Model Comprehensive Testing
-
-**Test Scope**: Full HuggingFace Transformers test suite for BERT models using mindtorch_v2 backend
-
-**Methodology**: Used `run_test_v2.py` with torch_proxy to run the complete BERT test suite (246 tests)
-
-**Test Execution Summary**:
-- **Date**: 2026-02-06
-- **Model**: BERT (all variants: base, MaskedLM, SequenceClassification, TokenClassification, QuestionAnswering, MultipleChoice, NextSentencePrediction, PreTraining, LMHeadModel)
-- **Backend**: mindtorch_v2 with torch_proxy
-- **Device**: Ascend NPU (910B)
-- **Duration**: 20 minutes 43 seconds
-
-**Results Overview**:
-
-| Metric | Count | Percentage |
-|--------|-------|------------|
-| **PASSED** | 110 | 79.1% (of runnable) |
-| **FAILED** | 29 | 20.9% (of runnable) |
-| **SKIPPED** | 107 | 43.5% (of total) |
-| **TOTAL** | 246 | 100% |
-
-**Pass Rate Analysis**:
-- **Runnable tests**: 139 (110 passed + 29 failed)
-- **Pass rate**: 110/139 = **79.1%**
-- **Overall coverage**: 110/246 = 44.7% (many tests skipped due to network/environment)
-
-**Failed Test Categories**:
-
-1. **Generation Tests (13 failures)** - Text generation functionality not fully implemented:
-   - Greedy search, beam search, sampling
-   - Assisted decoding, prompt lookup decoding
-   - Generate from embeddings
-
-2. **Model Loading/Saving Tests (6 failures)** - Serialization and device context issues:
-   - SafeTensors support
-   - Tied weights handling
-   - Device context management
-   - Global device setting (subprocess test)
-
-3. **Training Tests (3 failures)** - Gradient checkpointing implementation gaps:
-   - Reentrant and non-reentrant modes
-
-4. **Offloading Tests (3 failures)** - Feature not implemented:
-   - CPU offload, disk offload
-
-5. **Other Tests (4 failures)** - Various edge cases:
-   - Determinism, padding, model outputs equivalence, token resizing
-
-**Comparison: BERT vs Albert**:
-
-| Metric | Albert | BERT | Difference |
-|--------|--------|------|------------|
-| Pass rate | 98.2% | 79.1% | -19.1% |
-| Failed tests | 1 | 29 | +28 |
-| Core functionality | ✅ All working | ✅ All working | Same |
-| Generation | N/A | ❌ Not working | BERT-specific |
-
-**Key Findings**:
-
-✅ **What Works Well (110 tests passing)**:
-- All core model functionality (forward/backward pass, training)
-- All 8 BERT model variants work correctly
-- Attention mechanisms, hidden states, outputs
-- Parameter initialization, buffer handling
-- PEFT integration, gradient computation
-- Model resizing and pruning (basic)
-
-❌ **What Needs Work (29 tests failing)**:
-- **Text generation** (highest priority): `generate()` method and generation utilities
-- **Model serialization**: SafeTensors edge cases, tied weights
-- **Gradient checkpointing**: Reentrant/non-reentrant modes
-- **Model offloading**: CPU/disk offload (not implemented)
-
-**Missing APIs/Features Identified**:
-
-1. **Generation Module** (`transformers.generation`):
-   - `GenerationMixin.generate()`
-   - `GenerationConfig`
-   - Beam search, sampling utilities
-   - Stopping criteria
-
-2. **Gradient Checkpointing**:
-   - `torch.utils.checkpoint.checkpoint()`
-   - Reentrant and non-reentrant modes
-
-3. **Model Offloading**:
-   - `accelerate` library integration
-   - CPU/disk offload utilities
-
-4. **SafeTensors**:
-   - Better safetensors integration
-   - Tied weights handling
-
-**Conclusion**: BERT achieves a **79.1% pass rate** with mindtorch_v2, which is good but lower than Albert's 98.2%. The main difference is that BERT tests include text generation functionality, which is not yet fully implemented in mindtorch_v2. Core model functionality (forward/backward pass, training) works excellently for all BERT variants.
-
-**Recommendation**: Focus on implementing the `generate()` method and generation utilities to improve the pass rate significantly. The core PyTorch compatibility layer is solid.
-
----
-
-### Session: 2026-02-06 - mindtorch_v2 GPT-2 Model Testing & Bug Fixes
-
-**Test Scope**: Full HuggingFace Transformers test suite for GPT-2 models using mindtorch_v2 backend
-
-**Methodology**: Used `run_test_v2.py` with torch_proxy to run the complete GPT-2 test suite (255 tests)
-
-**Test Execution Summary**:
-- **Date**: 2026-02-06
-- **Model**: GPT-2 (all variants: base, LMHeadModel, ForSequenceClassification, ForTokenClassification)
-- **Backend**: mindtorch_v2 with torch_proxy
-- **Device**: Ascend NPU (910B)
-- **Duration**: 15 minutes 33 seconds
-
-**Results Overview**:
-
-| Metric | Count | Percentage |
-|--------|-------|------------|
-| **PASSED** | 40 | 28.4% (of runnable) |
-| **FAILED** | 101 | 71.6% (of runnable) |
-| **SKIPPED** | 114 | 44.7% (of total) |
-| **TOTAL** | 255 | 100% |
-
-**Pass Rate Analysis**:
-- **Runnable tests**: 141 (40 passed + 101 failed)
-- **Pass rate**: 40/141 = **28.4%**
-- **Overall coverage**: 40/255 = 15.7% (many tests skipped due to network/environment)
-
-**Comparison: GPT-2 vs BERT vs Albert**:
-
-| Metric | Albert | BERT | GPT-2 | Trend |
-|--------|--------|------|-------|-------|
-| Pass rate | 98.2% | 79.1% | 28.4% | Declining |
-| Failed tests | 1 | 29 | 101 | Increasing |
-| Core functionality | ✅ | ✅ | ❌ | Degrading |
-| Model type | Encoder | Encoder | Decoder | Different |
-
-**Root Cause Analysis**:
-
-The GPT-2 pass rate (28.4%) is significantly lower than BERT (79.1%) and Albert (98.2%). Investigation revealed:
-
-1. **Missing `torch.addmm` function** (✅ FIXED):
-   - GPT-2 uses Conv1D layers that rely on `addmm`
-   - Error: `AttributeError: module 'mindtorch_v2' has no attribute 'addmm'`
-   - **Fix**: Implemented `addmm(input, mat1, mat2, beta=1, alpha=1)` in `_functional.py`
-   - Formula: `out = beta * input + alpha * (mat1 @ mat2)`
-
-2. **Tensor.view() contiguity issues** (⚠️ BLOCKING):
-   - GPT-2 attention reshaping hits view() contiguity errors
-   - Error: `RuntimeError: view size is not compatible with input tensor's size and stride`
-   - **Impact**: Blocks basic forward pass for GPT-2
-   - **Root cause**: `view()` requires contiguous tensors, but GPT-2 operations produce non-contiguous tensors
-
-3. **Text generation dependency**:
-   - GPT-2 is primarily a generation model
-   - Many tests require `generate()` method
-   - Same issue as BERT but more critical for GPT-2
-
-4. **Decoder-only architecture complexity**:
-   - Causal attention masking
-   - Different tensor layout patterns than encoder models
-
-**Bugs Fixed**:
-
-| # | Bug | File | Fix Description |
-|---|-----|------|-----------------|
-| 1 | Missing `torch.addmm` | `_functional.py:89-103` | Added `addmm(input, mat1, mat2, beta=1, alpha=1)` function |
-| 2 | Missing export | `__init__.py:36` | Exported `addmm` in module imports |
-
-**Remaining Blockers**:
-
-1. **High Priority**:
-   - `Tensor.view()` contiguity handling - Blocks basic forward pass
-   - Need to auto-call `contiguous()` or improve error handling
-
-2. **Medium Priority**:
-   - Text generation utilities (`generate()`, beam search, sampling)
-   - Causal attention masking verification
-
-3. **Low Priority**:
-   - Model serialization edge cases
-   - Gradient checkpointing
-
-**Key Findings**:
-
-✅ **What Works**:
-- Model creation and initialization
-- Parameter loading
-- Basic tensor operations (with addmm fix)
-
-❌ **What Doesn't Work**:
-- Forward pass (blocked by view() contiguity)
-- Text generation (not implemented)
-- Most core functionality tests
-
-**Comparison with Model Types**:
-
-| Feature | Encoder (Albert/BERT) | Decoder (GPT-2) |
-|---------|----------------------|-----------------|
-| Forward pass | ✅ Works | ❌ Blocked by view() |
-| Attention | ✅ Bidirectional | ❌ Causal (issues) |
-| Tensor ops | ✅ Mostly contiguous | ❌ Non-contiguous |
-| Generation | ⚠️ Optional | ❌ Critical |
-| Pass rate | 79-98% | 28% |
-
-**Recommendations**:
-
-1. **Immediate**: Fix `Tensor.view()` to handle non-contiguous tensors
-   - Option A: Auto-call `contiguous()` when view() fails
-   - Option B: Improve error message to suggest `reshape()` or `contiguous()`
-   - Option C: Make `view()` more permissive like PyTorch
-
-2. **Short-term**: Test GPT-2 again after view() fix to identify next blockers
-
-3. **Medium-term**: Implement text generation utilities
-
-4. **Long-term**: Test other decoder models (GPT-J, GPT-Neo, etc.)
-
-**Conclusion**: GPT-2 reveals fundamental issues with mindtorch_v2's handling of decoder-only models. The main blocker is `Tensor.view()` contiguity handling, which prevents even basic forward passes. After fixing `addmm`, the next critical fix is improving `view()` to handle non-contiguous tensors like PyTorch does.
-
-**Status**:
-- ✅ Encoder-only models: Production-ready (79-98% pass rate)
-- ⚠️ Decoder-only models: Needs work (28% pass rate, blocked by view())
-- ❓ Encoder-decoder models: Not yet tested
-
----
-
-### Session: 2026-02-06 - mindtorch_v2 Comprehensive Testing Summary
-
-**Models Tested**: Albert, BERT, GPT-2
-
-**Overall Results**:
-
-| Model | Pass Rate | Passed | Failed | Skipped | Total | Status |
-|-------|-----------|--------|--------|---------|-------|--------|
-| Albert | 98.2% | 54 | 1 | 47 | 102 | ✅ Excellent |
-| BERT | 79.1% | 110 | 29 | 107 | 246 | ✅ Good |
-| GPT-2 | 28.4% | 40 | 101 | 114 | 255 | ⚠️ Needs Work |
-
-**Key Achievements**:
-
-1. **torch_proxy system validated**: Successfully intercepts PyTorch imports across all models
-2. **Encoder-only models work excellently**: 79-98% pass rate for BERT/Albert
-3. **No transformers-specific hacks**: mindtorch_v2 remains general-purpose
-4. **Identified critical gaps**: `addmm`, `view()` contiguity, generation utilities
-
-**Critical Bugs Fixed**:
-
-1. ✅ `torch.addmm` - Implemented and exported
-   - Impact: Unblocks GPT-2 Conv1D layers
-   - Location: `src/mindtorch_v2/_functional.py:89-103`
-
-**Critical Bugs Remaining**:
-
-1. ❌ `Tensor.view()` contiguity - Blocks GPT-2 forward pass
-2. ❌ Text generation utilities - Blocks 13+ BERT tests, many GPT-2 tests
-3. ⚠️ Gradient checkpointing - Blocks 3 BERT tests
-4. ⚠️ Model offloading - Blocks 3 BERT tests
-
-**Recommendations by Model Type**:
-
-1. **Encoder-only models** (BERT, RoBERTa, Albert, etc.):
-   - ✅ **Production-ready** for core functionality
-   - ✅ Forward/backward pass, training, inference all work
-   - ⚠️ Generation features optional (if needed, implement `generate()`)
-
-2. **Decoder-only models** (GPT-2, GPT-J, LLaMA, etc.):
-   - ❌ **Not ready** - blocked by view() contiguity issues
-   - ❌ Fix `Tensor.view()` first before using
-   - ❌ Implement generation utilities
-   - 💡 **Use mindtorch v1 for now**
-
-3. **Encoder-decoder models** (T5, BART, etc.):
-   - ❓ **Not yet tested**
-   - 🔮 Likely similar to BERT (good core, missing generation)
-
-**Next Steps**:
-
-1. **Immediate**: Fix `Tensor.view()` contiguity handling
-2. **Short-term**: Re-test GPT-2 and identify remaining blockers
-3. **Medium-term**: Implement text generation utilities
-4. **Long-term**: Test encoder-decoder models (T5, BART)
-
-**Conclusion**: mindtorch_v2 demonstrates **excellent compatibility** with encoder-only transformer models but needs critical fixes for decoder-only models. The torch_proxy system works well, and the codebase remains clean without transformers-specific hacks. Main blockers are `view()` contiguity and text generation utilities.
-
----
-
-### Session: 2026-02-06 - GPT-2 Re-test After Fixes & Final Results
-
-**Test Scope**: Re-ran GPT-2 test suite after implementing `addmm` and `view()` contiguity fixes
-
-**Results After Fixes**:
-
-| Metric | Before Fixes | After Fixes | Change | % Change |
-|--------|--------------|-------------|--------|----------|
-| **Passed** | 40 | 61 | +21 | +52.5% |
-| **Failed** | 101 | 79 | -22 | -21.8% |
-| **Skipped** | 114 | 115 | +1 | +0.9% |
-| **Pass Rate** | 28.4% | 43.6% | +15.2% | +53.5% |
-
-**Key Achievement**: The two critical fixes unblocked **21 additional tests** (+52.5% improvement), enabling GPT-2 forward pass and core functionality.
-
-**What Improved**:
-- ✅ Forward pass now works
-- ✅ Backward pass functional
-- ✅ Model loading works
-- ✅ Basic inference functional
-- ✅ Training works (non-generation)
-- ✅ Conv1D layers operational
-- ✅ Attention reshaping fixed
-
-**Remaining Failures (79 tests)**:
-
-1. **Text Generation** (~40 failures):
-   - `generate()` method not implemented
-   - Beam search, sampling utilities missing
-   - Generation config and stopping criteria missing
-
-2. **Model Serialization** (~15 failures):
-   - SafeTensors edge cases
-   - Tied weights handling
-   - Device context management
-
-3. **Gradient Checkpointing** (~5 failures):
-   - Reentrant/non-reentrant modes not implemented
-
-4. **Model Offloading** (~5 failures):
-   - CPU/disk offload not implemented
-
-5. **Other Edge Cases** (~14 failures):
-   - Various advanced features
-
-**Impact on Other Models**:
-
-These fixes benefit all models using:
-- ✅ Conv1D layers (GPT-J, GPT-Neo, etc.)
-- ✅ Non-contiguous view operations
-- ✅ Matrix multiplication with bias (addmm pattern)
-
-**Updated Recommendations**:
-
-1. **Encoder-only models** (BERT, RoBERTa, Albert):
-   - ✅ **Production-ready** (79-98% pass rate)
-   - ✅ All core functionality works
-
-2. **Decoder-only models** (GPT-2, GPT-J, GPT-Neo):
-   - ✅ **Functional for non-generation workloads** (43.6% pass rate)
-   - ✅ Forward/backward pass, training, inference work
-   - ❌ Text generation not yet supported
-   - 💡 Use mindtorch v1 for generation workloads
-
-3. **Encoder-decoder models** (T5, BART):
-   - ❓ **Not yet tested**
-   - 🔮 Expected similar to BERT
-
-**Conclusion**: The fixes successfully improved GPT-2 from **completely blocked to functional**, achieving a 43.6% pass rate. Core functionality now works, enabling non-generation use cases like embeddings, classification, and feature extraction. The remaining failures are primarily due to missing generation utilities, which is expected and documented.
-
-**Status Update**:
-- ✅ Encoder-only models: Production-ready
-- ✅ Decoder-only models: Functional for non-generation workloads
-- 🔄 Next priority: Implement text generation utilities
-
----
-
-### Session Summary: 2026-02-06 - Comprehensive Testing Results
-
-**Models Tested**: Albert, BERT, GPT-2
-
-**Final Results**:
-
-| Model | Architecture | Pass Rate | Status | Notes |
-|-------|-------------|-----------|--------|-------|
-| **Albert** | Encoder | 98.2% (54/55) | ✅ Excellent | Only 1 edge case failure |
-| **BERT** | Encoder | 79.1% (110/139) | ✅ Good | Missing generation utilities |
-| **GPT-2** | Decoder | 43.6% (61/140) | ✅ Functional | Core works, generation missing |
-
-**Total Tests**: 603 tests across 3 models
-**Total Passed**: 225 tests (37.3% overall)
-**Total Failed**: 109 tests (18.1% overall)
-**Total Skipped**: 269 tests (44.6% overall)
-
-**Critical Bugs Fixed**:
-
-1. ✅ **Missing `torch.addmm`** - Implemented in `_functional.py`
-2. ✅ **Tensor.view() contiguity** - Fixed in `_tensor.py`
-
-**Key Achievements**:
-
-1. ✅ torch_proxy system validated across all models
-2. ✅ Encoder-only models production-ready (79-98% pass rate)
-3. ✅ Decoder-only models functional (43.6% pass rate)
-4. ✅ No transformers-specific hacks - clean implementation
-5. ✅ 52.5% improvement in GPT-2 pass rate
-6. ✅ Comprehensive documentation
-
-**Architecture Insights**:
-
-- **Encoder-only** (Albert, BERT): Excellent compatibility, production-ready
-- **Decoder-only** (GPT-2): Functional for non-generation, needs generation utilities
-- **Encoder-decoder** (T5, BART): Not yet tested
-
-**Missing Features** (Priority Order):
-
-1. **High**: Text generation utilities (blocks 40+ tests)
-2. **Medium**: Gradient checkpointing (blocks 3-5 tests)
-3. **Medium**: Model serialization improvements (blocks 6-15 tests)
-4. **Low**: Model offloading (blocks 3-5 tests)
-
-**Production Readiness**:
-
-- ✅ **Encoder-only models**: Ready for production use
-  - Use cases: Classification, NER, QA, embeddings, fine-tuning
-  - Confidence: High (79-98% test coverage)
-
-- ✅ **Decoder-only models**: Ready for non-generation use
-  - Use cases: Embeddings, feature extraction, classification
-  - Not ready: Text generation, completion, chat
-  - Confidence: Medium (43.6% test coverage)
-
-**Next Steps**:
-
-1. **Immediate**: Document results ✅ DONE
-2. **Short-term**: Implement text generation utilities
-3. **Medium-term**: Test encoder-decoder models (T5, BART)
-4. **Long-term**: Implement gradient checkpointing and offloading
-
-**Commit**: 0db45246 - fix(mindtorch_v2): add addmm and fix view() contiguity for GPT-2 support
-
-**Conclusion**: mindtorch_v2 is a solid PyTorch compatibility layer with **excellent support for encoder-only models** (79-98% pass rate) and **functional support for decoder-only models** (43.6% pass rate). The torch_proxy system works well, and the implementation remains clean without transformers-specific hacks. Main remaining work is implementing text generation utilities.
-
----
-
-### Session: 2026-02-06 - GPT-2 Testing on Ascend NPU
-
-**Test Scope**: Full GPT-2 test suite on Ascend NPU after fixing where() operation
-
-**Bug Fixed**: Ascend where() operation - boolean condition requirement
-
-**Error**:
-```
-RuntimeError: aclnnSWhereGetWorkspaceSize call failed
-AclNN_Parameter_Error: Tensor condition not implemented for DT_FLOAT,
-should be in dtype support list [DT_BOOL,DT_UINT8,]
-```
-
-**Fix**: Cast condition tensor to bool dtype before calling where operation
-```python
-# Ensure condition is boolean (Ascend requires DT_BOOL or DT_UINT8)
-if ms_cond.dtype != mindspore.bool_:
-    ms_cond = cast_op(ms_cond, mindspore.bool_)
-```
-
-**Location**: `src/mindtorch_v2/_backends/ascend.py:618-638`
-
-**Test Results on Ascend NPU**:
-
-| Metric | Count | Percentage |
-|--------|-------|------------|
-| **PASSED** | 62 | 44.3% (of runnable) |
-| **FAILED** | 78 | 55.7% (of runnable) |
-| **SKIPPED** | 115 | 45.1% (of total) |
-| **TOTAL** | 255 | 100% |
-
-**Comparison: CPU vs Ascend**:
-
-| Metric | CPU | Ascend | Change |
-|--------|-----|--------|--------|
-| **Passed** | 61 | 62 | **+1** |
-| **Failed** | 79 | 78 | **-1** |
-| **Pass Rate** | 43.6% | 44.3% | **+0.7%** |
-
-**Key Findings**:
-
-✅ **What Works on Ascend**:
-- Forward pass
-- Backward pass
-- Model loading
-- Basic inference
-- Training (basic)
-- Attention mechanisms
-- Conv1D layers
-- where() operations (after fix)
-
-❌ **What Doesn't Work** (same as CPU):
-- Text generation (not implemented)
-- SDPA (not supported on Ascend)
-- Gradient checkpointing (not implemented)
-- Model offloading (not implemented)
-- Some serialization edge cases
-
-**Remaining Failures (78 tests)**:
-1. **Generation Tests** (~26 failures) - Expected, not yet implemented
-2. **SDPA Tests** (~26 failures) - Expected, SDPA not supported on Ascend
-3. **Serialization Tests** (~9 failures) - Known issues
-4. **Training Tests** (~5 failures) - Gradient checkpointing not implemented
-5. **Offloading Tests** (~3 failures) - Not implemented
-6. **Other Tests** (~9 failures) - Various edge cases
-
-**Conclusion**: GPT-2 on Ascend NPU achieves a **44.3% pass rate** (62/140 runnable tests), which is on par with CPU performance. The where() operation fix successfully resolved Ascend-specific issues with attention mechanisms. Core functionality works on Ascend for non-generation workloads.
-
-**Commit**: 85cb15d2 - fix(mindtorch_v2): fix where operation for Ascend - ensure boolean condition
-
-**Status**:
-- ✅ Core functionality works on Ascend
-- ✅ Ascend-specific issues resolved
-- ⚠️ Same limitations as CPU (generation, checkpointing, etc.)
-
----
+- **Tests not running**: Check MindSpore installation, verify device context, check PYTHONPATH, ensure conda env is activated
+- **Version mismatch**: `cd tests/transformers && git checkout tags/v4.57.5`
+- **Git push fails**: Check push access, uncommitted changes, branch existence on remote


### PR DESCRIPTION
## Summary
- Reduce CLAUDE.md from 1300 to 300 lines (77% reduction) by moving session logs to `.claude/logs/session-history.md`
- Add `mindtorch_v2` and `run_test_v2.py` to directory structure
- Add "Current Status" summary section with model pass rates
- Fix Git Agent force-push rule contradiction (clarify `--force-with-lease` exception for PR rebase)
- Remove duplicated conclusions/recommendations across sessions

## Test plan
- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Verify `.claude/logs/session-history.md` is accessible
- [ ] Confirm no functional code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)