### PR TITLE
feat(mindtorch_v2): add allclose/isclose/equal

### DIFF
--- a/docs/plans/ops-coverage.md
+++ b/docs/plans/ops-coverage.md
@@ -95,3 +95,6 @@ This document is about collaboration rules only (not defining the op scope).
 | `aten::all` | CPU | done | - | numpy impl + meta + tests |
 | `aten::any` | CPU | done | - | numpy impl + meta + tests |
 | `aten::argmax` | CPU | done | - | numpy impl + meta + tests |
+| `aten::allclose` | CPU | done | - | numpy impl + meta + tests |
+| `aten::isclose` | CPU | done | - | numpy impl + meta + tests |
+| `aten::equal` | CPU | done | - | numpy impl + meta + tests |

--- a/src/mindtorch_v2/__init__.py
+++ b/src/mindtorch_v2/__init__.py
@@ -15,7 +15,7 @@ from ._device import device as Device, _default_device, get_default_device, set_
 from ._tensor import Tensor
 from ._creation import tensor, zeros, ones, empty, arange, linspace, full
 from ._storage import UntypedStorage, TypedStorage
-from ._functional import add, mul, matmul, relu, sum, all, any, argmax, abs, neg, exp, log, sqrt
+from ._functional import add, mul, matmul, relu, sum, all, any, argmax, allclose, isclose, equal, abs, neg, exp, log, sqrt
 from ._functional import sin, cos, tan, tanh, sigmoid, floor, ceil, round, trunc, frac
 from ._functional import pow, log2, log10, exp2, rsqrt
 from ._functional import sign, signbit, isnan, isinf, isfinite
@@ -72,6 +72,9 @@ __all__ = [
     "all",
     "any",
     "argmax",
+    "allclose",
+    "isclose",
+    "equal",
     "sin",
     "cos",
     "tan",

--- a/src/mindtorch_v2/_backends/cpu/__init__.py
+++ b/src/mindtorch_v2/_backends/cpu/__init__.py
@@ -20,6 +20,9 @@ from .ops import (
     all_,
     any_,
     argmax,
+    allclose,
+    isclose,
+    equal,
     add_,
     mul_,
     relu_,
@@ -150,6 +153,9 @@ registry.register("sum", "cpu", sum_, meta=meta_infer.infer_sum)
 registry.register("all", "cpu", all_, meta=meta_infer.infer_reduce_bool)
 registry.register("any", "cpu", any_, meta=meta_infer.infer_reduce_bool)
 registry.register("argmax", "cpu", argmax, meta=meta_infer.infer_argmax)
+registry.register("allclose", "cpu", allclose, meta=meta_infer.infer_reduce_bool)
+registry.register("isclose", "cpu", isclose, meta=meta_infer.infer_unary_bool)
+registry.register("equal", "cpu", equal, meta=meta_infer.infer_reduce_bool)
 registry.register("add_", "cpu", add_, meta=meta_infer.infer_binary)
 registry.register("mul_", "cpu", mul_, meta=meta_infer.infer_binary)
 registry.register("relu_", "cpu", relu_, meta=meta_infer.infer_unary)

--- a/src/mindtorch_v2/_backends/cpu/ops.py
+++ b/src/mindtorch_v2/_backends/cpu/ops.py
@@ -57,6 +57,31 @@ def argmax(a, dim=None, keepdim=False):
     return _from_numpy(out, int64_dtype, a.device)
 
 
+def allclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):
+    return np.allclose(
+        _to_numpy(a),
+        _to_numpy(b),
+        rtol=rtol,
+        atol=atol,
+        equal_nan=equal_nan,
+    )
+
+
+def isclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):
+    out = np.isclose(
+        _to_numpy(a),
+        _to_numpy(b),
+        rtol=rtol,
+        atol=atol,
+        equal_nan=equal_nan,
+    )
+    return _from_numpy(out, bool_dtype, a.device)
+
+
+def equal(a, b):
+    return np.array_equal(_to_numpy(a), _to_numpy(b))
+
+
 def add_(a, b):
     arr = _to_numpy(a)
     arr += _to_numpy(b)

