### PR TITLE
feat(mindtorch_v2): add all/any/argmax

### DIFF
--- a/docs/plans/ops-coverage.md
+++ b/docs/plans/ops-coverage.md
@@ -92,3 +92,6 @@ This document is about collaboration rules only (not defining the op scope).
 | `aten::arange` | CPU | done | - | numpy impl + meta + tests |
 | `aten::linspace` | CPU | done | - | numpy impl + meta + tests |
 | `aten::full` | CPU | done | - | numpy impl + meta + tests |
+| `aten::all` | CPU | done | - | numpy impl + meta + tests |
+| `aten::any` | CPU | done | - | numpy impl + meta + tests |
+| `aten::argmax` | CPU | done | - | numpy impl + meta + tests |

--- a/src/mindtorch_v2/__init__.py
+++ b/src/mindtorch_v2/__init__.py
@@ -15,7 +15,7 @@ from ._device import device as Device, _default_device, get_default_device, set_
 from ._tensor import Tensor
 from ._creation import tensor, zeros, ones, empty, arange, linspace, full
 from ._storage import UntypedStorage, TypedStorage
-from ._functional import add, mul, matmul, relu, sum, abs, neg, exp, log, sqrt
+from ._functional import add, mul, matmul, relu, sum, all, any, argmax, abs, neg, exp, log, sqrt
 from ._functional import sin, cos, tan, tanh, sigmoid, floor, ceil, round, trunc, frac
 from ._functional import pow, log2, log10, exp2, rsqrt
 from ._functional import sign, signbit, isnan, isinf, isfinite
