### PR TITLE
feat(mindtorch_v2): add arange/linspace/full

### DIFF
--- a/docs/plans/ops-coverage.md
+++ b/docs/plans/ops-coverage.md
@@ -89,3 +89,6 @@ This document is about collaboration rules only (not defining the op scope).
 | `aten::hypot` | CPU | done | - | numpy impl + meta + tests |
 | `aten::remainder` | CPU | done | - | numpy impl + meta + tests |
 | `aten::fmod` | CPU | done | - | numpy impl + meta + tests |
+| `aten::arange` | CPU | done | - | numpy impl + meta + tests |
+| `aten::linspace` | CPU | done | - | numpy impl + meta + tests |
+| `aten::full` | CPU | done | - | numpy impl + meta + tests |

--- a/src/mindtorch_v2/__init__.py
+++ b/src/mindtorch_v2/__init__.py
@@ -13,7 +13,7 @@ from ._dtype import float as float  # noqa: F811
 from ._dtype import int as int  # noqa: F811
 from ._device import device as Device, _default_device, get_default_device, set_default_device
 from ._tensor import Tensor
-from ._creation import tensor, zeros, ones
+from ._creation import tensor, zeros, ones, empty, arange, linspace, full
 from ._storage import UntypedStorage, TypedStorage
 from ._functional import add, mul, matmul, relu, sum, abs, neg, exp, log, sqrt
 from ._functional import sin, cos, tan, tanh, sigmoid, floor, ceil, round, trunc, frac
