### PR TITLE
feat(mindtorch_v2): add argmin/count_nonzero/logspace

### DIFF
--- a/docs/plans/ops-coverage.md
+++ b/docs/plans/ops-coverage.md
@@ -98,3 +98,6 @@ This document is about collaboration rules only (not defining the op scope).
 | `aten::allclose` | CPU | done | - | numpy impl + meta + tests |
 | `aten::isclose` | CPU | done | - | numpy impl + meta + tests |
 | `aten::equal` | CPU | done | - | numpy impl + meta + tests |
+| `aten::argmin` | CPU | done | - | numpy impl + meta + tests |
+| `aten::count_nonzero` | CPU | done | - | numpy impl + meta + tests |
+| `aten::logspace` | CPU | done | - | numpy impl + meta + tests |

--- a/src/mindtorch_v2/__init__.py
+++ b/src/mindtorch_v2/__init__.py
@@ -13,9 +13,9 @@ from ._dtype import float as float  # noqa: F811
 from ._dtype import int as int  # noqa: F811
 from ._device import device as Device, _default_device, get_default_device, set_default_device
 from ._tensor import Tensor
-from ._creation import tensor, zeros, ones, empty, arange, linspace, full
+from ._creation import tensor, zeros, ones, empty, arange, linspace, full, logspace
 from ._storage import UntypedStorage, TypedStorage
-from ._functional import add, mul, matmul, relu, sum, all, any, argmax, allclose, isclose, equal, abs, neg, exp, log, sqrt
+from ._functional import add, mul, matmul, relu, sum, all, any, argmax, argmin, count_nonzero, allclose, isclose, equal, abs, neg, exp, log, sqrt
 from ._functional import sin, cos, tan, tanh, sigmoid, floor, ceil, round, trunc, frac
 from ._functional import pow, log2, log10, exp2, rsqrt
 from ._functional import sign, signbit, isnan, isinf, isfinite
