### PR TITLE
v2: add tensor indexing (__getitem__/__setitem__) for CPU and NPU backends

### DIFF
--- a/src/mindtorch_v2/_backends/cpu/__init__.py
+++ b/src/mindtorch_v2/_backends/cpu/__init__.py
@@ -90,6 +90,8 @@ from .ops import (
     hypot,
     remainder,
     fmod,
+    getitem,
+    setitem,
 )
 
 registry.register("add", "cpu", add, meta=meta_infer.infer_binary)
@@ -153,6 +155,8 @@ registry.register("logaddexp2", "cpu", logaddexp2, meta=meta_infer.infer_binary)
 registry.register("hypot", "cpu", hypot, meta=meta_infer.infer_binary)
 registry.register("remainder", "cpu", remainder, meta=meta_infer.infer_binary)
 registry.register("fmod", "cpu", fmod, meta=meta_infer.infer_binary)
+registry.register("getitem", "cpu", getitem)
+registry.register("setitem", "cpu", setitem)
 registry.register("contiguous", "cpu", contiguous, meta=meta_infer.infer_unary)
 registry.register("sum", "cpu", sum_, meta=meta_infer.infer_sum)
 registry.register("all", "cpu", all_, meta=meta_infer.infer_reduce_bool)

--- a/src/mindtorch_v2/_backends/cpu/creation.py
+++ b/src/mindtorch_v2/_backends/cpu/creation.py
@@ -22,6 +22,8 @@ def tensor_create(data, dtype=None, device=None, requires_grad=False):
 
 
 def zeros_create(shape, dtype=None, device=None, requires_grad=False):
+    if isinstance(shape, int):
+        shape = (shape,)
     shape = tuple(shape)
     storage = typed_storage_from_numpy(np.zeros(shape, dtype=to_numpy_dtype(dtype)), dtype, device=device)
     stride = _contiguous_stride(shape)
@@ -29,6 +31,8 @@ def zeros_create(shape, dtype=None, device=None, requires_grad=False):
 
 
 def ones_create(shape, dtype=None, device=None, requires_grad=False):
+    if isinstance(shape, int):
+        shape = (shape,)
     shape = tuple(shape)
     storage = typed_storage_from_numpy(np.ones(shape, dtype=to_numpy_dtype(dtype)), dtype, device=device)
     stride = _contiguous_stride(shape)
@@ -36,6 +40,8 @@ def ones_create(shape, dtype=None, device=None, requires_grad=False):
 
 
 def empty_create(shape, dtype=None, device=None, requires_grad=False):
+    if isinstance(shape, int):
+        shape = (shape,)
     shape = tuple(shape)
     storage = typed_storage_from_numpy(np.empty(shape, dtype=to_numpy_dtype(dtype)), dtype, device=device)
     stride = _contiguous_stride(shape)

--- a/src/mindtorch_v2/_backends/cpu/ops.py
+++ b/src/mindtorch_v2/_backends/cpu/ops.py
@@ -420,3 +420,22 @@ def remainder(a, b):
 
 def fmod(a, b):
     return _from_numpy(np.fmod(_to_numpy(a), _to_numpy(b)), a.dtype, a.device)
+
+
+def getitem(tensor, key):
+    arr = _to_numpy(tensor)
+    result = arr[key]
+    if isinstance(result, np.generic) or (isinstance(result, np.ndarray) and result.ndim == 0):
+        # Return 0-dim tensor (matches PyTorch behavior)
+        scalar_arr = np.array(result)
+        return _from_numpy(scalar_arr, tensor.dtype, tensor.device)
+    return _from_numpy(np.ascontiguousarray(result), tensor.dtype, tensor.device)
+
+
+def setitem(tensor, key, value):
+    arr = _to_numpy(tensor)
+    if hasattr(value, 'numpy'):
+        arr[key] = value.numpy()
+    else:
+        arr[key] = value
+    return tensor

--- a/src/mindtorch_v2/_backends/npu/__init__.py
+++ b/src/mindtorch_v2/_backends/npu/__init__.py
@@ -49,6 +49,8 @@ from .ops import (
     relu_,
     zero_,
     contiguous,
+    getitem,
+    setitem,
 )
 from .runtime import is_available, _model_dir, _probe_model_dirs
 from . import allocator
@@ -107,5 +109,7 @@ registry.register("tensor", "npu", tensor_create)
 registry.register("zeros", "npu", zeros_create)
 registry.register("ones", "npu", ones_create)
 registry.register("empty", "npu", empty_create)
+registry.register("getitem", "npu", getitem)
+registry.register("setitem", "npu", setitem)
 
 __all__ = ["is_available", "_probe_model_dirs", "_model_dir", "allocator"]

--- a/src/mindtorch_v2/_backends/npu/creation.py
+++ b/src/mindtorch_v2/_backends/npu/creation.py
@@ -31,6 +31,8 @@ def zeros_create(shape, dtype=None, device=None, requires_grad=False):
     runtime = npu_runtime.get_runtime((device.index if hasattr(device, "index") else None) or 0)
     stream = npu_state.current_stream((device.index if hasattr(device, "index") else None) or 0)
     _require_inplace_one_zero()
+    if isinstance(shape, int):
+        shape = (shape,)
     shape = tuple(shape)
     size = int(np.prod(shape))
     out_size = size * np.dtype(npu_runtime._dtype_to_numpy(dtype)).itemsize
@@ -45,6 +47,8 @@ def ones_create(shape, dtype=None, device=None, requires_grad=False):
     runtime = npu_runtime.get_runtime((device.index if hasattr(device, "index") else None) or 0)
     stream = npu_state.current_stream((device.index if hasattr(device, "index") else None) or 0)
     _require_inplace_one_zero()
+    if isinstance(shape, int):
+        shape = (shape,)
     shape = tuple(shape)
     size = int(np.prod(shape))
     out_size = size * np.dtype(npu_runtime._dtype_to_numpy(dtype)).itemsize
@@ -58,6 +62,8 @@ def ones_create(shape, dtype=None, device=None, requires_grad=False):
 def empty_create(shape, dtype=None, device=None, requires_grad=False):
     runtime = npu_runtime.get_runtime((device.index if hasattr(device, "index") else None) or 0)
     stream = npu_state.current_stream((device.index if hasattr(device, "index") else None) or 0)
+    if isinstance(shape, int):
+        shape = (shape,)
     shape = tuple(shape)
     size = int(np.prod(shape))
     out_size = size * np.dtype(npu_runtime._dtype_to_numpy(dtype)).itemsize


### PR DESCRIPTION
Add `__getitem__` and `__setitem__` support to mindtorch_v2 Tensor class.

## Changes

- **Tensor class** (`_tensor.py`): Add `__getitem__`, `__setitem__`, `item()`, `tolist()`, `__int__`, `__float__`, `__bool__`, `__len__`, `__iter__`, and comparison operators
- **CPU backend**: Implement getitem/setitem via numpy indexing
- **NPU backend**: Implement getitem/setitem via D2D memcpy for contiguous sub-regions
- **Creation functions**: Fix `zeros`, `ones`, `empty` to accept single int as shape (both CPU and NPU)

## Supported indexing patterns

- `tensor[i]` — integer index → 0-dim tensor (matches PyTorch behavior)
- `tensor[i:j]` — slice → sub-tensor copy
- `tensor[i:j] = value` — slice assignment (scalar, CPU tensor, or NPU tensor)

## Motivation

Fixes `'Tensor' object is not subscriptable` errors in distributed object collectives and general tensor operations.