### PR TITLE
cpu: add where op

### DIFF
--- a/docs/plans/ops-coverage.md
+++ b/docs/plans/ops-coverage.md
@@ -73,3 +73,4 @@ This document is about collaboration rules only (not defining the op scope).
 | `aten::amax` | CPU | done | - | numpy impl + meta + tests |
 | `aten::fmin` | CPU | done | - | numpy impl + meta + tests |
 | `aten::fmax` | CPU | done | - | numpy impl + meta + tests |
+| `aten::where` | CPU | done | - | numpy impl + meta + tests |

--- a/src/mindtorch_v2/__init__.py
+++ b/src/mindtorch_v2/__init__.py
@@ -21,7 +21,7 @@ from ._functional import pow, log2, log10, exp2, rsqrt
 from ._functional import sign, signbit, isnan, isinf, isfinite
 from ._functional import sinh, cosh, erf, erfc, softplus
 from ._functional import clamp, clamp_min, clamp_max, relu6, hardtanh
-from ._functional import min, max, amin, amax, fmin, fmax
+from ._functional import min, max, amin, amax, fmin, fmax, where
 from ._printing import set_printoptions, get_printoptions
 from ._dispatch import pipeline_context
 from ._backends import cpu
@@ -98,6 +98,7 @@ __all__ = [
     "amax",
     "fmin",
     "fmax",
+    "where",
     "sum",
     # printing
     "set_printoptions",

--- a/src/mindtorch_v2/_backends/cpu/__init__.py
+++ b/src/mindtorch_v2/_backends/cpu/__init__.py
@@ -55,6 +55,7 @@ from .ops import (
     amax,
     fmin,
     fmax,
+    where,
 )
 
 registry.register("add", "cpu", add, meta=meta_infer.infer_binary)
@@ -102,6 +103,7 @@ registry.register("amin", "cpu", amin, meta=meta_infer.infer_sum)
 registry.register("amax", "cpu", amax, meta=meta_infer.infer_sum)
 registry.register("fmin", "cpu", fmin, meta=meta_infer.infer_binary)
 registry.register("fmax", "cpu", fmax, meta=meta_infer.infer_binary)
+registry.register("where", "cpu", where, meta=meta_infer.infer_binary)
 registry.register("contiguous", "cpu", contiguous, meta=meta_infer.infer_unary)
 registry.register("sum", "cpu", sum_, meta=meta_infer.infer_sum)
 registry.register("add_", "cpu", add_, meta=meta_infer.infer_binary)

--- a/src/mindtorch_v2/_backends/cpu/ops.py
+++ b/src/mindtorch_v2/_backends/cpu/ops.py
@@ -263,3 +263,14 @@ def fmin(a, b):
 
 def fmax(a, b):
     return _from_numpy(np.fmax(_to_numpy(a), _to_numpy(b)), a.dtype, a.device)
+
+
+def where(cond, x, y):
+    cond_arr = _to_numpy(cond)
+    x_arr = _to_numpy(x)
+    if isinstance(y, Tensor):
+        y_arr = _to_numpy(y)
+    else:
+        y_arr = y
+    out = np.where(cond_arr, x_arr, y_arr)
+    return _from_numpy(out, x.dtype, x.device)

--- a/src/mindtorch_v2/_backends/meta/__init__.py
+++ b/src/mindtorch_v2/_backends/meta/__init__.py
@@ -14,6 +14,7 @@ from .ops import (
     _meta_clamp_min_meta,
     _meta_clamp_max_meta,
     _meta_hardtanh_meta,
+    _meta_where_meta,
     _meta_view_meta,
     _meta_contiguous_meta,
 )
@@ -63,6 +64,7 @@ registry.register("amin", "meta", _meta_sum_meta)
 registry.register("amax", "meta", _meta_sum_meta)
 registry.register("fmin", "meta", _meta_binary_meta)
 registry.register("fmax", "meta", _meta_binary_meta)
+registry.register("where", "meta", _meta_where_meta)
 registry.register("contiguous", "meta", _meta_contiguous_meta)
 registry.register("sum", "meta", _meta_sum_meta)
 registry.register("reshape", "meta", view_backend.reshape, meta=_meta_view_meta)

--- a/src/mindtorch_v2/_backends/meta/ops.py
+++ b/src/mindtorch_v2/_backends/meta/ops.py
@@ -41,6 +41,23 @@ def _meta_binary_or_scalar_meta(a, b):
     return _meta_tensor(shape, a.dtype, a.device)
 
 
+def _meta_where_meta(cond, x, y):
+    if hasattr(cond, "shape"):
+        cond_shape = cond.shape
+    else:
+        cond_shape = ()
+    if hasattr(x, "shape"):
+        x_shape = x.shape
+    else:
+        x_shape = ()
+    if hasattr(y, "shape"):
+        y_shape = y.shape
+    else:
+        y_shape = ()
+    shape = _broadcast_shape(_broadcast_shape(cond_shape, x_shape), y_shape)
+    return _meta_tensor(shape, x.dtype, x.device)
+
+
 def _meta_unary_meta(a):
     return _meta_tensor(a.shape, a.dtype, a.device)
 
@@ -128,6 +145,7 @@ def _meta_contiguous_meta(a):
 __all__ = [
     "_meta_binary_meta",
     "_meta_binary_or_scalar_meta",
+    "_meta_where_meta",
     "_meta_matmul_meta",
     "_meta_sum_meta",
     "_meta_transpose_meta",

--- a/src/mindtorch_v2/_functional.py
+++ b/src/mindtorch_v2/_functional.py
@@ -182,6 +182,10 @@ def fmin(a, b):
 def fmax(a, b):
     return dispatch("fmax", a.device.type, a, b)
 
+
+def where(cond, x, y):
+    return dispatch("where", x.device.type, cond, x, y)
+
 def sinh(a):
     return dispatch("sinh", a.device.type, a)
 

--- a/src/mindtorch_v2/_tensor.py
+++ b/src/mindtorch_v2/_tensor.py
@@ -29,6 +29,7 @@ from ._functional import relu6 as relu6_dispatch, hardtanh as hardtanh_dispatch
 from ._functional import min as min_dispatch, max as max_dispatch
 from ._functional import amin as amin_dispatch, amax as amax_dispatch
 from ._functional import fmin as fmin_dispatch, fmax as fmax_dispatch
+from ._functional import where as where_dispatch
 from ._functional import reshape as reshape_dispatch
 from ._functional import transpose as transpose_dispatch, view as view_dispatch, to as to_dispatch
 from ._autograd.engine import backward as _backward
@@ -564,6 +565,9 @@ class Tensor:
 
     def fmax(self, other):
         return fmax_dispatch(self, other)
+
+    def where(self, other, y):
+        return where_dispatch(self, other, y)
     def sum(self, dim=None, keepdim=False):
         return sum(self, dim=dim, keepdim=keepdim)
 

--- a/tests/mindtorch_v2/test_meta_device.py
+++ b/tests/mindtorch_v2/test_meta_device.py
@@ -75,6 +75,7 @@ def test_meta_unary_elementwise_ops_shape():
         lambda t: torch.max(t, t),
         lambda t: torch.fmin(t, t),
         lambda t: torch.fmax(t, t),
+        lambda t: torch.where(t, t, t),
     ):
         out = op(x)
         assert out.device.type == "meta"

--- a/tests/mindtorch_v2/test_ops_cpu.py
+++ b/tests/mindtorch_v2/test_ops_cpu.py
@@ -302,3 +302,18 @@ def test_fmax_cpu():
     y = torch.tensor([0.5, 1.0, float('nan')])
     expected = np.fmax(x.numpy(), y.numpy())
     np.testing.assert_allclose(torch.fmax(x, y).numpy(), expected)
+
+
+def test_where_scalar_cpu():
+    cond = torch.tensor([True, False, True])
+    x = torch.tensor([1.0, 2.0, 3.0])
+    expected = np.where(cond.numpy(), x.numpy(), 0.5)
+    np.testing.assert_allclose(torch.where(cond, x, 0.5).numpy(), expected)
+
+
+def test_where_tensor_cpu():
+    cond = torch.tensor([True, False, True])
+    x = torch.tensor([1.0, 2.0, 3.0])
+    y = torch.tensor([3.0, 2.0, 1.0])
+    expected = np.where(cond.numpy(), x.numpy(), y.numpy())
+    np.testing.assert_allclose(torch.where(cond, x, y).numpy(), expected)


### PR DESCRIPTION
## Summary
- add where CPU op with scalar/tensor support and meta kernel
- update ops coverage table

## Test Plan
- [x] pytest tests/mindtorch_v2/test_ops_cpu.py::test_where_scalar_cpu tests/mindtorch_v2/test_ops_cpu.py::test_where_tensor_cpu tests/mindtorch_v2/test_meta_device.py::test_meta_unary_elementwise_ops_shape -q