--- a/src/mindtorch_v2/_backends/meta/__init__.py
+++ b/src/mindtorch_v2/_backends/meta/__init__.py
@@ -30,6 +30,7 @@ from .ops import (
     _meta_addcdiv_meta,
     _meta_view_meta,
     _meta_contiguous_meta,
+    _meta_equal_meta,
 )
 
 registry.register("add", "meta", _meta_binary_meta)
@@ -81,6 +82,9 @@ registry.register("amax", "meta", _meta_sum_meta)
 registry.register("all", "meta", _meta_reduce_bool_meta)
 registry.register("any", "meta", _meta_reduce_bool_meta)
 registry.register("argmax", "meta", _meta_argmax_meta)
+registry.register("allclose", "meta", _meta_reduce_bool_meta)
+registry.register("isclose", "meta", _meta_binary_meta)
+registry.register("equal", "meta", _meta_equal_meta)
 registry.register("fmin", "meta", _meta_binary_meta)
 registry.register("fmax", "meta", _meta_binary_meta)
 registry.register("where", "meta", _meta_where_meta)

--- a/src/mindtorch_v2/_backends/meta/ops.py
+++ b/src/mindtorch_v2/_backends/meta/ops.py
@@ -29,7 +29,7 @@ def _broadcast_shape(a_shape, b_shape):
         return np.broadcast(np.empty(a_shape), np.empty(b_shape)).shape
 
 
-def _meta_binary_meta(a, b):
+def _meta_binary_meta(a, b, **kwargs):
     shape = _broadcast_shape(a.shape, b.shape)
     return _meta_tensor(shape, a.dtype, a.device)
 
@@ -82,7 +82,7 @@ def _meta_unary_meta(a):
     return _meta_tensor(a.shape, a.dtype, a.device)
 
 
-def _meta_unary_bool_meta(a):
+def _meta_unary_bool_meta(a, **kwargs):
     return _meta_tensor(a.shape, bool_dtype, a.device)
 
 
@@ -117,9 +117,17 @@ def _meta_sum_meta(a, dim=None, keepdim=False):
     return _meta_tensor(tuple(shape), a.dtype, a.device)
 
 
-def _meta_reduce_bool_meta(a, dim=None, keepdim=False):
+def _meta_reduce_bool_meta(a, b=None, dim=None, keepdim=False, **kwargs):
+    if dim is None and b is not None:
+        return _meta_tensor((), bool_dtype, a.device)
+    if dim is None:
+        return _meta_tensor((), bool_dtype, a.device)
     out = _meta_sum_meta(a, dim=dim, keepdim=keepdim)
     return _meta_tensor(out.shape, bool_dtype, a.device)
+
+
+def _meta_equal_meta(a, b, **kwargs):
+    return _meta_tensor((), bool_dtype, a.device)
 
 
 def _meta_argmax_meta(a, dim=None, keepdim=False):
@@ -194,6 +202,7 @@ __all__ = [
     "_meta_sum_meta",
     "_meta_reduce_bool_meta",
     "_meta_argmax_meta",
+    "_meta_equal_meta",
     "_meta_transpose_meta",
     "_meta_unary_meta",
     "_meta_unary_bool_meta",

--- a/src/mindtorch_v2/_functional.py
+++ b/src/mindtorch_v2/_functional.py
@@ -282,6 +282,18 @@ def argmax(a, dim=None, keepdim=False):
     return dispatch("argmax", a.device.type, a, dim=dim, keepdim=keepdim)
 
 
+def allclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):
+    return dispatch("allclose", a.device.type, a, b, rtol=rtol, atol=atol, equal_nan=equal_nan)
+
+
+def isclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):
+    return dispatch("isclose", a.device.type, a, b, rtol=rtol, atol=atol, equal_nan=equal_nan)
+
+
+def equal(a, b):
+    return dispatch("equal", a.device.type, a, b)
+
+
 def reshape(a, shape):
     return dispatch("reshape", a.device.type, a, shape)
 

