### PR TITLE
[310B] NPU trunc/frac fallback and dispatch fix

### DIFF
--- a/src/mindtorch_v2/_backends/npu/__init__.py
+++ b/src/mindtorch_v2/_backends/npu/__init__.py
@@ -18,6 +18,7 @@ from .ops import (
     matmul,
     mul,
     neg,
+    sign,
     pow,
     relu,
     round,
@@ -46,6 +47,7 @@ registry.register("contiguous", "npu", contiguous, meta=meta_infer.infer_unary)
 registry.register("sum", "npu", sum_, meta=meta_infer.infer_sum)
 registry.register("abs", "npu", abs, meta=meta_infer.infer_unary)
 registry.register("neg", "npu", neg, meta=meta_infer.infer_unary)
+registry.register("sign", "npu", sign, meta=meta_infer.infer_unary)
 registry.register("exp", "npu", exp, meta=meta_infer.infer_unary)
 registry.register("log", "npu", log, meta=meta_infer.infer_unary)
 registry.register("sqrt", "npu", sqrt, meta=meta_infer.infer_unary)

--- a/src/mindtorch_v2/_backends/npu/acl_loader.py
+++ b/src/mindtorch_v2/_backends/npu/acl_loader.py
@@ -1,4 +1,5 @@
 import ctypes
+import glob
 import os
 import sys
 import threading
@@ -23,6 +24,7 @@ _CANDIDATE_PYTHON_DIRS = (
 )
 
 _PRELOAD_LIBS = (
+    "libascend_protobuf.so",
     "libascendcl.so",
     "libascendcl_impl.so",
     "libopapi.so",
@@ -58,6 +60,13 @@ def _preload_libs(paths):
             candidate = os.path.join(base, lib)
             if os.path.exists(candidate):
                 ctypes.CDLL(candidate, mode=ctypes.RTLD_GLOBAL)
+                continue
+            if lib == "libascend_protobuf.so":
+                for match in sorted(glob.glob(candidate + "*")):
+                    if not os.path.isfile(match):
+                        continue
+                    ctypes.CDLL(match, mode=ctypes.RTLD_GLOBAL)
+                    break
 
 
 def _import_acl():

--- a/src/mindtorch_v2/_backends/npu/aclnn.py
+++ b/src/mindtorch_v2/_backends/npu/aclnn.py
@@ -303,6 +303,30 @@ class AclnnBindings:
             ctypes.c_int32,
             [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
         )
+        self.aclnn_sign_get_workspace = _optional_symbol(
+            libs,
+            "aclnnSignGetWorkspaceSize",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_void_p)],
+        )
+        self.aclnn_sign = _optional_symbol(
+            libs,
+            "aclnnSign",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
+        self.aclnn_signbit_get_workspace = _optional_symbol(
+            libs,
+            "aclnnSignbitGetWorkspaceSize",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_void_p)],
+        )
+        self.aclnn_signbit = _optional_symbol(
+            libs,
+            "aclnnSignbit",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
         self.aclnn_floor_get_workspace = _optional_symbol(
             libs,
             "aclnnFloorGetWorkspaceSize",
@@ -1082,6 +1106,24 @@ def neg(self_ptr, out_ptr, shape, stride, dtype, runtime, stream=None):
                        self_ptr, out_ptr, shape, stride, dtype, runtime, stream)
 
 
+def sign(self_ptr, out_ptr, shape, stride, dtype, runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    return _unary_call(bindings, "aclnnSign", bindings.aclnn_sign_get_workspace, bindings.aclnn_sign,
+                       self_ptr, out_ptr, shape, stride, dtype, runtime, stream)
+
+
+def signbit(self_ptr, out_ptr, shape, stride, dtype, runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    return _unary_call(bindings, "aclnnSignbit", bindings.aclnn_signbit_get_workspace, bindings.aclnn_signbit,
+                       self_ptr, out_ptr, shape, stride, dtype, runtime, stream)
+
+
 def exp(self_ptr, out_ptr, shape, stride, dtype, runtime, stream=None):
     global acl
     if acl is None:
@@ -1416,5 +1458,37 @@ def ones_zero_symbols_ok():
                 bindings.aclnn_inplace_zero,
             ]
         )
+    except Exception:
+        return False
+
+
+def trunc_symbols_ok():
+    try:
+        bindings = get_bindings()
+        return all([bindings.aclnn_trunc_get_workspace, bindings.aclnn_trunc])
+    except Exception:
+        return False
+
+
+def frac_symbols_ok():
+    try:
+        bindings = get_bindings()
+        return all([bindings.aclnn_frac_get_workspace, bindings.aclnn_frac])
+    except Exception:
+        return False
+
+
+def sign_symbols_ok():
+    try:
+        bindings = get_bindings()
+        return all([bindings.aclnn_sign_get_workspace, bindings.aclnn_sign])
+    except Exception:
+        return False
+
+
+def signbit_symbols_ok():
+    try:
+        bindings = get_bindings()
+        return all([bindings.aclnn_signbit_get_workspace, bindings.aclnn_signbit])
     except Exception:
         return False

--- a/src/mindtorch_v2/_dispatch/keys.py
+++ b/src/mindtorch_v2/_dispatch/keys.py
@@ -22,10 +22,13 @@ class DispatchKeySet(set):
         has_npu = False
         has_cpu = False
         requires_grad = False
+        saw_device = False
         for tensor in tensors:
             if not hasattr(tensor, "device"):
                 continue
-            dev_type = tensor.device.type
+            saw_device = True
+            dev = tensor.device
+            dev_type = dev.type if hasattr(dev, "type") else dev
             if dev_type == "meta":
                 has_meta = True
             elif dev_type == "npu":
@@ -34,7 +37,7 @@ class DispatchKeySet(set):
                 has_cpu = True
             if getattr(tensor, "requires_grad", False):
                 requires_grad = True
-        if not tensors and device is not None:
+        if (not saw_device) and device is not None:
             dev_type = device.type if hasattr(device, "type") else device
             if dev_type == "meta":
                 has_meta = True


### PR DESCRIPTION
## Summary
- Add NPU sign kernel and register it
- Fix dispatch key selection for explicit device on non-tensor inputs
- Add NPU-only trunc/frac fallback when aclnn returns 561103, keep direct aclnn ops when available
- Preload Ascend protobuf to avoid ACL ABI mismatch

## Testing
........................................................................ [ 29%]
........................................................................ [ 58%]
...............................................................s........ [ 87%]
..............................                                           [100%]
245 passed, 1 skipped in 7.13s
Result: 245 passed, 1 skipped
