### PR TITLE
fix: align tensor where signature

### DIFF
--- a/src/mindtorch_v2/_tensor.py
+++ b/src/mindtorch_v2/_tensor.py
@@ -568,8 +568,8 @@ class Tensor:
     def fmax(self, other):
         return fmax_dispatch(self, other)
 
-    def where(self, other, y):
-        return where_dispatch(self, other, y)
+    def where(self, condition, other):
+        return where_dispatch(condition, self, other)
 
     def atan(self):
         return atan_dispatch(self)

--- a/tests/mindtorch_v2/test_ops_cpu.py
+++ b/tests/mindtorch_v2/test_ops_cpu.py
@@ -319,6 +319,21 @@ def test_where_tensor_cpu():
     np.testing.assert_allclose(torch.where(cond, x, y).numpy(), expected)
 
 
+def test_tensor_where_cpu():
+    cond = torch.tensor([True, False, True])
+    x = torch.tensor([1.0, 2.0, 3.0])
+    y = torch.tensor([3.0, 2.0, 1.0])
+    expected = np.where(cond.numpy(), x.numpy(), y.numpy())
+    np.testing.assert_allclose(x.where(cond, y).numpy(), expected)
+
+
+def test_tensor_where_scalar_cpu():
+    cond = torch.tensor([True, False, True])
+    x = torch.tensor([1.0, 2.0, 3.0])
+    expected = np.where(cond.numpy(), x.numpy(), 0.5)
+    np.testing.assert_allclose(x.where(cond, 0.5).numpy(), expected)
+
+
 def test_atan_cpu():
     x = torch.tensor([-1.0, 0.0, 1.0])
     expected = np.arctan(x.numpy())


### PR DESCRIPTION
## Summary
- align Tensor.where signature with torch.where(cond, self, other)
- add coverage for tensor where variants

## Test Plan
- [x] pytest tests/mindtorch_v2/test_ops_cpu.py::test_tensor_where_cpu tests/mindtorch_v2/test_ops_cpu.py::test_tensor_where_scalar_cpu -q