### PR TITLE
Dispatch: align duplicate-arg schema errors

### DIFF
--- a/src/mindtorch_v2/_dispatch/schema.py
+++ b/src/mindtorch_v2/_dispatch/schema.py
@@ -36,7 +36,8 @@ class OpSchema:
         for idx, value in enumerate(args):
             param = positional_params[idx]
             if param.name in kwargs:
-                raise TypeError(f"{name}() got multiple values for argument '{param.name}'")
+                arg_name = _torch_param_name(param.name)
+                raise TypeError(f"{name}() got multiple values for argument '{arg_name}'")
         provided = {p.name for p in positional_params[: len(args)]} | set(kwargs.keys())
         missing = [p.name for p in params if p.name not in provided and not p.has_default]
         if missing:

--- a/tests/mindtorch_v2/contract/test_schema_positional.py
+++ b/tests/mindtorch_v2/contract/test_schema_positional.py
@@ -1,0 +1,18 @@
+import mindtorch_v2 as torch
+import torch as pt
+from mindtorch_v2._dispatch.dispatcher import dispatch
+from mindtorch_v2._dispatch.registry import registry
+from tests.mindtorch_v2.contract.helpers import assert_torch_error
+
+
+def test_dispatch_relu_duplicate_arg_matches_torch():
+    registry.register_schema("relu", "relu(Tensor self) -> Tensor")
+    a = torch.tensor([1.0])
+
+    def mt():
+        dispatch("relu", a.device.type, a, self=a)
+
+    def th():
+        pt.relu(pt.tensor([1.0]), input=pt.tensor([1.0]))
+
+    assert_torch_error(mt, th)


### PR DESCRIPTION
## Summary
- add contract test for duplicate-arg schema binding
- align duplicate-arg error names with torch (self -> input)

## Testing
- pytest tests/mindtorch_v2/contract/test_schema_positional.py -v