### PR TITLE
feat(mindtorch_v2): add npu unary ops

### DIFF
--- a/docs/plans/2026-02-15-npu-unary-ops.md
+++ b/docs/plans/2026-02-15-npu-unary-ops.md
@@ -1,0 +1,237 @@
+# NPU Unary Ops (MindTorch v2) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add NPU kernels for CPU-supported unary ops (float16 + float32) using direct ACLNN bindings, without NumPy in the NPU execution path.
+
+**Architecture:** Extend ACLNN ctypes bindings for each op, implement NPU wrappers in `ops.py` via shared unary/binary helpers, and register kernels in the NPU backend. Tests live in `tests/mindtorch_v2/test_ops_npu.py` with NPU-only parameterized cases. No fallback to CPU or composed ops.
+
+**Tech Stack:** Python, ctypes, ACL runtime (`acl`), ACLNN shared libraries.
+
+---
+
+### Task 1: Add failing NPU unary op tests
+
+**Files:**
+- Modify: `tests/mindtorch_v2/test_ops_npu.py`
+
+**Step 1: Write the failing test**
+
+```python
+import pytest
+import mindtorch_v2 as torch
+import numpy as np
+
+
+@pytest.mark.parametrize(
+    "op_name, numpy_fn",
+    [
+        ("abs", np.abs),
+        ("neg", np.negative),
+        ("exp", np.exp),
+        ("log", np.log),
+        ("sqrt", np.sqrt),
+        ("rsqrt", lambda x: 1.0 / np.sqrt(x)),
+        ("sin", np.sin),
+        ("cos", np.cos),
+        ("tanh", np.tanh),
+        ("sigmoid", lambda x: 1.0 / (1.0 + np.exp(-x))),
+        ("ceil", np.ceil),
+        ("floor", np.floor),
+        ("round", np.round),
+        ("trunc", np.trunc),
+        ("frac", lambda x: x - np.trunc(x)),
+        ("log2", np.log2),
+        ("log10", np.log10),
+        ("exp2", np.exp2),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float32])
+def test_npu_unary_ops(op_name, numpy_fn, dtype):
+    if not torch.npu.is_available():
+        pytest.skip("NPU not available")
+    data = np.array([-2.0, -0.5, 0.5, 2.0], dtype=np.float32)
+    x = torch.tensor(data, device="npu", dtype=dtype)
+    op = getattr(torch, op_name)
+    out = op(x)
+    expected = numpy_fn(data).astype(np.float32)
+    assert out.device.type == "npu"
+    assert np.allclose(out.to("cpu").numpy().astype(np.float32), expected, atol=1e-3, rtol=1e-3)
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/mindtorch_v2/test_ops_npu.py::test_npu_unary_ops -v`
+Expected: FAIL (missing NPU kernels).
+
+**Step 3: Write minimal implementation**
+
+_No production code yet (TDD)._
+
+**Step 4: Run test to verify it fails**
+
+Run: `pytest tests/mindtorch_v2/test_ops_npu.py::test_npu_unary_ops -v`
+Expected: FAIL.
+
+**Step 5: Commit**
+
+_No commit (tests failing)._ 
+
+---
+
+### Task 2: Bind ACLNN unary ops
+
+**Files:**
+- Modify: `src/mindtorch_v2/_backends/npu/aclnn.py`
+
+**Step 1: Write the failing test**
+
+Reuse failing test from Task 1.
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/mindtorch_v2/test_ops_npu.py::test_npu_unary_ops -v`
+Expected: FAIL.
+
+**Step 3: Write minimal implementation**
+
+Add ACLNN bindings in `AclnnBindings.__init__` for each op:
+
+```python
+self.aclnn_abs_get_workspace = _optional_symbol(..., "aclnnAbsGetWorkspaceSize", ...)
+self.aclnn_abs = _optional_symbol(..., "aclnnAbs", ...)
+# repeat for neg/exp/log/sqrt/rsqrt/sin/cos/tanh/sigmoid/ceil/floor/round/trunc/frac/log2/log10/exp2
+```
+
+Then add wrappers matching existing patterns:
+
+```python
+def abs(self_ptr, out_ptr, shape, stride, dtype, runtime, stream=None):
+    # mirror aclnn.add/relU pattern with GetWorkspaceSize + Execute + cleanup
+```
+
+**Step 4: Run test to verify it fails**
+
+Run: `pytest tests/mindtorch_v2/test_ops_npu.py::test_npu_unary_ops -v`
+Expected: FAIL (kernel not registered yet).
+
+**Step 5: Commit**
+
+_No commit (tests failing)._ 
+
+---
+
+### Task 3: Implement NPU unary ops + register kernels
+
+**Files:**
+- Modify: `src/mindtorch_v2/_backends/npu/ops.py`
+- Modify: `src/mindtorch_v2/_backends/npu/__init__.py`
+
+**Step 1: Write the failing test**
+
+Reuse failing test from Task 1.
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/mindtorch_v2/test_ops_npu.py::test_npu_unary_ops -v`
+Expected: FAIL.
+
+**Step 3: Write minimal implementation**
+
+Add helpers in `ops.py`:
+
+```python
+def _unary_op(a, fn):
+    runtime = npu_runtime.get_runtime((a.device.index or 0))
+    stream = npu_state.current_stream((a.device.index or 0))
+    if a.device.type != "npu":
+        raise ValueError("NPU unary op expects NPU tensors")
+    out_size = _numel(a.shape) * _dtype_itemsize(a.dtype)
+    out_ptr = npu_runtime._alloc_device(out_size, runtime=runtime)
+    storage = _unwrap_storage(a)
+    fn(storage.data_ptr(), out_ptr, a.shape, a.stride, a.dtype, runtime, stream=stream.stream)
+    out_storage = npu_typed_storage_from_ptr(out_ptr, _numel(a.shape), a.dtype, device=a.device)
+    return _wrap_tensor(out_storage, a.shape, a.stride)
+```
+
+Then define each op:
+
+```python
+def abs(a): return _unary_op(a, aclnn.abs)
+# ... for neg/exp/log/sqrt/rsqrt/sin/cos/tanh/sigmoid/ceil/floor/round/trunc/frac/log2/log10/exp2
+```
+
+Register kernels in `npu/__init__.py` using meta infer:
+
+```python
+registry.register("abs", "npu", abs, meta=meta_infer.infer_unary)
+# ... etc
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest tests/mindtorch_v2/test_ops_npu.py::test_npu_unary_ops -v`
+Expected: PASS (or skip if NPU missing).
+
+**Step 5: Commit**
+
+```bash
+git add src/mindtorch_v2/_backends/npu/aclnn.py src/mindtorch_v2/_backends/npu/ops.py src/mindtorch_v2/_backends/npu/__init__.py tests/mindtorch_v2/test_ops_npu.py
+git commit -m "feat(mindtorch_v2): add npu unary ops"
+```
+
+---
+
+### Task 4: Add NPU pow (binary) + tests
+
+**Files:**
+- Modify: `tests/mindtorch_v2/test_ops_npu.py`
+- Modify: `src/mindtorch_v2/_backends/npu/aclnn.py`
+- Modify: `src/mindtorch_v2/_backends/npu/ops.py`
+- Modify: `src/mindtorch_v2/_backends/npu/__init__.py`
+
+**Step 1: Write the failing test**
+
+```python
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float32])
+def test_npu_pow(dtype):
+    if not torch.npu.is_available():
+        pytest.skip("NPU not available")
+    base = torch.tensor([1.0, 2.0, 3.0], device="npu", dtype=dtype)
+    exp = torch.tensor([2.0, 3.0, 0.5], device="npu", dtype=dtype)
+    out = torch.pow(base, exp)
+    expected = np.power(base.to("cpu").numpy(), exp.to("cpu").numpy())
+    assert np.allclose(out.to("cpu").numpy().astype(np.float32), expected.astype(np.float32), atol=1e-3, rtol=1e-3)
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/mindtorch_v2/test_ops_npu.py::test_npu_pow -v`
+Expected: FAIL.
+
+**Step 3: Write minimal implementation**
+
+Bind ACLNN pow symbols and wrapper, then implement in `ops.py` via `_binary_op` helper:
+
+```python
+def _binary_op(a, b, fn):
+    # validate device/dtype, allocate out, call fn(self_ptr, other_ptr, out_ptr, shape, stride, dtype, runtime, stream)
+```
+
+Register kernel:
+
+```python
+registry.register("pow", "npu", pow, meta=meta_infer.infer_binary)
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest tests/mindtorch_v2/test_ops_npu.py::test_npu_pow -v`
+Expected: PASS (or skip if NPU missing).
+
+**Step 5: Commit**
+
+```bash
+git add src/mindtorch_v2/_backends/npu/aclnn.py src/mindtorch_v2/_backends/npu/ops.py src/mindtorch_v2/_backends/npu/__init__.py tests/mindtorch_v2/test_ops_npu.py
+git commit -m "feat(mindtorch_v2): add npu pow"
+```

