### PR TITLE
Dispatch: add functionalize key and rules

### DIFF
--- a/src/mindtorch_v2/__init__.py
+++ b/src/mindtorch_v2/__init__.py
@@ -24,7 +24,7 @@ from ._functional import clamp, clamp_min, clamp_max, relu6, hardtanh
 from ._functional import min, max, amin, amax, fmin, fmax, where
 from ._functional import atan, atan2, asin, acos, lerp, addcmul, addcdiv
 from ._printing import set_printoptions, get_printoptions
-from ._dispatch import pipeline_context
+from ._dispatch import pipeline_context, functionalize_context
 from ._backends import cpu
 from ._autograd.grad_mode import is_grad_enabled, set_grad_enabled, no_grad, enable_grad
 from . import _autograd as autograd
@@ -35,6 +35,10 @@ from . import distributed
 
 def pipeline():
     return pipeline_context()
+
+
+def functionalize():
+    return functionalize_context()
 
 
 __all__ = [
@@ -115,6 +119,8 @@ __all__ = [
     # pipeline
     "pipeline",
     "pipeline_context",
+    "functionalize",
+    "functionalize_context",
     # device
     "get_default_device",
     "set_default_device",

--- a/src/mindtorch_v2/_dispatch/__init__.py
+++ b/src/mindtorch_v2/_dispatch/__init__.py
@@ -1,5 +1,6 @@
 from .dispatcher import dispatch
 from .pipeline import pipeline_context, current_pipeline
+from .functionalize import functionalize_context
 from .registry import registry
 
-__all__ = ["dispatch", "pipeline_context", "current_pipeline", "registry"]
+__all__ = ["dispatch", "pipeline_context", "current_pipeline", "functionalize_context", "registry"]

--- a/src/mindtorch_v2/_dispatch/functionalize.py
+++ b/src/mindtorch_v2/_dispatch/functionalize.py
@@ -1,0 +1,94 @@
+import contextlib
+
+from .registry import registry
+
+
+_ENABLED = False
+
+
+@contextlib.contextmanager
+def functionalize_context():
+    global _ENABLED
+    prev = _ENABLED
+    _ENABLED = True
+    try:
+        yield
+    finally:
+        _ENABLED = prev
+
+
+def is_functionalize_enabled():
+    return _ENABLED
+
+
+def _has_mutation(schema_obj):
+    if schema_obj is None:
+        return False
+    return any(param.mutates for param in schema_obj.params)
+
+
+def should_functionalize(entry):
+    if not _has_mutation(entry.schema_obj):
+        return False
+    from .keys import DispatchKey
+
+    if DispatchKey.Functionalize in entry.fallthrough:
+        return False
+    return True
+
+
+def _mutating_args(schema_obj, args, kwargs):
+    if schema_obj is None:
+        return []
+    if kwargs is None:
+        kwargs = {}
+    params = schema_obj.params
+    positional = [p for p in params if not p.kw_only]
+    bound = {}
+    for idx, value in enumerate(args):
+        if idx < len(positional):
+            bound[positional[idx].name] = value
+    for key, value in kwargs.items():
+        bound[key] = value
+    mutated = []
+    for param in params:
+        if not param.mutates:
+            continue
+        if param.name in bound:
+            mutated.append(bound[param.name])
+    return mutated
+
+
+def _derive_functional_name(op_name):
+    if op_name.endswith("_"):
+        return op_name[:-1]
+    return registry.get_functionalize(op_name)
+
+
+def _writeback(target, result):
+    if target is result:
+        return target
+    if getattr(target, "device", None) is not None and target.device.type == "meta":
+        return target
+    target.storage().copy_(result.storage())
+    target.shape = result.shape
+    target.stride = result.stride
+    target.offset = result.offset
+    target._base = result._base
+    target._view_meta = result._view_meta
+    return target
+
+
+def functionalize_op(name, alias_name, entry, keyset, args, kwargs, redispatch):
+    functional_name = _derive_functional_name(name)
+    if not functional_name or not registry.has(functional_name):
+        raise RuntimeError(f"functionalize: missing rule for op {alias_name}()")
+
+    from .keys import DispatchKey
+
+    out = redispatch(functional_name, keyset.without(DispatchKey.Functionalize), *args, **kwargs)
+    mutated = _mutating_args(entry.schema_obj, args, kwargs)
+    if mutated:
+        target = mutated[0]
+        return _writeback(target, out)
+    return out

--- a/src/mindtorch_v2/_dispatch/keys.py
+++ b/src/mindtorch_v2/_dispatch/keys.py
@@ -6,6 +6,7 @@ class DispatchKey(Enum):
     NPU = auto()
     Meta = auto()
     Autograd = auto()
+    Functionalize = auto()
     Pipeline = auto()
 
 
@@ -16,7 +17,7 @@ class DispatchKeySet(set):
         return DispatchKeySet({key for key in self if key != keys})
 
     @classmethod
-    def from_tensors(cls, tensors, *, grad_enabled=False, pipeline_enabled=False, device=None):
+    def from_tensors(cls, tensors, *, grad_enabled=False, pipeline_enabled=False, functionalize_enabled=False, device=None):
         keys = cls()
         has_meta = False
         has_npu = False
@@ -53,6 +54,8 @@ class DispatchKeySet(set):
             keys.add(DispatchKey.CPU)
         if grad_enabled and requires_grad:
             keys.add(DispatchKey.Autograd)
+        if functionalize_enabled:
+            keys.add(DispatchKey.Functionalize)
         if pipeline_enabled and not has_meta:
             keys.add(DispatchKey.Pipeline)
         return keys

--- a/tests/mindtorch_v2/contract/test_functionalize.py
+++ b/tests/mindtorch_v2/contract/test_functionalize.py
@@ -1,0 +1,51 @@
+import pytest
+
+import mindtorch_v2 as torch
+from mindtorch_v2._dispatch.dispatcher import dispatch
+from mindtorch_v2._dispatch.keys import DispatchKey
+from mindtorch_v2._dispatch.registry import registry
+from mindtorch_v2._dispatch.functionalize import functionalize_context
+
+
+
+def test_functionalize_routes_inplace_to_functional_kernel():
+    called = {}
+
+    def add_kernel(a, b):
+        called["name"] = "add"
+        out = torch.tensor((a._numpy_view() + b._numpy_view()).copy(), device=a.device)
+        return out
+
+    def add_inplace_kernel(a, b):
+        called["name"] = "add_"
+        return a
+
+    registry.register_schema("add", "add(Tensor a, Tensor b) -> Tensor")
+    registry.register_schema("add_", "add_(Tensor(a!) self, Tensor other) -> Tensor")
+    registry.register_kernel("add", DispatchKey.Functionalize, add_kernel)
+    registry.register_kernel("add_", DispatchKey.Functionalize, add_inplace_kernel)
+    registry.register_kernel("add", DispatchKey.CPU, add_kernel)
+    registry.register_kernel("add_", DispatchKey.CPU, add_inplace_kernel)
+
+    a = torch.tensor([1.0, 2.0])
+    b = torch.tensor([3.0, 4.0])
+
+    with functionalize_context():
+        out = dispatch("add_", a.device.type, a, b)
+
+    assert called.get("name") == "add"
+    assert out is a
+    assert a.storage().data.tolist() == [4.0, 6.0]
+
+
+
+def test_functionalize_missing_rule_errors():
+    registry.register_schema("mystery_", "mystery_(Tensor(a!) self) -> Tensor")
+    registry.register_kernel("mystery_", DispatchKey.CPU, lambda a: a)
+    registry.register_kernel("mystery_", DispatchKey.Functionalize, lambda a: a)
+
+    a = torch.tensor([1.0])
+
+    with functionalize_context():
+        with pytest.raises(RuntimeError, match=r"functionalize: missing rule for op mystery_\(\)"):
+            dispatch("mystery_", a.device.type, a)

--- a/tests/mindtorch_v2/test_dispatch_keys.py
+++ b/tests/mindtorch_v2/test_dispatch_keys.py
@@ -34,6 +34,15 @@ def test_keyset_includes_pipeline_when_enabled():
     assert DispatchKey.Pipeline in keyset
 
 
+# Functionalize is opt-in; ensure no accidental enablement.
+
+
+def test_keyset_includes_functionalize_when_enabled():
+    a = torch.ones((2,))
+    keyset = DispatchKeySet.from_tensors((a,), functionalize_enabled=True)
+    assert DispatchKey.Functionalize in keyset
+
+
 def test_dispatch_keyset_without_removes_keys():
     keyset = DispatchKeySet({DispatchKey.CPU, DispatchKey.Autograd})
     trimmed = keyset.without(DispatchKey.Autograd)


### PR DESCRIPTION
## Summary
- add Functionalize dispatch key, context, and functionalization writeback
- derive functionalize rule for inplace schemas at registration time
- add functionalize contract tests plus keyset coverage

## Test Plan
- [x] pytest -q tests/mindtorch_v2