### PR TITLE
cpu: add lerp op

### DIFF
--- a/docs/plans/ops-coverage.md
+++ b/docs/plans/ops-coverage.md
@@ -78,3 +78,4 @@ This document is about collaboration rules only (not defining the op scope).
 | `aten::atan2` | CPU | done | - | numpy impl + meta + tests |
 | `aten::asin` | CPU | done | - | numpy impl + meta + tests |
 | `aten::acos` | CPU | done | - | numpy impl + meta + tests |
+| `aten::lerp` | CPU | done | - | numpy impl + meta + tests |

--- a/src/mindtorch_v2/__init__.py
+++ b/src/mindtorch_v2/__init__.py
@@ -22,7 +22,7 @@ from ._functional import sign, signbit, isnan, isinf, isfinite
 from ._functional import sinh, cosh, erf, erfc, softplus
 from ._functional import clamp, clamp_min, clamp_max, relu6, hardtanh
 from ._functional import min, max, amin, amax, fmin, fmax, where
-from ._functional import atan, atan2, asin, acos
+from ._functional import atan, atan2, asin, acos, lerp
 from ._printing import set_printoptions, get_printoptions
 from ._dispatch import pipeline_context
 from ._backends import cpu
@@ -104,6 +104,7 @@ __all__ = [
     "atan2",
     "asin",
     "acos",
+    "lerp",
     "sum",
     # printing
     "set_printoptions",

--- a/src/mindtorch_v2/_backends/cpu/__init__.py
+++ b/src/mindtorch_v2/_backends/cpu/__init__.py
@@ -60,6 +60,7 @@ from .ops import (
     atan2,
     asin,
     acos,
+    lerp,
 )
 
 registry.register("add", "cpu", add, meta=meta_infer.infer_binary)
@@ -112,6 +113,7 @@ registry.register("atan", "cpu", atan, meta=meta_infer.infer_unary)
 registry.register("atan2", "cpu", atan2, meta=meta_infer.infer_binary)
 registry.register("asin", "cpu", asin, meta=meta_infer.infer_unary)
 registry.register("acos", "cpu", acos, meta=meta_infer.infer_unary)
+registry.register("lerp", "cpu", lerp, meta=meta_infer.infer_binary)
 registry.register("contiguous", "cpu", contiguous, meta=meta_infer.infer_unary)
 registry.register("sum", "cpu", sum_, meta=meta_infer.infer_sum)
 registry.register("add_", "cpu", add_, meta=meta_infer.infer_binary)

--- a/src/mindtorch_v2/_backends/cpu/ops.py
+++ b/src/mindtorch_v2/_backends/cpu/ops.py
@@ -290,3 +290,14 @@ def asin(a):
 
 def acos(a):
     return _from_numpy(np.arccos(_to_numpy(a)), a.dtype, a.device)
+
+
+def lerp(a, b, weight):
+    arr_a = _to_numpy(a)
+    arr_b = _to_numpy(b)
+    if isinstance(weight, Tensor):
+        w = _to_numpy(weight)
+    else:
+        w = weight
+    out = arr_a + w * (arr_b - arr_a)
+    return _from_numpy(out, a.dtype, a.device)

--- a/src/mindtorch_v2/_backends/meta/__init__.py
+++ b/src/mindtorch_v2/_backends/meta/__init__.py
@@ -15,6 +15,7 @@ from .ops import (
     _meta_clamp_max_meta,
     _meta_hardtanh_meta,
     _meta_where_meta,
+    _meta_lerp_meta,
     _meta_view_meta,
     _meta_contiguous_meta,
 )
@@ -69,6 +70,7 @@ registry.register("atan", "meta", _meta_unary_meta)
 registry.register("atan2", "meta", _meta_binary_meta)
 registry.register("asin", "meta", _meta_unary_meta)
 registry.register("acos", "meta", _meta_unary_meta)
+registry.register("lerp", "meta", _meta_lerp_meta)
 registry.register("contiguous", "meta", _meta_contiguous_meta)
 registry.register("sum", "meta", _meta_sum_meta)
 registry.register("reshape", "meta", view_backend.reshape, meta=_meta_view_meta)

--- a/src/mindtorch_v2/_backends/meta/ops.py
+++ b/src/mindtorch_v2/_backends/meta/ops.py
@@ -58,6 +58,15 @@ def _meta_where_meta(cond, x, y):
     return _meta_tensor(shape, x.dtype, x.device)
 
 
+def _meta_lerp_meta(a, b, weight):
+    if hasattr(weight, "shape"):
+        w_shape = weight.shape
+    else:
+        w_shape = ()
+    shape = _broadcast_shape(_broadcast_shape(a.shape, b.shape), w_shape)
+    return _meta_tensor(shape, a.dtype, a.device)
+
+
 def _meta_unary_meta(a):
     return _meta_tensor(a.shape, a.dtype, a.device)
 
@@ -146,6 +155,7 @@ __all__ = [
     "_meta_binary_meta",
     "_meta_binary_or_scalar_meta",
     "_meta_where_meta",
+    "_meta_lerp_meta",
     "_meta_matmul_meta",
     "_meta_sum_meta",
     "_meta_transpose_meta",

--- a/src/mindtorch_v2/_functional.py
+++ b/src/mindtorch_v2/_functional.py
@@ -202,6 +202,10 @@ def asin(a):
 def acos(a):
     return dispatch("acos", a.device.type, a)
 
+
+def lerp(a, b, weight):
+    return dispatch("lerp", a.device.type, a, b, weight)
+
 def sinh(a):
     return dispatch("sinh", a.device.type, a)
 

--- a/src/mindtorch_v2/_tensor.py
+++ b/src/mindtorch_v2/_tensor.py
@@ -32,6 +32,7 @@ from ._functional import fmin as fmin_dispatch, fmax as fmax_dispatch
 from ._functional import where as where_dispatch
 from ._functional import atan as atan_dispatch, atan2 as atan2_dispatch
 from ._functional import asin as asin_dispatch, acos as acos_dispatch
+from ._functional import lerp as lerp_dispatch
 from ._functional import reshape as reshape_dispatch
 from ._functional import transpose as transpose_dispatch, view as view_dispatch, to as to_dispatch
 from ._autograd.engine import backward as _backward
@@ -582,6 +583,9 @@ class Tensor:
 
     def acos(self):
         return acos_dispatch(self)
+
+    def lerp(self, other, weight):
+        return lerp_dispatch(self, other, weight)
     def sum(self, dim=None, keepdim=False):
         return sum(self, dim=dim, keepdim=keepdim)
 

--- a/tests/mindtorch_v2/test_meta_device.py
+++ b/tests/mindtorch_v2/test_meta_device.py
@@ -80,6 +80,7 @@ def test_meta_unary_elementwise_ops_shape():
         lambda t: torch.atan2(t, t),
         lambda t: torch.asin(t),
         lambda t: torch.acos(t),
+        lambda t: torch.lerp(t, t, 0.5),
     ):
         out = op(x)
         assert out.device.type == "meta"

--- a/tests/mindtorch_v2/test_ops_cpu.py
+++ b/tests/mindtorch_v2/test_ops_cpu.py
@@ -334,6 +334,24 @@ def test_tensor_where_scalar_cpu():
     np.testing.assert_allclose(x.where(cond, 0.5).numpy(), expected)
 
 
+def test_lerp_scalar_cpu():
+    x = torch.tensor([0.0, 1.0, 2.0])
+    y = torch.tensor([2.0, 3.0, 4.0])
+    weight = 0.25
+    expected = x.numpy() + weight * (y.numpy() - x.numpy())
+    np.testing.assert_allclose(torch.lerp(x, y, weight).numpy(), expected)
+    np.testing.assert_allclose(x.lerp(y, weight).numpy(), expected)
+
+
+def test_lerp_tensor_cpu():
+    x = torch.tensor([0.0, 1.0, 2.0])
+    y = torch.tensor([2.0, 3.0, 4.0])
+    weight = torch.tensor([0.0, 0.5, 1.0])
+    expected = x.numpy() + weight.numpy() * (y.numpy() - x.numpy())
+    np.testing.assert_allclose(torch.lerp(x, y, weight).numpy(), expected)
+    np.testing.assert_allclose(x.lerp(y, weight).numpy(), expected)
+
+
 def test_atan_cpu():
     x = torch.tensor([-1.0, 0.0, 1.0])
     expected = np.arctan(x.numpy())


### PR DESCRIPTION
## Summary
- add lerp CPU op with scalar/tensor weights + meta kernel
- update ops coverage table

## Test Plan
- [x] pytest tests/mindtorch_v2/test_ops_cpu.py::test_lerp_scalar_cpu tests/mindtorch_v2/test_ops_cpu.py::test_lerp_tensor_cpu tests/mindtorch_v2/test_meta_device.py::test_meta_unary_elementwise_ops_shape -q