### PR TITLE
feat(mindtorch_v2): add eye/range

### DIFF
--- a/docs/plans/ops-coverage.md
+++ b/docs/plans/ops-coverage.md
@@ -101,3 +101,5 @@ This document is about collaboration rules only (not defining the op scope).
 | `aten::argmin` | CPU | done | - | numpy impl + meta + tests |
 | `aten::count_nonzero` | CPU | done | - | numpy impl + meta + tests |
 | `aten::logspace` | CPU | done | - | numpy impl + meta + tests |
+| `aten::eye` | CPU | done | - | numpy impl + meta + tests |
+| `aten::range` | CPU | done | - | numpy impl + meta + tests |

--- a/src/mindtorch_v2/__init__.py
+++ b/src/mindtorch_v2/__init__.py
@@ -13,7 +13,7 @@ from ._dtype import float as float  # noqa: F811
 from ._dtype import int as int  # noqa: F811
 from ._device import device as Device, _default_device, get_default_device, set_default_device
 from ._tensor import Tensor
-from ._creation import tensor, zeros, ones, empty, arange, linspace, full, logspace
+from ._creation import tensor, zeros, ones, empty, arange, linspace, full, logspace, eye, range
 from ._storage import UntypedStorage, TypedStorage
 from ._functional import add, mul, matmul, relu, sum, all, any, argmax, argmin, count_nonzero, allclose, isclose, equal, abs, neg, exp, log, sqrt
 from ._functional import sin, cos, tan, tanh, sigmoid, floor, ceil, round, trunc, frac
