### PR TITLE
v2-distributed: add stub classes for FSDP, DTensor, DeviceMesh

### DIFF
--- a/src/mindtorch_v2/distributed/__init__.py
+++ b/src/mindtorch_v2/distributed/__init__.py
@@ -16,6 +16,7 @@ from ._object_collectives import (
     broadcast_object_list, all_gather_object,
     gather_object, scatter_object_list,
 )
+from .device_mesh import init_device_mesh
 from . import nn
 
 # ---------------------------------------------------------------------------
@@ -645,6 +646,7 @@ __all__ = [
     # Sub-groups
     "new_group", "new_subgroups", "new_subgroups_by_enumeration",
     "split_group",
+    "init_device_mesh",
     # Misc
     "supports_complex",
     "default_pg_timeout", "get_debug_level",

--- a/src/mindtorch_v2/distributed/_tensor/__init__.py
+++ b/src/mindtorch_v2/distributed/_tensor/__init__.py
@@ -1,0 +1,1 @@
+"""torch.distributed._tensor stub."""

--- a/src/mindtorch_v2/distributed/_tensor/experimental.py
+++ b/src/mindtorch_v2/distributed/_tensor/experimental.py
@@ -1,0 +1,7 @@
+"""torch.distributed._tensor.experimental stub."""
+from contextlib import contextmanager
+
+
+@contextmanager
+def implicit_replication():
+    yield

--- a/src/mindtorch_v2/distributed/device_mesh.py
+++ b/src/mindtorch_v2/distributed/device_mesh.py
@@ -1,5 +1,14 @@
 """torch.distributed.device_mesh stub - not available in mindtorch_v2."""
 
+
+class DeviceMesh:
+    pass
+
+
+def init_device_mesh(*args, **kwargs):
+    raise NotImplementedError("DeviceMesh is not available in mindtorch_v2.")
+
+
 def __getattr__(name):
     raise AttributeError(
         f"module 'torch.distributed.device_mesh' has no attribute '{name}'. "

--- a/src/mindtorch_v2/distributed/fsdp.py
+++ b/src/mindtorch_v2/distributed/fsdp.py
@@ -1,5 +1,29 @@
 """torch.distributed.fsdp stub - not available in mindtorch_v2."""
 
+
+class FullyShardedDataParallel:
+    def __init__(self, *args, **kwargs):
+        raise RuntimeError("FSDP is not available in mindtorch_v2.")
+
+
+class FullStateDictConfig:
+    pass
+
+
+class FullOptimStateDictConfig:
+    pass
+
+
+class StateDictType:
+    FULL_STATE_DICT = 0
+
+
+class ShardingStrategy:
+    FULL_SHARD = 0
+    SHARD_GRAD_OP = 1
+    NO_SHARD = 2
+
+
 def __getattr__(name):
     raise AttributeError(
         f"module 'torch.distributed.fsdp' has no attribute '{name}'. "

--- a/src/mindtorch_v2/distributed/tensor.py
+++ b/src/mindtorch_v2/distributed/tensor.py
@@ -1,5 +1,22 @@
 """torch.distributed.tensor stub - not available in mindtorch_v2."""
 
+
+class DTensor:
+    pass
+
+
+class Replicate:
+    pass
+
+
+class Shard:
+    pass
+
+
+class Placement:
+    pass
+
+
 def __getattr__(name):
     raise AttributeError(
         f"module 'torch.distributed.tensor' has no attribute '{name}'. "


### PR DESCRIPTION
## Summary
- Replace `__getattr__`-only stubs in `fsdp.py`, `tensor.py`, `device_mesh.py` with importable stub classes so unguarded imports (e.g. `from torch.distributed.fsdp import FullyShardedDataParallel` in `trainer_seq2seq.py`) succeed at import time
- Add `_tensor/experimental.py` with `implicit_replication` no-op context manager
- Expose `init_device_mesh` via `torch.distributed` public API

## Test plan
- [x] `from mindtorch_v2.distributed.fsdp import FullyShardedDataParallel` succeeds
- [x] `from mindtorch_v2.distributed.tensor import DTensor, Replicate, Shard, Placement` succeeds
- [x] `from mindtorch_v2.distributed.device_mesh import DeviceMesh, init_device_mesh` succeeds
- [x] `from mindtorch_v2.distributed._tensor.experimental import implicit_replication` succeeds
- [x] `from mindtorch_v2.distributed import init_device_mesh` succeeds
- [x] `FullyShardedDataParallel()` raises `RuntimeError`
- [x] `init_device_mesh()` raises `NotImplementedError`
- [x] Unknown attributes still raise `AttributeError` via `__getattr__` fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)