--- a/src/mindtorch_v2/_backends/npu/__init__.py
+++ b/src/mindtorch_v2/_backends/npu/__init__.py
@@ -3,7 +3,38 @@ from ..common import view as view_backend
 from ..meta import infer as meta_infer
 from ..._dispatch.registry import registry
 from .creation import empty_create, ones_create, tensor_create, zeros_create
-from .ops import add, matmul, mul, relu, sum_, add_, mul_, relu_, zero_, contiguous
+from .ops import (
+    abs,
+    add,
+    ceil,
+    cos,
+    exp,
+    exp2,
+    floor,
+    frac,
+    log,
+    log10,
+    log2,
+    matmul,
+    mul,
+    neg,
+    pow,
+    relu,
+    round,
+    rsqrt,
+    sigmoid,
+    sin,
+    sqrt,
+    sum_,
+    tan,
+    tanh,
+    trunc,
+    add_,
+    mul_,
+    relu_,
+    zero_,
+    contiguous,
+)
 from .runtime import is_available, _model_dir, _probe_model_dirs
 from . import allocator
 
@@ -13,6 +44,26 @@ registry.register("matmul", "npu", matmul, meta=meta_infer.infer_matmul)
 registry.register("relu", "npu", relu, meta=meta_infer.infer_unary)
 registry.register("contiguous", "npu", contiguous, meta=meta_infer.infer_unary)
 registry.register("sum", "npu", sum_, meta=meta_infer.infer_sum)
