### PR TITLE
cpu: add addcmul/addcdiv ops

### DIFF
--- a/docs/plans/ops-coverage.md
+++ b/docs/plans/ops-coverage.md
@@ -79,3 +79,5 @@ This document is about collaboration rules only (not defining the op scope).
 | `aten::asin` | CPU | done | - | numpy impl + meta + tests |
 | `aten::acos` | CPU | done | - | numpy impl + meta + tests |
 | `aten::lerp` | CPU | done | - | numpy impl + meta + tests |
+| `aten::addcmul` | CPU | done | - | numpy impl + meta + tests |
+| `aten::addcdiv` | CPU | done | - | numpy impl + meta + tests |

--- a/src/mindtorch_v2/__init__.py
+++ b/src/mindtorch_v2/__init__.py
@@ -22,7 +22,7 @@ from ._functional import sign, signbit, isnan, isinf, isfinite
 from ._functional import sinh, cosh, erf, erfc, softplus
 from ._functional import clamp, clamp_min, clamp_max, relu6, hardtanh
 from ._functional import min, max, amin, amax, fmin, fmax, where
-from ._functional import atan, atan2, asin, acos, lerp
+from ._functional import atan, atan2, asin, acos, lerp, addcmul, addcdiv
 from ._printing import set_printoptions, get_printoptions
 from ._dispatch import pipeline_context
 from ._backends import cpu