@@ -63,6 +63,7 @@ __all__ = [
     "arange",
     "linspace",
     "full",
+    "logspace",
     # ops
     "add",
     "mul",
@@ -76,6 +77,8 @@ __all__ = [
     "all",
     "any",
     "argmax",
+    "argmin",
+    "count_nonzero",
     "allclose",
     "isclose",
     "equal",

--- a/src/mindtorch_v2/_backends/cpu/__init__.py
+++ b/src/mindtorch_v2/_backends/cpu/__init__.py
@@ -7,6 +7,7 @@ from .creation import (
     empty_create,
     full_create,
     linspace_create,
+    logspace_create,
     ones_create,
     tensor_create,
     zeros_create,
@@ -20,6 +21,8 @@ from .ops import (
     all_,
     any_,
     argmax,
+    argmin,
+    count_nonzero,
     allclose,
     isclose,
     equal,
@@ -153,6 +156,8 @@ registry.register("sum", "cpu", sum_, meta=meta_infer.infer_sum)
 registry.register("all", "cpu", all_, meta=meta_infer.infer_reduce_bool)
 registry.register("any", "cpu", any_, meta=meta_infer.infer_reduce_bool)
 registry.register("argmax", "cpu", argmax, meta=meta_infer.infer_argmax)
+registry.register("argmin", "cpu", argmin, meta=meta_infer.infer_argmax)
+registry.register("count_nonzero", "cpu", count_nonzero, meta=meta_infer.infer_argmax)
 registry.register("allclose", "cpu", allclose, meta=meta_infer.infer_reduce_bool)
 registry.register("isclose", "cpu", isclose, meta=meta_infer.infer_unary_bool)
 registry.register("equal", "cpu", equal, meta=meta_infer.infer_reduce_bool)
@@ -172,3 +177,4 @@ registry.register("empty", "cpu", empty_create)
 registry.register("arange", "cpu", arange_create)
 registry.register("linspace", "cpu", linspace_create)
 registry.register("full", "cpu", full_create)
+registry.register("logspace", "cpu", logspace_create)

--- a/src/mindtorch_v2/_backends/cpu/creation.py
+++ b/src/mindtorch_v2/_backends/cpu/creation.py
@@ -65,3 +65,10 @@ def full_create(shape, fill_value, dtype=None, device=None):
     )
     stride = _contiguous_stride(shape)
     return Tensor(storage, shape, stride)
+
+
+def logspace_create(start, end, steps, dtype=None, device=None):
+    arr = np.logspace(start, end, steps, dtype=to_numpy_dtype(dtype))
+    storage = typed_storage_from_numpy(arr, dtype, device=device)
+    stride = tuple(np.array(arr.strides) // arr.itemsize)
+    return Tensor(storage, arr.shape, stride)

--- a/src/mindtorch_v2/_backends/cpu/ops.py
+++ b/src/mindtorch_v2/_backends/cpu/ops.py
@@ -57,6 +57,31 @@ def argmax(a, dim=None, keepdim=False):
     return _from_numpy(out, int64_dtype, a.device)
 
 
+def argmin(a, dim=None, keepdim=False):
+    arr = _to_numpy(a)
+    if dim is None:
+        out = np.array(np.argmin(arr), dtype=np.int64)
+    else:
+        out = np.argmin(arr, axis=dim)
+        if keepdim:
+            out = np.expand_dims(out, axis=dim)
+        out = out.astype(np.int64)
+    return _from_numpy(out, int64_dtype, a.device)
+
+
+def count_nonzero(a, dim=None, keepdim=False):
+    arr = _to_numpy(a)
+    if dim is None:
+        count = np.count_nonzero(arr)
+        if keepdim:
+            out = np.array(count, dtype=np.int64).reshape((1,) * arr.ndim)
+        else:
+            out = np.array(count, dtype=np.int64)
+    else:
+        out = np.count_nonzero(arr, axis=dim, keepdims=keepdim).astype(np.int64)
+    return _from_numpy(out, int64_dtype, a.device)
+
+
 def allclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):
     return np.allclose(
         _to_numpy(a),

--- a/src/mindtorch_v2/_backends/meta/__init__.py
+++ b/src/mindtorch_v2/_backends/meta/__init__.py
@@ -6,6 +6,7 @@ from .creation import (
     empty_create_meta,
     full_create_meta,
     linspace_create_meta,
+    logspace_create_meta,
     ones_create_meta,
     tensor_create_meta,
     zeros_create_meta,
@@ -82,6 +83,8 @@ registry.register("amax", "meta", _meta_sum_meta)
 registry.register("all", "meta", _meta_reduce_bool_meta)
 registry.register("any", "meta", _meta_reduce_bool_meta)
 registry.register("argmax", "meta", _meta_argmax_meta)
+registry.register("argmin", "meta", _meta_argmax_meta)
+registry.register("count_nonzero", "meta", _meta_argmax_meta)
 registry.register("allclose", "meta", _meta_reduce_bool_meta)
 registry.register("isclose", "meta", _meta_binary_meta)
 registry.register("equal", "meta", _meta_equal_meta)
@@ -114,3 +117,4 @@ registry.register("empty", "meta", empty_create_meta)
 registry.register("arange", "meta", arange_create_meta)
 registry.register("linspace", "meta", linspace_create_meta)
 registry.register("full", "meta", full_create_meta)
+registry.register("logspace", "meta", logspace_create_meta)

--- a/src/mindtorch_v2/_backends/meta/creation.py
+++ b/src/mindtorch_v2/_backends/meta/creation.py
@@ -63,6 +63,13 @@ def full_create_meta(shape, fill_value, dtype=None, device=None):
     return Tensor(storage, shape, stride)
 
 
+def logspace_create_meta(start, end, steps, dtype=None, device=None):
+    arr = np.logspace(start, end, steps, dtype=to_numpy_dtype(dtype))
+    stride = tuple(np.array(arr.strides) // arr.itemsize)
+    storage = meta_typed_storage_from_shape(arr.shape, dtype, device=device)
+    return Tensor(storage, arr.shape, stride)
+
+
 __all__ = [
     "tensor_create_meta",
     "zeros_create_meta",
@@ -71,4 +78,5 @@ __all__ = [
     "arange_create_meta",
     "linspace_create_meta",
     "full_create_meta",
+    "logspace_create_meta",
 ]

--- a/src/mindtorch_v2/_creation.py
+++ b/src/mindtorch_v2/_creation.py
@@ -6,6 +6,7 @@ from ._functional import empty as empty_dispatch
 from ._functional import arange as arange_dispatch
 from ._functional import linspace as linspace_dispatch
 from ._functional import full as full_dispatch
+from ._functional import logspace as logspace_dispatch
 
 
 def tensor(data, dtype=float32, device=None, requires_grad=False):
@@ -34,3 +35,7 @@ def linspace(start, end, steps, dtype=float32, device=None):
 
 def full(shape, fill_value, dtype=float32, device=None):
     return full_dispatch(shape, fill_value, dtype=dtype, device=device)
+
+
+def logspace(start, end, steps, dtype=float32, device=None):
+    return logspace_dispatch(start, end, steps, dtype=dtype, device=device)

--- a/src/mindtorch_v2/_functional.py
+++ b/src/mindtorch_v2/_functional.py
@@ -282,6 +282,14 @@ def argmax(a, dim=None, keepdim=False):
     return dispatch("argmax", a.device.type, a, dim=dim, keepdim=keepdim)
 
 
+def argmin(a, dim=None, keepdim=False):
+    return dispatch("argmin", a.device.type, a, dim=dim, keepdim=keepdim)
+
+
+def count_nonzero(a, dim=None, keepdim=False):
+    return dispatch("count_nonzero", a.device.type, a, dim=dim, keepdim=keepdim)
+
+
 def allclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):
     return dispatch("allclose", a.device.type, a, b, rtol=rtol, atol=atol, equal_nan=equal_nan)
 
@@ -292,6 +300,11 @@ def isclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):
 
 def equal(a, b):
     return dispatch("equal", a.device.type, a, b)
+
+
+def logspace(start, end, steps, dtype=None, device=None):
+    dev = _as_device(device)
+    return dispatch("logspace", dev, start, end, steps, dtype=dtype)
 
 
 def reshape(a, shape):

--- a/src/mindtorch_v2/_tensor.py
+++ b/src/mindtorch_v2/_tensor.py
@@ -38,6 +38,7 @@ from ._functional import addcmul as addcmul_dispatch, addcdiv as addcdiv_dispatc
 from ._functional import logaddexp as logaddexp_dispatch, logaddexp2 as logaddexp2_dispatch
 from ._functional import hypot as hypot_dispatch, remainder as remainder_dispatch, fmod as fmod_dispatch
 from ._functional import all as all_dispatch, any as any_dispatch, argmax as argmax_dispatch
+from ._functional import argmin as argmin_dispatch, count_nonzero as count_nonzero_dispatch
 from ._functional import allclose as allclose_dispatch, isclose as isclose_dispatch, equal as equal_dispatch
 from ._functional import reshape as reshape_dispatch
 from ._functional import transpose as transpose_dispatch, view as view_dispatch, to as to_dispatch
@@ -633,6 +634,12 @@ class Tensor:
 
     def argmax(self, dim=None, keepdim=False):
         return argmax_dispatch(self, dim=dim, keepdim=keepdim)
+
+    def argmin(self, dim=None, keepdim=False):
+        return argmin_dispatch(self, dim=dim, keepdim=keepdim)
+
+    def count_nonzero(self, dim=None, keepdim=False):
+        return count_nonzero_dispatch(self, dim=dim, keepdim=keepdim)
 
     def allclose(self, other, rtol=1e-05, atol=1e-08, equal_nan=False):
         return allclose_dispatch(self, other, rtol=rtol, atol=atol, equal_nan=equal_nan)

--- a/tests/mindtorch_v2/test_meta_device.py
+++ b/tests/mindtorch_v2/test_meta_device.py
@@ -102,6 +102,8 @@ def test_meta_unary_elementwise_ops_shape():
         lambda t: torch.all(t, dim=0),
         lambda t: torch.any(t, dim=0),
         lambda t: torch.argmax(t, dim=0),
+        lambda t: torch.argmin(t, dim=0),
+        lambda t: torch.count_nonzero(t, dim=0),
     ):
         out = op(x)
         assert out.device.type == "meta"
@@ -115,6 +117,12 @@ def test_meta_unary_elementwise_ops_shape():
         out = op(x)
         assert out.device.type == "meta"
         assert out.shape in ((), x.shape)
+
+
+def test_meta_logspace_shape():
+    x = torch.logspace(0.0, 2.0, 3, device="meta")
+    assert x.device.type == "meta"
+    assert x.shape == (3,)
 
 
 def test_meta_pow_shape():

--- a/tests/mindtorch_v2/test_ops_cpu.py
+++ b/tests/mindtorch_v2/test_ops_cpu.py
@@ -357,6 +357,31 @@ def test_equal_cpu():
     assert not torch.equal(x, z)
 
 
+def test_argmin_cpu():
+    x = torch.tensor([[1.0, 3.0, 2.0], [4.0, 0.0, 5.0]])
+    expected = np.argmin(x.numpy(), axis=1)
+    np.testing.assert_array_equal(torch.argmin(x, dim=1).numpy(), expected)
+    expected_keep = np.argmin(x.numpy(), axis=1)
+    np.testing.assert_array_equal(torch.argmin(x, dim=1, keepdim=True).numpy(), expected_keep.reshape(2, 1))
+
+
+def test_count_nonzero_cpu():
+    x = torch.tensor([[0.0, 1.0, 2.0], [0.0, 0.0, 3.0]])
+    expected = np.count_nonzero(x.numpy(), axis=1)
+    np.testing.assert_array_equal(torch.count_nonzero(x, dim=1).numpy(), expected)
+    expected_keep = np.count_nonzero(x.numpy(), axis=1, keepdims=True)
+    np.testing.assert_array_equal(
+        torch.count_nonzero(x, dim=1, keepdim=True).numpy(),
+        expected_keep,
+    )
+
+
+def test_logspace_cpu():
+    x = torch.logspace(0.0, 2.0, 3)
+    expected = np.logspace(0.0, 2.0, 3)
+    np.testing.assert_allclose(x.numpy(), expected)
+
+
 def test_fmin_cpu():
     x = torch.tensor([1.0, float('nan'), 2.0])
     y = torch.tensor([0.5, 1.0, float('nan')])


### PR DESCRIPTION
## Summary
- add numpy-backed cpu implementations for argmin/count_nonzero and logspace
- register cpu/meta backends + dispatch + top-level exports
- add cpu + meta tests and update ops coverage

## Testing
- pytest tests/mindtorch_v2/test_ops_cpu.py::test_argmin_cpu tests/mindtorch_v2/test_ops_cpu.py::test_count_nonzero_cpu tests/mindtorch_v2/test_ops_cpu.py::test_logspace_cpu tests/mindtorch_v2/test_meta_device.py::test_meta_unary_elementwise_ops_shape tests/mindtorch_v2/test_meta_device.py::test_meta_logspace_shape -q