+registry.register("abs", "npu", abs, meta=meta_infer.infer_unary)
+registry.register("neg", "npu", neg, meta=meta_infer.infer_unary)
+registry.register("exp", "npu", exp, meta=meta_infer.infer_unary)
+registry.register("log", "npu", log, meta=meta_infer.infer_unary)
+registry.register("sqrt", "npu", sqrt, meta=meta_infer.infer_unary)
+registry.register("rsqrt", "npu", rsqrt, meta=meta_infer.infer_unary)
+registry.register("sin", "npu", sin, meta=meta_infer.infer_unary)
+registry.register("cos", "npu", cos, meta=meta_infer.infer_unary)
+registry.register("tan", "npu", tan, meta=meta_infer.infer_unary)
+registry.register("tanh", "npu", tanh, meta=meta_infer.infer_unary)
+registry.register("sigmoid", "npu", sigmoid, meta=meta_infer.infer_unary)
+registry.register("floor", "npu", floor, meta=meta_infer.infer_unary)
+registry.register("ceil", "npu", ceil, meta=meta_infer.infer_unary)
+registry.register("round", "npu", round, meta=meta_infer.infer_unary)
+registry.register("trunc", "npu", trunc, meta=meta_infer.infer_unary)
+registry.register("frac", "npu", frac, meta=meta_infer.infer_unary)
+registry.register("log2", "npu", log2, meta=meta_infer.infer_unary)
+registry.register("log10", "npu", log10, meta=meta_infer.infer_unary)
+registry.register("exp2", "npu", exp2, meta=meta_infer.infer_unary)
+registry.register("pow", "npu", pow, meta=meta_infer.infer_binary)
 registry.register("add_", "npu", add_, meta=meta_infer.infer_binary)
 registry.register("mul_", "npu", mul_, meta=meta_infer.infer_binary)
 registry.register("relu_", "npu", relu_, meta=meta_infer.infer_unary)