--- a/src/mindtorch_v2/_tensor.py
+++ b/src/mindtorch_v2/_tensor.py
@@ -38,6 +38,7 @@ from ._functional import addcmul as addcmul_dispatch, addcdiv as addcdiv_dispatc
 from ._functional import logaddexp as logaddexp_dispatch, logaddexp2 as logaddexp2_dispatch
 from ._functional import hypot as hypot_dispatch, remainder as remainder_dispatch, fmod as fmod_dispatch
 from ._functional import all as all_dispatch, any as any_dispatch, argmax as argmax_dispatch
+from ._functional import allclose as allclose_dispatch, isclose as isclose_dispatch, equal as equal_dispatch
 from ._functional import reshape as reshape_dispatch
 from ._functional import transpose as transpose_dispatch, view as view_dispatch, to as to_dispatch
 from ._autograd.engine import backward as _backward
@@ -632,6 +633,15 @@ class Tensor:
 
     def argmax(self, dim=None, keepdim=False):
         return argmax_dispatch(self, dim=dim, keepdim=keepdim)
+
+    def allclose(self, other, rtol=1e-05, atol=1e-08, equal_nan=False):
+        return allclose_dispatch(self, other, rtol=rtol, atol=atol, equal_nan=equal_nan)
+
+    def isclose(self, other, rtol=1e-05, atol=1e-08, equal_nan=False):
+        return isclose_dispatch(self, other, rtol=rtol, atol=atol, equal_nan=equal_nan)
+
+    def equal(self, other):
+        return equal_dispatch(self, other)
 
     def __repr__(self):
         return format_tensor(self)

--- a/tests/mindtorch_v2/test_meta_device.py
+++ b/tests/mindtorch_v2/test_meta_device.py
@@ -107,6 +107,15 @@ def test_meta_unary_elementwise_ops_shape():
         assert out.device.type == "meta"
         assert out.shape == ()
 
+    for op in (
+        lambda t: torch.allclose(t, t),
+        lambda t: torch.isclose(t, t),
+        lambda t: torch.equal(t, t),
+    ):
+        out = op(x)
+        assert out.device.type == "meta"
+        assert out.shape in ((), x.shape)
+
 
 def test_meta_pow_shape():
     x = torch.tensor([1.0, 2.0, 3.0], device="meta")

--- a/tests/mindtorch_v2/test_ops_cpu.py
+++ b/tests/mindtorch_v2/test_ops_cpu.py
@@ -335,6 +335,28 @@ def test_argmax_cpu():
     np.testing.assert_array_equal(torch.argmax(x, dim=1, keepdim=True).numpy(), expected_keep.reshape(2, 1))
 
 
+def test_allclose_cpu():
+    x = torch.tensor([1.0, 1.0, 1.0001])
+    y = torch.tensor([1.0, 1.0, 1.0])
+    assert torch.allclose(x, y, rtol=1e-3, atol=1e-4)
+    assert not torch.allclose(x, y, rtol=1e-6, atol=1e-8)
+
+
+def test_isclose_cpu():
+    x = torch.tensor([1.0, 1.0, 1.0001])
+    y = torch.tensor([1.0, 1.0, 1.0])
+    expected = np.isclose(x.numpy(), y.numpy(), rtol=1e-3, atol=1e-4)
+    np.testing.assert_array_equal(torch.isclose(x, y, rtol=1e-3, atol=1e-4).numpy(), expected)
+
+
+def test_equal_cpu():
+    x = torch.tensor([1.0, 2.0])
+    y = torch.tensor([1.0, 2.0])
+    z = torch.tensor([1.0, 3.0])
+    assert torch.equal(x, y)
+    assert not torch.equal(x, z)
+
+
 def test_fmin_cpu():
     x = torch.tensor([1.0, float('nan'), 2.0])
     y = torch.tensor([0.5, 1.0, float('nan')])


### PR DESCRIPTION
## Summary
- add numpy-backed cpu implementations for allclose/isclose/equal
- register meta shape inference + dispatch + tensor/functional exports
- add cpu + meta tests and update ops coverage

## Testing
- pytest tests/mindtorch_v2/test_ops_cpu.py::test_allclose_cpu tests/mindtorch_v2/test_ops_cpu.py::test_isclose_cpu tests/mindtorch_v2/test_ops_cpu.py::test_equal_cpu tests/mindtorch_v2/test_meta_device.py::test_meta_unary_elementwise_ops_shape -q