@@ -106,6 +106,8 @@ __all__ = [
     "asin",
     "acos",
     "lerp",
+    "addcmul",
+    "addcdiv",
     "sum",
     # printing
     "set_printoptions",

--- a/src/mindtorch_v2/_backends/cpu/__init__.py
+++ b/src/mindtorch_v2/_backends/cpu/__init__.py
@@ -61,6 +61,8 @@ from .ops import (
     asin,
     acos,
     lerp,
+    addcmul,
+    addcdiv,
 )
 
 registry.register("add", "cpu", add, meta=meta_infer.infer_binary)
@@ -114,6 +116,8 @@ registry.register("atan2", "cpu", atan2, meta=meta_infer.infer_binary)
 registry.register("asin", "cpu", asin, meta=meta_infer.infer_unary)
 registry.register("acos", "cpu", acos, meta=meta_infer.infer_unary)
 registry.register("lerp", "cpu", lerp, meta=meta_infer.infer_binary)
+registry.register("addcmul", "cpu", addcmul, meta=meta_infer.infer_binary)
+registry.register("addcdiv", "cpu", addcdiv, meta=meta_infer.infer_binary)
 registry.register("contiguous", "cpu", contiguous, meta=meta_infer.infer_unary)
 registry.register("sum", "cpu", sum_, meta=meta_infer.infer_sum)
 registry.register("add_", "cpu", add_, meta=meta_infer.infer_binary)

--- a/src/mindtorch_v2/_backends/cpu/ops.py
+++ b/src/mindtorch_v2/_backends/cpu/ops.py
@@ -301,3 +301,19 @@ def lerp(a, b, weight):
         w = weight
     out = arr_a + w * (arr_b - arr_a)
     return _from_numpy(out, a.dtype, a.device)
+
+
+def addcmul(a, b, c, value=1.0):
+    return _from_numpy(
+        _to_numpy(a) + value * (_to_numpy(b) * _to_numpy(c)),
+        a.dtype,
+        a.device,
+    )
+
+
+def addcdiv(a, b, c, value=1.0):
+    return _from_numpy(
+        _to_numpy(a) + value * (_to_numpy(b) / _to_numpy(c)),
+        a.dtype,
+        a.device,
+    )

--- a/src/mindtorch_v2/_backends/meta/__init__.py
+++ b/src/mindtorch_v2/_backends/meta/__init__.py
@@ -16,6 +16,8 @@ from .ops import (
     _meta_hardtanh_meta,
     _meta_where_meta,
     _meta_lerp_meta,
+    _meta_addcmul_meta,
+    _meta_addcdiv_meta,
     _meta_view_meta,
     _meta_contiguous_meta,
 )
@@ -71,6 +73,8 @@ registry.register("atan2", "meta", _meta_binary_meta)
 registry.register("asin", "meta", _meta_unary_meta)
 registry.register("acos", "meta", _meta_unary_meta)
 registry.register("lerp", "meta", _meta_lerp_meta)
+registry.register("addcmul", "meta", _meta_addcmul_meta)
+registry.register("addcdiv", "meta", _meta_addcdiv_meta)
 registry.register("contiguous", "meta", _meta_contiguous_meta)
 registry.register("sum", "meta", _meta_sum_meta)
 registry.register("reshape", "meta", view_backend.reshape, meta=_meta_view_meta)

--- a/src/mindtorch_v2/_backends/meta/ops.py
+++ b/src/mindtorch_v2/_backends/meta/ops.py
@@ -67,6 +67,16 @@ def _meta_lerp_meta(a, b, weight):
     return _meta_tensor(shape, a.dtype, a.device)
 
 
+def _meta_addcmul_meta(a, b, c, value=1.0):
+    shape = _broadcast_shape(_broadcast_shape(a.shape, b.shape), c.shape)
+    return _meta_tensor(shape, a.dtype, a.device)
+
+
+def _meta_addcdiv_meta(a, b, c, value=1.0):
+    shape = _broadcast_shape(_broadcast_shape(a.shape, b.shape), c.shape)
+    return _meta_tensor(shape, a.dtype, a.device)
+
+
 def _meta_unary_meta(a):
     return _meta_tensor(a.shape, a.dtype, a.device)
 
@@ -156,6 +166,8 @@ __all__ = [
     "_meta_binary_or_scalar_meta",
     "_meta_where_meta",
     "_meta_lerp_meta",
+    "_meta_addcmul_meta",
+    "_meta_addcdiv_meta",
     "_meta_matmul_meta",
     "_meta_sum_meta",
     "_meta_transpose_meta",

--- a/src/mindtorch_v2/_functional.py
+++ b/src/mindtorch_v2/_functional.py
@@ -206,6 +206,14 @@ def acos(a):
 def lerp(a, b, weight):
     return dispatch("lerp", a.device.type, a, b, weight)
 
+
+def addcmul(a, b, c, value=1.0):
+    return dispatch("addcmul", a.device.type, a, b, c, value=value)
+
+
+def addcdiv(a, b, c, value=1.0):
+    return dispatch("addcdiv", a.device.type, a, b, c, value=value)
+
 def sinh(a):
     return dispatch("sinh", a.device.type, a)
 

--- a/src/mindtorch_v2/_tensor.py
+++ b/src/mindtorch_v2/_tensor.py
@@ -33,6 +33,7 @@ from ._functional import where as where_dispatch
 from ._functional import atan as atan_dispatch, atan2 as atan2_dispatch
 from ._functional import asin as asin_dispatch, acos as acos_dispatch
 from ._functional import lerp as lerp_dispatch
+from ._functional import addcmul as addcmul_dispatch, addcdiv as addcdiv_dispatch
 from ._functional import reshape as reshape_dispatch
 from ._functional import transpose as transpose_dispatch, view as view_dispatch, to as to_dispatch
 from ._autograd.engine import backward as _backward
@@ -586,6 +587,12 @@ class Tensor:
 
     def lerp(self, other, weight):
         return lerp_dispatch(self, other, weight)
+
+    def addcmul(self, tensor1, tensor2, value=1.0):
+        return addcmul_dispatch(self, tensor1, tensor2, value=value)
+
+    def addcdiv(self, tensor1, tensor2, value=1.0):
+        return addcdiv_dispatch(self, tensor1, tensor2, value=value)
     def sum(self, dim=None, keepdim=False):
         return sum(self, dim=dim, keepdim=keepdim)
 

--- a/tests/mindtorch_v2/test_meta_device.py
+++ b/tests/mindtorch_v2/test_meta_device.py
@@ -81,6 +81,8 @@ def test_meta_unary_elementwise_ops_shape():
         lambda t: torch.asin(t),
         lambda t: torch.acos(t),
         lambda t: torch.lerp(t, t, 0.5),
+        lambda t: torch.addcmul(t, t, t, value=0.5),
+        lambda t: torch.addcdiv(t, t, t, value=0.5),
     ):
         out = op(x)
         assert out.device.type == "meta"

--- a/tests/mindtorch_v2/test_ops_cpu.py
+++ b/tests/mindtorch_v2/test_ops_cpu.py
@@ -352,6 +352,26 @@ def test_lerp_tensor_cpu():
     np.testing.assert_allclose(x.lerp(y, weight).numpy(), expected)
 
 
+def test_addcmul_cpu():
+    x = torch.tensor([1.0, 2.0, 3.0])
+    y = torch.tensor([2.0, 2.0, 2.0])
+    z = torch.tensor([3.0, 4.0, 5.0])
+    value = 0.5
+    expected = x.numpy() + value * (y.numpy() * z.numpy())
+    np.testing.assert_allclose(torch.addcmul(x, y, z, value=value).numpy(), expected)
+    np.testing.assert_allclose(x.addcmul(y, z, value=value).numpy(), expected)
+
+
+def test_addcdiv_cpu():
+    x = torch.tensor([1.0, 2.0, 3.0])
+    y = torch.tensor([2.0, 4.0, 6.0])
+    z = torch.tensor([1.0, 2.0, 3.0])
+    value = 0.25
+    expected = x.numpy() + value * (y.numpy() / z.numpy())
+    np.testing.assert_allclose(torch.addcdiv(x, y, z, value=value).numpy(), expected)
+    np.testing.assert_allclose(x.addcdiv(y, z, value=value).numpy(), expected)
+
+
 def test_atan_cpu():
     x = torch.tensor([-1.0, 0.0, 1.0])
     expected = np.arctan(x.numpy())


### PR DESCRIPTION
## Summary
- add addcmul/addcdiv CPU ops with meta + tests
- update ops coverage table

## Test Plan
- [x] pytest tests/mindtorch_v2/test_ops_cpu.py::test_addcmul_cpu tests/mindtorch_v2/test_ops_cpu.py::test_addcdiv_cpu tests/mindtorch_v2/test_meta_device.py::test_meta_unary_elementwise_ops_shape -q