@@ -55,6 +55,10 @@ __all__ = [
     "tensor",
     "zeros",
     "ones",
+    "empty",
+    "arange",
+    "linspace",
+    "full",
     # ops
     "add",
     "mul",

--- a/src/mindtorch_v2/_backends/cpu/__init__.py
+++ b/src/mindtorch_v2/_backends/cpu/__init__.py
@@ -2,7 +2,15 @@ from ..common import convert as convert_backend
 from ..common import view as view_backend
 from ..meta import infer as meta_infer
 from ..._dispatch.registry import registry
-from .creation import empty_create, ones_create, tensor_create, zeros_create
+from .creation import (
+    arange_create,
+    empty_create,
+    full_create,
+    linspace_create,
+    ones_create,
+    tensor_create,
+    zeros_create,
+)
 from .ops import (
     add,
     matmul,
@@ -149,3 +157,6 @@ registry.register("tensor", "cpu", tensor_create)
 registry.register("zeros", "cpu", zeros_create)
 registry.register("ones", "cpu", ones_create)
 registry.register("empty", "cpu", empty_create)
+registry.register("arange", "cpu", arange_create)
+registry.register("linspace", "cpu", linspace_create)
+registry.register("full", "cpu", full_create)

--- a/src/mindtorch_v2/_backends/cpu/creation.py
+++ b/src/mindtorch_v2/_backends/cpu/creation.py
@@ -40,3 +40,28 @@ def empty_create(shape, dtype=None, device=None, requires_grad=False):
     storage = typed_storage_from_numpy(np.empty(shape, dtype=to_numpy_dtype(dtype)), dtype, device=device)
     stride = _contiguous_stride(shape)
     return Tensor(storage, shape, stride, requires_grad=requires_grad)
+
+
+def arange_create(start, end, step=1, dtype=None, device=None):
+    arr = np.arange(start, end, step, dtype=to_numpy_dtype(dtype))
+    storage = typed_storage_from_numpy(arr, dtype, device=device)
+    stride = tuple(np.array(arr.strides) // arr.itemsize)
+    return Tensor(storage, arr.shape, stride)
+
+
+def linspace_create(start, end, steps, dtype=None, device=None):
+    arr = np.linspace(start, end, steps, dtype=to_numpy_dtype(dtype))
+    storage = typed_storage_from_numpy(arr, dtype, device=device)
+    stride = tuple(np.array(arr.strides) // arr.itemsize)
+    return Tensor(storage, arr.shape, stride)
+
+
+def full_create(shape, fill_value, dtype=None, device=None):
+    shape = tuple(shape)
+    storage = typed_storage_from_numpy(
+        np.full(shape, fill_value, dtype=to_numpy_dtype(dtype)),
+        dtype,
+        device=device,
+    )
+    stride = _contiguous_stride(shape)
+    return Tensor(storage, shape, stride)

--- a/src/mindtorch_v2/_backends/meta/__init__.py
+++ b/src/mindtorch_v2/_backends/meta/__init__.py
@@ -1,7 +1,15 @@
 from ..common import convert as convert_backend
 from ..common import view as view_backend
 from ..._dispatch.registry import registry
-from .creation import empty_create_meta, ones_create_meta, tensor_create_meta, zeros_create_meta
+from .creation import (
+    arange_create_meta,
+    empty_create_meta,
+    full_create_meta,
+    linspace_create_meta,
+    ones_create_meta,
+    tensor_create_meta,
+    zeros_create_meta,
+)
 from .ops import (
     _meta_binary_meta,
     _meta_binary_or_scalar_meta,
@@ -94,3 +102,6 @@ registry.register("tensor", "meta", tensor_create_meta)
 registry.register("zeros", "meta", zeros_create_meta)
 registry.register("ones", "meta", ones_create_meta)
 registry.register("empty", "meta", empty_create_meta)
+registry.register("arange", "meta", arange_create_meta)
+registry.register("linspace", "meta", linspace_create_meta)
+registry.register("full", "meta", full_create_meta)

--- a/src/mindtorch_v2/_backends/meta/creation.py
+++ b/src/mindtorch_v2/_backends/meta/creation.py
@@ -42,9 +42,33 @@ def empty_create_meta(shape, dtype=None, device=None, requires_grad=False):
     return Tensor(storage, shape, stride, requires_grad=requires_grad)
 
 
+def arange_create_meta(start, end, step=1, dtype=None, device=None):
+    arr = np.arange(start, end, step, dtype=to_numpy_dtype(dtype))
+    stride = tuple(np.array(arr.strides) // arr.itemsize)
+    storage = meta_typed_storage_from_shape(arr.shape, dtype, device=device)
+    return Tensor(storage, arr.shape, stride)
+
+
+def linspace_create_meta(start, end, steps, dtype=None, device=None):
+    arr = np.linspace(start, end, steps, dtype=to_numpy_dtype(dtype))
+    stride = tuple(np.array(arr.strides) // arr.itemsize)
+    storage = meta_typed_storage_from_shape(arr.shape, dtype, device=device)
+    return Tensor(storage, arr.shape, stride)
+
+
+def full_create_meta(shape, fill_value, dtype=None, device=None):
+    shape = tuple(shape)
+    stride = _contiguous_stride(shape)
+    storage = meta_typed_storage_from_shape(shape, dtype, device=device)
+    return Tensor(storage, shape, stride)
+
+
 __all__ = [
     "tensor_create_meta",
     "zeros_create_meta",
     "ones_create_meta",
     "empty_create_meta",
+    "arange_create_meta",
+    "linspace_create_meta",
+    "full_create_meta",
 ]

--- a/src/mindtorch_v2/_creation.py
+++ b/src/mindtorch_v2/_creation.py
@@ -3,6 +3,9 @@ from ._functional import tensor as tensor_dispatch
 from ._functional import zeros as zeros_dispatch
 from ._functional import ones as ones_dispatch
 from ._functional import empty as empty_dispatch
+from ._functional import arange as arange_dispatch
+from ._functional import linspace as linspace_dispatch
+from ._functional import full as full_dispatch
 
 
 def tensor(data, dtype=float32, device=None, requires_grad=False):
@@ -19,3 +22,15 @@ def ones(shape, dtype=float32, device=None):
 
 def empty(shape, dtype=float32, device=None):
     return empty_dispatch(shape, dtype=dtype, device=device)
+
+
+def arange(start, end=None, step=1, dtype=float32, device=None):
+    return arange_dispatch(start, end=end, step=step, dtype=dtype, device=device)
+
+
+def linspace(start, end, steps, dtype=float32, device=None):
+    return linspace_dispatch(start, end, steps, dtype=dtype, device=device)
+
+
+def full(shape, fill_value, dtype=float32, device=None):
+    return full_dispatch(shape, fill_value, dtype=dtype, device=device)

--- a/src/mindtorch_v2/_functional.py
+++ b/src/mindtorch_v2/_functional.py
@@ -302,6 +302,23 @@ def empty(shape, dtype=None, device=None):
     return dispatch("empty", dev, shape, dtype=dtype)
 
 
+def arange(start, end=None, step=1, dtype=None, device=None):
+    dev = _as_device(device)
+    if end is None:
+        start, end = 0, start
+    return dispatch("arange", dev, start, end, step, dtype=dtype)
+
+
+def linspace(start, end, steps, dtype=None, device=None):
+    dev = _as_device(device)
+    return dispatch("linspace", dev, start, end, steps, dtype=dtype)
+
+
+def full(shape, fill_value, dtype=None, device=None):
+    dev = _as_device(device)
+    return dispatch("full", dev, shape, fill_value, dtype=dtype)
+
+
 def to(a, device, non_blocking=False):
     return dispatch("to", a.device, a, device, non_blocking=non_blocking)
 

--- a/tests/mindtorch_v2/test_creation.py
+++ b/tests/mindtorch_v2/test_creation.py
@@ -18,3 +18,21 @@ def test_creation_device_index_cpu_meta():
     meta_tensor = torch.ones((1,), device="meta:1")
     assert meta_tensor.device.type == "meta"
     assert meta_tensor.device.index == 1
+
+
+def test_arange_cpu():
+    x = torch.arange(0, 5)
+    assert x.shape == (5,)
+    assert x.numpy().tolist() == [0, 1, 2, 3, 4]
+
+
+def test_linspace_cpu():
+    x = torch.linspace(0.0, 1.0, 5)
+    assert x.shape == (5,)
+    assert x.numpy().tolist() == [0.0, 0.25, 0.5, 0.75, 1.0]
+
+
+def test_full_cpu():
+    x = torch.full((2, 3), 1.5)
+    assert x.shape == (2, 3)
+    assert x.numpy().tolist() == [[1.5, 1.5, 1.5], [1.5, 1.5, 1.5]]


### PR DESCRIPTION
## Summary
- add numpy-backed creation ops for arange/linspace/full
- register cpu/meta backends + dispatch + top-level exports
- add creation tests and update ops coverage

## Testing
- pytest tests/mindtorch_v2/test_creation.py::test_arange_cpu tests/mindtorch_v2/test_creation.py::test_linspace_cpu tests/mindtorch_v2/test_creation.py::test_full_cpu -q