@@ -69,6 +69,9 @@ __all__ = [
     "exp",
     "log",
     "sqrt",
+    "all",
+    "any",
+    "argmax",
     "sin",
     "cos",
     "tan",

--- a/src/mindtorch_v2/_backends/cpu/__init__.py
+++ b/src/mindtorch_v2/_backends/cpu/__init__.py
@@ -17,6 +17,9 @@ from .ops import (
     mul,
     relu,
     sum_,
+    all_,
+    any_,
+    argmax,
     add_,
     mul_,
     relu_,
@@ -144,6 +147,9 @@ registry.register("remainder", "cpu", remainder, meta=meta_infer.infer_binary)
 registry.register("fmod", "cpu", fmod, meta=meta_infer.infer_binary)
 registry.register("contiguous", "cpu", contiguous, meta=meta_infer.infer_unary)
 registry.register("sum", "cpu", sum_, meta=meta_infer.infer_sum)
+registry.register("all", "cpu", all_, meta=meta_infer.infer_reduce_bool)
+registry.register("any", "cpu", any_, meta=meta_infer.infer_reduce_bool)
+registry.register("argmax", "cpu", argmax, meta=meta_infer.infer_argmax)
 registry.register("add_", "cpu", add_, meta=meta_infer.infer_binary)
 registry.register("mul_", "cpu", mul_, meta=meta_infer.infer_binary)
 registry.register("relu_", "cpu", relu_, meta=meta_infer.infer_unary)

--- a/src/mindtorch_v2/_backends/cpu/ops.py
+++ b/src/mindtorch_v2/_backends/cpu/ops.py
@@ -2,6 +2,7 @@ import math
 import numpy as np
 
 from ..._dtype import bool as bool_dtype
+from ..._dtype import int64 as int64_dtype
 from ..._storage import typed_storage_from_numpy
 from ..._tensor import Tensor
 
@@ -34,6 +35,26 @@ def relu(a):
 
 def sum_(a, dim=None, keepdim=False):
     return _from_numpy(_to_numpy(a).sum(axis=dim, keepdims=keepdim), a.dtype, a.device)
+
+
+def all_(a, dim=None, keepdim=False):
+    return _from_numpy(np.all(_to_numpy(a), axis=dim, keepdims=keepdim), bool_dtype, a.device)
+
+
+def any_(a, dim=None, keepdim=False):
+    return _from_numpy(np.any(_to_numpy(a), axis=dim, keepdims=keepdim), bool_dtype, a.device)
+
+
+def argmax(a, dim=None, keepdim=False):
+    arr = _to_numpy(a)
+    if dim is None:
+        out = np.array(np.argmax(arr), dtype=np.int64)
+    else:
+        out = np.argmax(arr, axis=dim)
+        if keepdim:
+            out = np.expand_dims(out, axis=dim)
+        out = out.astype(np.int64)
+    return _from_numpy(out, int64_dtype, a.device)
 
 
 def add_(a, b):

--- a/src/mindtorch_v2/_backends/meta/__init__.py
+++ b/src/mindtorch_v2/_backends/meta/__init__.py
@@ -15,6 +15,8 @@ from .ops import (
     _meta_binary_or_scalar_meta,
     _meta_matmul_meta,
     _meta_sum_meta,
+    _meta_reduce_bool_meta,
+    _meta_argmax_meta,
     _meta_transpose_meta,
     _meta_unary_meta,
     _meta_unary_bool_meta,
@@ -76,6 +78,9 @@ registry.register("min", "meta", _meta_binary_meta)
 registry.register("max", "meta", _meta_binary_meta)
 registry.register("amin", "meta", _meta_sum_meta)
 registry.register("amax", "meta", _meta_sum_meta)
+registry.register("all", "meta", _meta_reduce_bool_meta)
+registry.register("any", "meta", _meta_reduce_bool_meta)
+registry.register("argmax", "meta", _meta_argmax_meta)
 registry.register("fmin", "meta", _meta_binary_meta)
 registry.register("fmax", "meta", _meta_binary_meta)
 registry.register("where", "meta", _meta_where_meta)

--- a/src/mindtorch_v2/_backends/meta/infer.py
+++ b/src/mindtorch_v2/_backends/meta/infer.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 import numpy as np
 
 from ..._dtype import bool as bool_dtype
+from ..._dtype import int64 as int64_dtype
 
 
 @dataclass(frozen=True)
@@ -55,6 +56,16 @@ def infer_sum(a, dim=None, keepdim=False):
         shape = [s for i, s in enumerate(shape) if i not in dims]
     shape = tuple(shape)
     return TensorSpec(shape=shape, stride=_contiguous_stride(shape), dtype=a.dtype)
+
+
+def infer_reduce_bool(a, dim=None, keepdim=False):
+    spec = infer_sum(a, dim=dim, keepdim=keepdim)
+    return TensorSpec(shape=spec.shape, stride=spec.stride, dtype=bool_dtype)
+
+
+def infer_argmax(a, dim=None, keepdim=False):
+    spec = infer_sum(a, dim=dim, keepdim=keepdim)
+    return TensorSpec(shape=spec.shape, stride=spec.stride, dtype=int64_dtype)
 
 
 def infer_view(a, shape):

--- a/src/mindtorch_v2/_backends/meta/ops.py
+++ b/src/mindtorch_v2/_backends/meta/ops.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from ..._dtype import bool as bool_dtype
+from ..._dtype import int64 as int64_dtype
 from ..._dtype import to_numpy_dtype
 from ..._storage import meta_typed_storage_from_shape
 from ..._tensor import Tensor
@@ -116,6 +117,27 @@ def _meta_sum_meta(a, dim=None, keepdim=False):
     return _meta_tensor(tuple(shape), a.dtype, a.device)
 
 
+def _meta_reduce_bool_meta(a, dim=None, keepdim=False):
+    out = _meta_sum_meta(a, dim=dim, keepdim=keepdim)
+    return _meta_tensor(out.shape, bool_dtype, a.device)
+
+
+def _meta_argmax_meta(a, dim=None, keepdim=False):
+    shape = list(a.shape)
+    if dim is None:
+        dims = list(range(len(shape)))
+    elif isinstance(dim, int):
+        dims = [dim]
+    else:
+        dims = list(dim)
+    for d in sorted(dims):
+        shape[d] = 1
+    if not keepdim:
+        shape = [s for i, s in enumerate(shape) if i not in dims]
+    # PyTorch argmax returns int64
+    return _meta_tensor(tuple(shape), int64_dtype, a.device)
+
+
 def _meta_view_meta(a, shape):
     return _meta_tensor(tuple(shape), a.dtype, a.device)
 
@@ -170,6 +192,8 @@ __all__ = [
     "_meta_addcdiv_meta",
     "_meta_matmul_meta",
     "_meta_sum_meta",
+    "_meta_reduce_bool_meta",
+    "_meta_argmax_meta",
     "_meta_transpose_meta",
     "_meta_unary_meta",
     "_meta_unary_bool_meta",

--- a/src/mindtorch_v2/_functional.py
+++ b/src/mindtorch_v2/_functional.py
@@ -270,6 +270,18 @@ def sum(a, dim=None, keepdim=False):
     return dispatch("sum", a.device.type, a, dim=dim, keepdim=keepdim)
 
 
+def all(a, dim=None, keepdim=False):
+    return dispatch("all", a.device.type, a, dim=dim, keepdim=keepdim)
+
+
+def any(a, dim=None, keepdim=False):
+    return dispatch("any", a.device.type, a, dim=dim, keepdim=keepdim)
+
+
+def argmax(a, dim=None, keepdim=False):
+    return dispatch("argmax", a.device.type, a, dim=dim, keepdim=keepdim)
+
+
 def reshape(a, shape):
     return dispatch("reshape", a.device.type, a, shape)
 

--- a/src/mindtorch_v2/_tensor.py
+++ b/src/mindtorch_v2/_tensor.py
@@ -37,6 +37,7 @@ from ._functional import lerp as lerp_dispatch
 from ._functional import addcmul as addcmul_dispatch, addcdiv as addcdiv_dispatch
 from ._functional import logaddexp as logaddexp_dispatch, logaddexp2 as logaddexp2_dispatch
 from ._functional import hypot as hypot_dispatch, remainder as remainder_dispatch, fmod as fmod_dispatch
+from ._functional import all as all_dispatch, any as any_dispatch, argmax as argmax_dispatch
 from ._functional import reshape as reshape_dispatch
 from ._functional import transpose as transpose_dispatch, view as view_dispatch, to as to_dispatch
 from ._autograd.engine import backward as _backward
@@ -622,6 +623,15 @@ class Tensor:
         return fmod_dispatch(self, other)
     def sum(self, dim=None, keepdim=False):
         return sum(self, dim=dim, keepdim=keepdim)
+
+    def all(self, dim=None, keepdim=False):
+        return all_dispatch(self, dim=dim, keepdim=keepdim)
+
+    def any(self, dim=None, keepdim=False):
+        return any_dispatch(self, dim=dim, keepdim=keepdim)
+
+    def argmax(self, dim=None, keepdim=False):
+        return argmax_dispatch(self, dim=dim, keepdim=keepdim)
 
     def __repr__(self):
         return format_tensor(self)

--- a/tests/mindtorch_v2/test_meta_device.py
+++ b/tests/mindtorch_v2/test_meta_device.py
@@ -99,6 +99,9 @@ def test_meta_unary_elementwise_ops_shape():
     for op in (
         lambda t: torch.amin(t, dim=0),
         lambda t: torch.amax(t, dim=0),
+        lambda t: torch.all(t, dim=0),
+        lambda t: torch.any(t, dim=0),
+        lambda t: torch.argmax(t, dim=0),
     ):
         out = op(x)
         assert out.device.type == "meta"

--- a/tests/mindtorch_v2/test_ops_cpu.py
+++ b/tests/mindtorch_v2/test_ops_cpu.py
@@ -311,6 +311,30 @@ def test_amax_cpu():
     np.testing.assert_allclose(torch.amax(x, dim=1).numpy(), expected)
 
 
+def test_all_cpu():
+    x = torch.tensor([[True, False], [True, True]], dtype=torch.bool)
+    expected = np.all(x.numpy(), axis=1)
+    np.testing.assert_array_equal(torch.all(x, dim=1).numpy(), expected)
+    expected_keep = np.all(x.numpy(), axis=1, keepdims=True)
+    np.testing.assert_array_equal(torch.all(x, dim=1, keepdim=True).numpy(), expected_keep)
+
+
+def test_any_cpu():
+    x = torch.tensor([[False, False], [True, False]], dtype=torch.bool)
+    expected = np.any(x.numpy(), axis=1)
+    np.testing.assert_array_equal(torch.any(x, dim=1).numpy(), expected)
+    expected_keep = np.any(x.numpy(), axis=1, keepdims=True)
+    np.testing.assert_array_equal(torch.any(x, dim=1, keepdim=True).numpy(), expected_keep)
+
+
+def test_argmax_cpu():
+    x = torch.tensor([[1.0, 3.0, 2.0], [4.0, 0.0, 5.0]])
+    expected = np.argmax(x.numpy(), axis=1)
+    np.testing.assert_array_equal(torch.argmax(x, dim=1).numpy(), expected)
+    expected_keep = np.argmax(x.numpy(), axis=1)
+    np.testing.assert_array_equal(torch.argmax(x, dim=1, keepdim=True).numpy(), expected_keep.reshape(2, 1))
+
+
 def test_fmin_cpu():
     x = torch.tensor([1.0, float('nan'), 2.0])
     y = torch.tensor([0.5, 1.0, float('nan')])


### PR DESCRIPTION
## Summary
- add numpy-backed cpu implementations for all/any/argmax
- register meta shape inference + dispatch + tensor/functional exports
- add cpu + meta tests and update ops coverage

## Testing
- pytest tests/mindtorch_v2/test_ops_cpu.py::test_all_cpu tests/mindtorch_v2/test_ops_cpu.py::test_any_cpu tests/mindtorch_v2/test_ops_cpu.py::test_argmax_cpu tests/mindtorch_v2/test_meta_device.py::test_meta_unary_elementwise_ops_shape -q