### PR TITLE
Dispatch: functionalize pipeline + view writeback

### DIFF
--- a/src/mindtorch_v2/_dispatch/__init__.py
+++ b/src/mindtorch_v2/_dispatch/__init__.py
@@ -1,6 +1,9 @@
 from .dispatcher import dispatch
 from .pipeline import pipeline_context, current_pipeline
 from .functionalize import functionalize_context
+from .schemas import register_schemas
 from .registry import registry
 
-__all__ = ["dispatch", "pipeline_context", "current_pipeline", "functionalize_context", "registry"]
+__all__ = ["dispatch", "pipeline_context", "current_pipeline", "functionalize_context", "registry", "register_schemas"]
+
+register_schemas()

--- a/src/mindtorch_v2/_dispatch/schemas.py
+++ b/src/mindtorch_v2/_dispatch/schemas.py
@@ -1,0 +1,8 @@
+from .registry import registry
+
+
+def register_schemas():
+    registry.register_schema("add_", "add_(Tensor(a!) self, Tensor other) -> Tensor")
+    registry.register_schema("mul_", "mul_(Tensor(a!) self, Tensor other) -> Tensor")
+    registry.register_schema("relu_", "relu_(Tensor(a!) self) -> Tensor")
+    registry.register_schema("zero_", "zero_(Tensor(a!) self) -> Tensor")

--- a/tests/mindtorch_v2/contract/test_functionalize_multi_mutation.py
+++ b/tests/mindtorch_v2/contract/test_functionalize_multi_mutation.py
@@ -1,0 +1,26 @@
+import mindtorch_v2 as torch
+from mindtorch_v2._dispatch.dispatcher import dispatch
+from mindtorch_v2._dispatch.keys import DispatchKey
+from mindtorch_v2._dispatch.registry import registry
+
+
+def test_functionalize_writes_back_all_mutations():
+    registry.register_schema("swap", "swap(Tensor a, Tensor b) -> (Tensor, Tensor)")
+    registry.register_schema("swap_", "swap_(Tensor(a!) a, Tensor(b!) b) -> Tensor")
+
+    def swap_kernel(a, b):
+        out_a = torch.tensor(b._numpy_view().copy(), device=a.device)
+        out_b = torch.tensor(a._numpy_view().copy(), device=a.device)
+        return out_a, out_b
+
+    registry.register_kernel("swap", DispatchKey.CPU, swap_kernel)
+    registry.register_kernel("swap_", DispatchKey.CPU, swap_kernel)
+
+    a = torch.tensor([1.0])
+    b = torch.tensor([2.0])
+
+    with torch.functionalize():
+        dispatch("swap_", a.device.type, a, b)
+
+    assert a.storage().data.tolist() == [2.0]
+    assert b.storage().data.tolist() == [1.0]

--- a/tests/mindtorch_v2/contract/test_functionalize_pipeline.py
+++ b/tests/mindtorch_v2/contract/test_functionalize_pipeline.py
@@ -1,0 +1,11 @@
+import mindtorch_v2 as torch
+
+
+def test_pipeline_records_functionalized_inplace():
+    a = torch.tensor([1.0, 2.0])
+    b = torch.tensor([3.0, 4.0])
+    with torch.functionalize():
+        with torch.pipeline():
+            out = a.add_(b)
+            assert out._pending is True
+    assert out._pending is False

--- a/tests/mindtorch_v2/contract/test_functionalize_view_writeback.py
+++ b/tests/mindtorch_v2/contract/test_functionalize_view_writeback.py
@@ -1,0 +1,9 @@
+import mindtorch_v2 as torch
+
+
+def test_functionalize_writeback_respects_view():
+    base = torch.tensor([1.0, 2.0, 3.0, 4.0])
+    view = base.view((2, 2))
+    with torch.functionalize():
+        view.add_(torch.ones((2, 2)))
+    assert base.storage().data.tolist() == [2.0, 3.0, 4.0, 5.0]

--- a/tests/mindtorch_v2/contract/test_schema_registration.py
+++ b/tests/mindtorch_v2/contract/test_schema_registration.py
@@ -1,0 +1,8 @@
+import mindtorch_v2 as torch
+from mindtorch_v2._dispatch.registry import registry
+
+
+def test_inplace_schema_registered():
+    entry = registry.get("aten::add_")
+    assert entry.schema_obj is not None
+    assert any(param.mutates for param in entry.schema_obj.params)


### PR DESCRIPTION
## Summary
- register inplace schemas centrally for functionalize
- functionalize during pipeline recording via pending op
- view-aware and multi-mutation writeback with new contract tests

## Test Plan
- [x] pytest -q tests/mindtorch_v2