--- a/src/mindtorch_v2/_backends/npu/aclnn.py
+++ b/src/mindtorch_v2/_backends/npu/aclnn.py
@@ -171,6 +171,258 @@ class AclnnBindings:
             ctypes.c_int32,
             [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
         )
+        self.aclnn_abs_get_workspace = _optional_symbol(
+            libs,
+            "aclnnAbsGetWorkspaceSize",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_void_p)],
+        )
+        self.aclnn_abs = _optional_symbol(
+            libs,
+            "aclnnAbs",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
+        self.aclnn_neg_get_workspace = _optional_symbol(
+            libs,
+            "aclnnNegGetWorkspaceSize",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_void_p)],
+        )
+        self.aclnn_neg = _optional_symbol(
+            libs,
+            "aclnnNeg",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
+        self.aclnn_exp_get_workspace = _optional_symbol(
+            libs,
+            "aclnnExpGetWorkspaceSize",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_void_p)],
+        )
+        self.aclnn_exp = _optional_symbol(
+            libs,
+            "aclnnExp",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
+        self.aclnn_log_get_workspace = _optional_symbol(
+            libs,
+            "aclnnLogGetWorkspaceSize",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_void_p)],
+        )
+        self.aclnn_log = _optional_symbol(
+            libs,
+            "aclnnLog",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
+        self.aclnn_sqrt_get_workspace = _optional_symbol(
+            libs,
+            "aclnnSqrtGetWorkspaceSize",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_void_p)],
+        )
+        self.aclnn_sqrt = _optional_symbol(
+            libs,
+            "aclnnSqrt",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
+        self.aclnn_rsqrt_get_workspace = _optional_symbol(
+            libs,
+            "aclnnRsqrtGetWorkspaceSize",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_void_p)],
+        )
+        self.aclnn_rsqrt = _optional_symbol(
+            libs,
+            "aclnnRsqrt",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
+        self.aclnn_sin_get_workspace = _optional_symbol(
+            libs,
+            "aclnnSinGetWorkspaceSize",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_void_p)],
+        )
+        self.aclnn_sin = _optional_symbol(
+            libs,
+            "aclnnSin",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
+        self.aclnn_cos_get_workspace = _optional_symbol(
+            libs,
+            "aclnnCosGetWorkspaceSize",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_void_p)],
+        )
+        self.aclnn_cos = _optional_symbol(
+            libs,
+            "aclnnCos",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
+        self.aclnn_tan_get_workspace = _optional_symbol(
+            libs,
+            "aclnnTanGetWorkspaceSize",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_void_p)],
+        )
+        self.aclnn_tan = _optional_symbol(
+            libs,
+            "aclnnTan",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
+        self.aclnn_tanh_get_workspace = _optional_symbol(
+            libs,
+            "aclnnTanhGetWorkspaceSize",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_void_p)],
+        )
+        self.aclnn_tanh = _optional_symbol(
+            libs,
+            "aclnnTanh",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
+        self.aclnn_sigmoid_get_workspace = _optional_symbol(
+            libs,
+            "aclnnSigmoidGetWorkspaceSize",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_void_p)],
+        )
+        self.aclnn_sigmoid = _optional_symbol(
+            libs,
+            "aclnnSigmoid",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
+        self.aclnn_floor_get_workspace = _optional_symbol(
+            libs,
+            "aclnnFloorGetWorkspaceSize",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_void_p)],
+        )
+        self.aclnn_floor = _optional_symbol(
+            libs,
+            "aclnnFloor",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
+        self.aclnn_ceil_get_workspace = _optional_symbol(
+            libs,
+            "aclnnCeilGetWorkspaceSize",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_void_p)],
+        )
+        self.aclnn_ceil = _optional_symbol(
+            libs,
+            "aclnnCeil",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
+        self.aclnn_round_get_workspace = _optional_symbol(
+            libs,
+            "aclnnRoundGetWorkspaceSize",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_void_p)],
+        )
+        self.aclnn_round = _optional_symbol(
+            libs,
+            "aclnnRound",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
+        self.aclnn_trunc_get_workspace = _optional_symbol(
+            libs,
+            "aclnnTruncGetWorkspaceSize",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_void_p)],
+        )
+        self.aclnn_trunc = _optional_symbol(
+            libs,
+            "aclnnTrunc",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
+        self.aclnn_frac_get_workspace = _optional_symbol(
+            libs,
+            "aclnnFracGetWorkspaceSize",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_void_p)],
+        )
+        self.aclnn_frac = _optional_symbol(
+            libs,
+            "aclnnFrac",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
+        self.aclnn_log2_get_workspace = _optional_symbol(
+            libs,
+            "aclnnLog2GetWorkspaceSize",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_void_p)],
+        )
+        self.aclnn_log2 = _optional_symbol(
+            libs,
+            "aclnnLog2",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
+        self.aclnn_log10_get_workspace = _optional_symbol(
+            libs,
+            "aclnnLog10GetWorkspaceSize",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_void_p)],
+        )
+        self.aclnn_log10 = _optional_symbol(
+            libs,
+            "aclnnLog10",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
+        self.aclnn_exp2_get_workspace = _optional_symbol(
+            libs,
+            "aclnnExp2GetWorkspaceSize",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_void_p)],
+        )
+        self.aclnn_exp2 = _optional_symbol(
+            libs,
+            "aclnnExp2",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
+        self.aclnn_pow_tensor_tensor_get_workspace = _optional_symbol(
+            libs,
+            "aclnnPowTensorTensorGetWorkspaceSize",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_void_p)],
+        )
+        self.aclnn_pow_tensor_tensor = _optional_symbol(
+            libs,
+            "aclnnPowTensorTensor",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
+        self.aclnn_pow_tensor_scalar_get_workspace = _optional_symbol(
+            libs,
+            "aclnnPowTensorScalarGetWorkspaceSize",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_void_p)],
+        )
+        self.aclnn_pow_tensor_scalar = _optional_symbol(
+            libs,
+            "aclnnPowTensorScalar",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
         self.aclnn_reduce_sum_get_workspace = _bind_symbol(
             libs,
             "aclnnReduceSumGetWorkspaceSize",
@@ -770,6 +1022,313 @@ def reduce_sum(self_ptr, out_ptr, shape, stride, dtype, dims, keepdim, runtime, 
         if workspace is not None:
             runtime.defer_free(workspace)
         _ = (self_keep, out_keep, dim_array)
+
+
+def _unary_call(bindings, name, get_workspace_fn, exec_fn, self_ptr, out_ptr, shape, stride, dtype, runtime, stream):
+    if get_workspace_fn is None or exec_fn is None:
+        raise RuntimeError(f"{name} symbols not available")
+    self_tensor, self_keep = _create_tensor(bindings, shape, stride, dtype, self_ptr)
+    out_tensor, out_keep = _create_tensor(bindings, shape, stride, dtype, out_ptr)
+    executor = ctypes.c_void_p()
+    workspace_size = ctypes.c_uint64(0)
+    workspace = None
+    try:
+        ret = get_workspace_fn(
+            self_tensor,
+            out_tensor,
+            ctypes.byref(workspace_size),
+            ctypes.byref(executor),
+        )
+        if ret != 0:
+            raise RuntimeError(f"{name}GetWorkspaceSize failed: {ret}")
+        if workspace_size.value:
+            workspace_ptr, ret = acl.rt.malloc(int(workspace_size.value), 0)
+            if ret != 0:
+                raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+            workspace = workspace_ptr
+        ret = exec_fn(
+            ctypes.c_void_p(0 if workspace is None else int(workspace)),
+            ctypes.c_uint64(workspace_size.value),
+            executor,
+            ctypes.c_void_p(int(runtime.stream if stream is None else stream)),
+        )
+        if ret != 0:
+            raise RuntimeError(f"{name} failed: {ret}")
+        _maybe_sync(runtime)
+    finally:
+        _defer_executor(executor)
+        bindings.acl_destroy_tensor(self_tensor)
+        bindings.acl_destroy_tensor(out_tensor)
+        if workspace is not None:
+            runtime.defer_free(workspace)
+        _ = (self_keep, out_keep)
+
+
+def abs(self_ptr, out_ptr, shape, stride, dtype, runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    return _unary_call(bindings, "aclnnAbs", bindings.aclnn_abs_get_workspace, bindings.aclnn_abs,
+                       self_ptr, out_ptr, shape, stride, dtype, runtime, stream)
+
+
+def neg(self_ptr, out_ptr, shape, stride, dtype, runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    return _unary_call(bindings, "aclnnNeg", bindings.aclnn_neg_get_workspace, bindings.aclnn_neg,
+                       self_ptr, out_ptr, shape, stride, dtype, runtime, stream)
+
+
+def exp(self_ptr, out_ptr, shape, stride, dtype, runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    return _unary_call(bindings, "aclnnExp", bindings.aclnn_exp_get_workspace, bindings.aclnn_exp,
+                       self_ptr, out_ptr, shape, stride, dtype, runtime, stream)
+
+
+def log(self_ptr, out_ptr, shape, stride, dtype, runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    return _unary_call(bindings, "aclnnLog", bindings.aclnn_log_get_workspace, bindings.aclnn_log,
+                       self_ptr, out_ptr, shape, stride, dtype, runtime, stream)
+
+
+def sqrt(self_ptr, out_ptr, shape, stride, dtype, runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    return _unary_call(bindings, "aclnnSqrt", bindings.aclnn_sqrt_get_workspace, bindings.aclnn_sqrt,
+                       self_ptr, out_ptr, shape, stride, dtype, runtime, stream)
+
+
+def rsqrt(self_ptr, out_ptr, shape, stride, dtype, runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    return _unary_call(bindings, "aclnnRsqrt", bindings.aclnn_rsqrt_get_workspace, bindings.aclnn_rsqrt,
+                       self_ptr, out_ptr, shape, stride, dtype, runtime, stream)
+
+
+def sin(self_ptr, out_ptr, shape, stride, dtype, runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    return _unary_call(bindings, "aclnnSin", bindings.aclnn_sin_get_workspace, bindings.aclnn_sin,
+                       self_ptr, out_ptr, shape, stride, dtype, runtime, stream)
+
+
+def cos(self_ptr, out_ptr, shape, stride, dtype, runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    return _unary_call(bindings, "aclnnCos", bindings.aclnn_cos_get_workspace, bindings.aclnn_cos,
+                       self_ptr, out_ptr, shape, stride, dtype, runtime, stream)
+
+
+def tan(self_ptr, out_ptr, shape, stride, dtype, runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    return _unary_call(bindings, "aclnnTan", bindings.aclnn_tan_get_workspace, bindings.aclnn_tan,
+                       self_ptr, out_ptr, shape, stride, dtype, runtime, stream)
+
+
+def tanh(self_ptr, out_ptr, shape, stride, dtype, runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    return _unary_call(bindings, "aclnnTanh", bindings.aclnn_tanh_get_workspace, bindings.aclnn_tanh,
+                       self_ptr, out_ptr, shape, stride, dtype, runtime, stream)
+
+
+def sigmoid(self_ptr, out_ptr, shape, stride, dtype, runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    return _unary_call(bindings, "aclnnSigmoid", bindings.aclnn_sigmoid_get_workspace, bindings.aclnn_sigmoid,
+                       self_ptr, out_ptr, shape, stride, dtype, runtime, stream)
+
+
+def floor(self_ptr, out_ptr, shape, stride, dtype, runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    return _unary_call(bindings, "aclnnFloor", bindings.aclnn_floor_get_workspace, bindings.aclnn_floor,
+                       self_ptr, out_ptr, shape, stride, dtype, runtime, stream)
+
+
+def ceil(self_ptr, out_ptr, shape, stride, dtype, runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    return _unary_call(bindings, "aclnnCeil", bindings.aclnn_ceil_get_workspace, bindings.aclnn_ceil,
+                       self_ptr, out_ptr, shape, stride, dtype, runtime, stream)
+
+
+def round(self_ptr, out_ptr, shape, stride, dtype, runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    return _unary_call(bindings, "aclnnRound", bindings.aclnn_round_get_workspace, bindings.aclnn_round,
+                       self_ptr, out_ptr, shape, stride, dtype, runtime, stream)
+
+
+def trunc(self_ptr, out_ptr, shape, stride, dtype, runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    return _unary_call(bindings, "aclnnTrunc", bindings.aclnn_trunc_get_workspace, bindings.aclnn_trunc,
+                       self_ptr, out_ptr, shape, stride, dtype, runtime, stream)
+
+
+def frac(self_ptr, out_ptr, shape, stride, dtype, runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    return _unary_call(bindings, "aclnnFrac", bindings.aclnn_frac_get_workspace, bindings.aclnn_frac,
+                       self_ptr, out_ptr, shape, stride, dtype, runtime, stream)
+
+
+def log2(self_ptr, out_ptr, shape, stride, dtype, runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    return _unary_call(bindings, "aclnnLog2", bindings.aclnn_log2_get_workspace, bindings.aclnn_log2,
+                       self_ptr, out_ptr, shape, stride, dtype, runtime, stream)
+
+
+def log10(self_ptr, out_ptr, shape, stride, dtype, runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    return _unary_call(bindings, "aclnnLog10", bindings.aclnn_log10_get_workspace, bindings.aclnn_log10,
+                       self_ptr, out_ptr, shape, stride, dtype, runtime, stream)
+
+
+def exp2(self_ptr, out_ptr, shape, stride, dtype, runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    return _unary_call(bindings, "aclnnExp2", bindings.aclnn_exp2_get_workspace, bindings.aclnn_exp2,
+                       self_ptr, out_ptr, shape, stride, dtype, runtime, stream)
+
+
+def pow_tensor_tensor(self_ptr, other_ptr, out_ptr, self_shape, self_stride, other_shape, other_stride,
+                      out_shape, out_stride, dtype, runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    if bindings.aclnn_pow_tensor_tensor_get_workspace is None or bindings.aclnn_pow_tensor_tensor is None:
+        raise RuntimeError("aclnnPowTensorTensor symbols not available")
+    self_tensor, self_keep = _create_tensor(bindings, self_shape, self_stride, dtype, self_ptr)
+    other_tensor, other_keep = _create_tensor(bindings, other_shape, other_stride, dtype, other_ptr)
+    out_tensor, out_keep = _create_tensor(bindings, out_shape, out_stride, dtype, out_ptr)
+    executor = ctypes.c_void_p()
+    workspace_size = ctypes.c_uint64(0)
+    workspace = None
+    try:
+        ret = bindings.aclnn_pow_tensor_tensor_get_workspace(
+            self_tensor,
+            other_tensor,
+            out_tensor,
+            ctypes.byref(workspace_size),
+            ctypes.byref(executor),
+        )
+        if ret != 0:
+            raise RuntimeError(f"aclnnPowTensorTensorGetWorkspaceSize failed: {ret}")
+        if workspace_size.value:
+            workspace_ptr, ret = acl.rt.malloc(int(workspace_size.value), 0)
+            if ret != 0:
+                raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+            workspace = workspace_ptr
+        ret = bindings.aclnn_pow_tensor_tensor(
+            ctypes.c_void_p(0 if workspace is None else int(workspace)),
+            ctypes.c_uint64(workspace_size.value),
+            executor,
+            ctypes.c_void_p(int(runtime.stream if stream is None else stream)),
+        )
+        if ret != 0:
+            raise RuntimeError(f"aclnnPowTensorTensor failed: {ret}")
+        _maybe_sync(runtime)
+    finally:
+        _defer_executor(executor)
+        bindings.acl_destroy_tensor(self_tensor)
+        bindings.acl_destroy_tensor(other_tensor)
+        bindings.acl_destroy_tensor(out_tensor)
+        if workspace is not None:
+            runtime.defer_free(workspace)
+        _ = (self_keep, other_keep, out_keep)
+
+
+def pow_tensor_scalar(self_ptr, scalar_value, out_ptr, shape, stride, dtype, runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    if bindings.aclnn_pow_tensor_scalar_get_workspace is None or bindings.aclnn_pow_tensor_scalar is None:
+        raise RuntimeError("aclnnPowTensorScalar symbols not available")
+    self_tensor, self_keep = _create_tensor(bindings, shape, stride, dtype, self_ptr)
+    out_tensor, out_keep = _create_tensor(bindings, shape, stride, dtype, out_ptr)
+    scalar, scalar_keep = _create_scalar(bindings, scalar_value, dtype)
+    executor = ctypes.c_void_p()
+    workspace_size = ctypes.c_uint64(0)
+    workspace = None
+    try:
+        ret = bindings.aclnn_pow_tensor_scalar_get_workspace(
+            self_tensor,
+            scalar,
+            out_tensor,
+            ctypes.byref(workspace_size),
+            ctypes.byref(executor),
+        )
+        if ret != 0:
+            raise RuntimeError(f"aclnnPowTensorScalarGetWorkspaceSize failed: {ret}")
+        if workspace_size.value:
+            workspace_ptr, ret = acl.rt.malloc(int(workspace_size.value), 0)
+            if ret != 0:
+                raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+            workspace = workspace_ptr
+        ret = bindings.aclnn_pow_tensor_scalar(
+            ctypes.c_void_p(0 if workspace is None else int(workspace)),
+            ctypes.c_uint64(workspace_size.value),
+            executor,
+            ctypes.c_void_p(int(runtime.stream if stream is None else stream)),
+        )
+        if ret != 0:
+            raise RuntimeError(f"aclnnPowTensorScalar failed: {ret}")
+        _maybe_sync(runtime)
+    finally:
+        _defer_executor(executor)
+        bindings.acl_destroy_tensor(self_tensor)
+        bindings.acl_destroy_tensor(out_tensor)
+        if scalar:
+            bindings.acl_destroy_scalar(scalar)
+        if workspace is not None:
+            runtime.defer_free(workspace)
+        _ = (self_keep, out_keep, scalar_keep)
 
 
 def matmul(a_ptr, b_ptr, out_ptr, a_shape, a_stride, b_shape, b_stride, out_shape, out_stride, dtype, runtime, stream=None):


### PR DESCRIPTION
## Summary
- add NPU unary ops via ACLNN (float16/float32)
- add NPU pow tensor/tensor and tensor/scalar
- extend NPU ops tests and add unary ops plan

## Test Plan
- [x] pytest tests/mindtorch_v2/test_ops_npu.py -v