@@ -64,6 +64,8 @@ __all__ = [
     "linspace",
     "full",
     "logspace",
+    "eye",
+    "range",
     # ops
     "add",
     "mul",

--- a/src/mindtorch_v2/_backends/cpu/__init__.py
+++ b/src/mindtorch_v2/_backends/cpu/__init__.py
@@ -6,9 +6,11 @@ from .creation import (
     arange_create,
     empty_create,
     full_create,
+    eye_create,
     linspace_create,
     logspace_create,
     ones_create,
+    range_create,
     tensor_create,
     zeros_create,
 )
@@ -178,3 +180,5 @@ registry.register("arange", "cpu", arange_create)
 registry.register("linspace", "cpu", linspace_create)
 registry.register("full", "cpu", full_create)
 registry.register("logspace", "cpu", logspace_create)
+registry.register("eye", "cpu", eye_create)
+registry.register("range", "cpu", range_create)

--- a/src/mindtorch_v2/_backends/cpu/creation.py
+++ b/src/mindtorch_v2/_backends/cpu/creation.py
@@ -72,3 +72,19 @@ def logspace_create(start, end, steps, dtype=None, device=None):
     storage = typed_storage_from_numpy(arr, dtype, device=device)
     stride = tuple(np.array(arr.strides) // arr.itemsize)
     return Tensor(storage, arr.shape, stride)
+
+
+def eye_create(n, m=None, dtype=None, device=None):
+    if m is None:
+        m = n
+    arr = np.eye(n, m, dtype=to_numpy_dtype(dtype))
+    storage = typed_storage_from_numpy(arr, dtype, device=device)
+    stride = tuple(np.array(arr.strides) // arr.itemsize)
+    return Tensor(storage, arr.shape, stride)
+
+
+def range_create(start, end, step=1, dtype=None, device=None):
+    arr = np.arange(start, end + step, step, dtype=to_numpy_dtype(dtype))
+    storage = typed_storage_from_numpy(arr, dtype, device=device)
+    stride = tuple(np.array(arr.strides) // arr.itemsize)
+    return Tensor(storage, arr.shape, stride)

--- a/src/mindtorch_v2/_backends/meta/__init__.py
+++ b/src/mindtorch_v2/_backends/meta/__init__.py
@@ -5,9 +5,11 @@ from .creation import (
     arange_create_meta,
     empty_create_meta,
     full_create_meta,
+    eye_create_meta,
     linspace_create_meta,
     logspace_create_meta,
     ones_create_meta,
+    range_create_meta,
     tensor_create_meta,
     zeros_create_meta,
 )
@@ -118,3 +120,5 @@ registry.register("arange", "meta", arange_create_meta)
 registry.register("linspace", "meta", linspace_create_meta)
 registry.register("full", "meta", full_create_meta)
 registry.register("logspace", "meta", logspace_create_meta)
+registry.register("eye", "meta", eye_create_meta)
+registry.register("range", "meta", range_create_meta)

--- a/src/mindtorch_v2/_backends/meta/creation.py
+++ b/src/mindtorch_v2/_backends/meta/creation.py
@@ -70,6 +70,22 @@ def logspace_create_meta(start, end, steps, dtype=None, device=None):
     return Tensor(storage, arr.shape, stride)
 
 
+def eye_create_meta(n, m=None, dtype=None, device=None):
+    if m is None:
+        m = n
+    arr = np.eye(n, m, dtype=to_numpy_dtype(dtype))
+    stride = tuple(np.array(arr.strides) // arr.itemsize)
+    storage = meta_typed_storage_from_shape(arr.shape, dtype, device=device)
+    return Tensor(storage, arr.shape, stride)
+
+
+def range_create_meta(start, end, step=1, dtype=None, device=None):
+    arr = np.arange(start, end + step, step, dtype=to_numpy_dtype(dtype))
+    stride = tuple(np.array(arr.strides) // arr.itemsize)
+    storage = meta_typed_storage_from_shape(arr.shape, dtype, device=device)
+    return Tensor(storage, arr.shape, stride)
+
+
 __all__ = [
     "tensor_create_meta",
     "zeros_create_meta",
@@ -79,4 +95,6 @@ __all__ = [
     "linspace_create_meta",
     "full_create_meta",
     "logspace_create_meta",
+    "eye_create_meta",
+    "range_create_meta",
 ]

--- a/src/mindtorch_v2/_creation.py
+++ b/src/mindtorch_v2/_creation.py
@@ -7,6 +7,8 @@ from ._functional import arange as arange_dispatch
 from ._functional import linspace as linspace_dispatch
 from ._functional import full as full_dispatch
 from ._functional import logspace as logspace_dispatch
+from ._functional import eye as eye_dispatch
+from ._functional import range as range_dispatch
 
 
 def tensor(data, dtype=float32, device=None, requires_grad=False):
@@ -39,3 +41,11 @@ def full(shape, fill_value, dtype=float32, device=None):
 
 def logspace(start, end, steps, dtype=float32, device=None):
     return logspace_dispatch(start, end, steps, dtype=dtype, device=device)
+
+
+def eye(n, m=None, dtype=float32, device=None):
+    return eye_dispatch(n, m, dtype=dtype, device=device)
+
+
+def range(start, end, step=1, dtype=float32, device=None):
+    return range_dispatch(start, end, step=step, dtype=dtype, device=device)

--- a/src/mindtorch_v2/_functional.py
+++ b/src/mindtorch_v2/_functional.py
@@ -307,6 +307,16 @@ def logspace(start, end, steps, dtype=None, device=None):
     return dispatch("logspace", dev, start, end, steps, dtype=dtype)
 
 
+def eye(n, m=None, dtype=None, device=None):
+    dev = _as_device(device)
+    return dispatch("eye", dev, n, m, dtype=dtype)
+
+
+def range(start, end, step=1, dtype=None, device=None):
+    dev = _as_device(device)
+    return dispatch("range", dev, start, end, step, dtype=dtype)
+
+
 def reshape(a, shape):
     return dispatch("reshape", a.device.type, a, shape)
 

--- a/tests/mindtorch_v2/test_creation.py
+++ b/tests/mindtorch_v2/test_creation.py
@@ -1,3 +1,4 @@
+import numpy as np
 import mindtorch_v2 as torch
 
 
@@ -18,6 +19,19 @@ def test_creation_device_index_cpu_meta():
     meta_tensor = torch.ones((1,), device="meta:1")
     assert meta_tensor.device.type == "meta"
     assert meta_tensor.device.index == 1
+
+
+def test_eye_cpu():
+    x = torch.eye(3, 2)
+    expected = [[1.0, 0.0], [0.0, 1.0], [0.0, 0.0]]
+    assert x.shape == (3, 2)
+    assert x.numpy().tolist() == expected
+
+
+def test_range_cpu():
+    x = torch.range(0.0, 2.0, 0.5)
+    expected = np.arange(0.0, 2.0 + 0.5, 0.5)
+    np.testing.assert_allclose(x.numpy(), expected)
 
 
 def test_arange_cpu():

--- a/tests/mindtorch_v2/test_meta_device.py
+++ b/tests/mindtorch_v2/test_meta_device.py
@@ -125,6 +125,18 @@ def test_meta_logspace_shape():
     assert x.shape == (3,)
 
 
+def test_meta_eye_shape():
+    x = torch.eye(3, 2, device="meta")
+    assert x.device.type == "meta"
+    assert x.shape == (3, 2)
+
+
+def test_meta_range_shape():
+    x = torch.range(0.0, 2.0, 0.5, device="meta")
+    assert x.device.type == "meta"
+    assert x.shape == (5,)
+
+
 def test_meta_pow_shape():
     x = torch.tensor([1.0, 2.0, 3.0], device="meta")
     out = torch.pow(x, 2.0)


### PR DESCRIPTION
## Summary
- add numpy-backed creation ops for eye/range
- register cpu/meta backends + dispatch + top-level exports
- add cpu + meta tests and update ops coverage

## Testing
- pytest tests/mindtorch_v2/test_creation.py::test_eye_cpu tests/mindtorch_v2/test_creation.py::test_range_cpu tests/mindtorch_v2/test_meta_device.py::test_meta_eye_shape tests/mindtorch_v2/test_meta_device.py::test_meta_range_shape -q