### PR TITLE
feat(mindtorch_v2): npu reductions and cast

### DIFF
--- a/docs/plans/2026-02-22-npu-reduction-ops.md
+++ b/docs/plans/2026-02-22-npu-reduction-ops.md
@@ -1,0 +1,260 @@
+# NPU Reduction Ops (MindTorch v2) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add NPU coverage for CPU-backed reduction ops (all/any/argmax/argmin/amin/amax/count_nonzero) with PyTorch-aligned behavior using ACLNN ctypes only.
+
+**Architecture:** Use ACLNN ArgMax/ArgMin for index reductions and ACLNN MaxDim/MinDim for value reductions; implement all/any/count_nonzero by building a boolean nonzero mask via aclnnEqScalar + aclnnLogicalNot and reducing with aclnnReduceSum to int64, then compare with scalar totals.
+
+**Tech Stack:** MindTorch v2 NPU backend, ACLNN ctypes (aclnn.py), existing NPU runtime allocator, pytest.
+
+---
+
+### Task 1: Add NPU tests for argmax/argmin/amin/amax
+
+**Files:**
+- Modify: `tests/mindtorch_v2/test_ops_npu.py`
+
+**Step 1: Write the failing tests**
+
+```python
+
+def test_npu_amin_amax():
+    if not torch.npu.is_available():
+        pytest.skip("NPU not available")
+    x = torch.tensor([[1.0, 2.0], [3.0, 0.5]], device="npu")
+    expected_min = np.amin(x.to("cpu").numpy(), axis=1)
+    expected_max = np.amax(x.to("cpu").numpy(), axis=1)
+    np.testing.assert_allclose(torch.amin(x, dim=1).to("cpu").numpy(), expected_min)
+    np.testing.assert_allclose(torch.amax(x, dim=1).to("cpu").numpy(), expected_max)
+
+
+def test_npu_argmax_argmin():
+    if not torch.npu.is_available():
+        pytest.skip("NPU not available")
+    x = torch.tensor([[1.0, 3.0, 2.0], [4.0, 0.0, 5.0]], device="npu")
+    expected_max = np.argmax(x.to("cpu").numpy(), axis=1)
+    expected_min = np.argmin(x.to("cpu").numpy(), axis=1)
+    np.testing.assert_array_equal(torch.argmax(x, dim=1).to("cpu").numpy(), expected_max)
+    np.testing.assert_array_equal(torch.argmin(x, dim=1).to("cpu").numpy(), expected_min)
+    np.testing.assert_array_equal(
+        torch.argmax(x, dim=1, keepdim=True).to("cpu").numpy(),
+        expected_max.reshape(2, 1),
+    )
+    np.testing.assert_array_equal(
+        torch.argmin(x, dim=1, keepdim=True).to("cpu").numpy(),
+        expected_min.reshape(2, 1),
+    )
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/mindtorch_v2/test_ops_npu.py::test_npu_amin_amax -v`
+Expected: FAIL (missing NPU implementations)
+
+Run: `pytest tests/mindtorch_v2/test_ops_npu.py::test_npu_argmax_argmin -v`
+Expected: FAIL (missing NPU implementations)
+
+---
+
+### Task 2: Add ACLNN bindings for argmax/argmin/max_dim/min_dim
+
+**Files:**
+- Modify: `src/mindtorch_v2/_backends/npu/aclnn.py`
+
+**Step 1: Add optional symbol bindings in `AclnnBindings.__init__`**
+
+```python
+self.aclnn_argmax_get_workspace = _optional_symbol(
+    libs,
+    "aclnnArgMaxGetWorkspaceSize",
+    ctypes.c_int32,
+    [ctypes.c_void_p, ctypes.c_int64, ctypes.c_bool, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_void_p)],
+)
+self.aclnn_argmax = _optional_symbol(
+    libs,
+    "aclnnArgMax",
+    ctypes.c_int32,
+    [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+)
+# Repeat for argmin/max_dim/min_dim with signatures from headers.
+```
+
+**Step 2: Implement `argmax`, `argmin`, `max_dim`, `min_dim` helpers**
+
+```python
+
+def argmax(self_ptr, out_ptr, shape, stride, dim, keepdim, out_shape, out_stride, runtime, stream=None):
+    # create tensors, allocate workspace, invoke aclnnArgMaxGetWorkspaceSize + aclnnArgMax
+```
+
+**Step 3: Add `*_symbols_ok()` helpers for availability checks**
+
+**Step 4: Commit**
+
+```bash
+git add src/mindtorch_v2/_backends/npu/aclnn.py
+git commit -m "feat(mindtorch_v2): add aclnn argmax/min bindings"
+```
+
+---
+
+### Task 3: Implement NPU argmax/argmin/amin/amax + registrations
+
+**Files:**
+- Modify: `src/mindtorch_v2/_backends/npu/ops.py`
+- Modify: `src/mindtorch_v2/_backends/npu/__init__.py`
+
+**Step 1: Implement `argmax` / `argmin` in `ops.py`**
+
+```python
+from ..._dtype import int64 as int64_dtype
+
+# Use aclnn.argmax/argmin
+# For dim is None: flatten to 1D via view_backend.reshape and use dim=0.
+# Allocate output with int64 dtype and contiguous stride.
+```
+
+**Step 2: Implement `amin` / `amax` using aclnn max_dim/min_dim**
+
+```python
+# Allocate value output (input dtype) and indices output (int64 dtype)
+# Use view_backend.reshape for dim=None, then reshape to keepdim True if needed
+```
+
+**Step 3: Register ops**
+
+```python
+registry.register("amin", "npu", amin, meta=meta_infer.infer_sum)
+registry.register("amax", "npu", amax, meta=meta_infer.infer_sum)
+registry.register("argmax", "npu", argmax, meta=meta_infer.infer_argmax)
+registry.register("argmin", "npu", argmin, meta=meta_infer.infer_argmax)
+```
+
+**Step 4: Run tests**
+
+Run: `pytest tests/mindtorch_v2/test_ops_npu.py::test_npu_amin_amax -v`
+Expected: PASS
+
+Run: `pytest tests/mindtorch_v2/test_ops_npu.py::test_npu_argmax_argmin -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/mindtorch_v2/_backends/npu/ops.py src/mindtorch_v2/_backends/npu/__init__.py
+git commit -m "feat(mindtorch_v2): add npu argmax/argmin/amin/amax"
+```
+
+---
+
+### Task 4: Add NPU tests for all/any/count_nonzero
+
+**Files:**
+- Modify: `tests/mindtorch_v2/test_ops_npu.py`
+
+**Step 1: Write the failing tests**
+
+```python
+
+def test_npu_all_any():
+    if not torch.npu.is_available():
+        pytest.skip("NPU not available")
+    x = torch.tensor([[True, False], [True, True]], device="npu", dtype=torch.bool)
+    expected_all = np.all(x.to("cpu").numpy(), axis=1)
+    expected_any = np.any(x.to("cpu").numpy(), axis=1)
+    np.testing.assert_array_equal(torch.all(x, dim=1).to("cpu").numpy(), expected_all)
+    np.testing.assert_array_equal(torch.any(x, dim=1).to("cpu").numpy(), expected_any)
+    expected_keep = np.all(x.to("cpu").numpy(), axis=1, keepdims=True)
+    np.testing.assert_array_equal(torch.all(x, dim=1, keepdim=True).to("cpu").numpy(), expected_keep)
+
+
+def test_npu_count_nonzero():
+    if not torch.npu.is_available():
+        pytest.skip("NPU not available")
+    x = torch.tensor([[0.0, 1.0, 2.0], [0.0, 0.0, 3.0]], device="npu")
+    expected = np.count_nonzero(x.to("cpu").numpy(), axis=1)
+    np.testing.assert_array_equal(torch.count_nonzero(x, dim=1).to("cpu").numpy(), expected)
+    expected_keep = np.count_nonzero(x.to("cpu").numpy(), axis=1, keepdims=True)
+    np.testing.assert_array_equal(
+        torch.count_nonzero(x, dim=1, keepdim=True).to("cpu").numpy(),
+        expected_keep,
+    )
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/mindtorch_v2/test_ops_npu.py::test_npu_all_any -v`
+Expected: FAIL
+
+Run: `pytest tests/mindtorch_v2/test_ops_npu.py::test_npu_count_nonzero -v`
+Expected: FAIL
+
+---
+
+### Task 5: Implement NPU all/any/count_nonzero + registrations
+
+**Files:**
+- Modify: `src/mindtorch_v2/_backends/npu/ops.py`
+- Modify: `src/mindtorch_v2/_backends/npu/__init__.py`
+
+**Step 1: Add helper to compute reduction dims/out shape**
+
+```python
+# Extract shared logic from sum_ to compute dims, out_shape, out_stride
+```
+
+**Step 2: Implement `count_nonzero`**
+
+```python
+# mask = logical_not(eq_scalar(a, 0))
+# out = reduce_sum(mask, dtype=int64)
+```
+
+**Step 3: Implement `all_` / `any_`**
+
+```python
+# count = reduce_sum(mask, dtype=int64)
+# any = logical_not(eq_scalar(count, 0))
+# all = eq_scalar(count, total_elements_per_reduction)
+```
+
+**Step 4: Register ops**
+
+```python
+registry.register("all", "npu", all_, meta=meta_infer.infer_reduce_bool)
+registry.register("any", "npu", any_, meta=meta_infer.infer_reduce_bool)
+registry.register("count_nonzero", "npu", count_nonzero, meta=meta_infer.infer_argmax)
+```
+
+**Step 5: Run tests**
+
+Run: `pytest tests/mindtorch_v2/test_ops_npu.py::test_npu_all_any -v`
+Expected: PASS
+
+Run: `pytest tests/mindtorch_v2/test_ops_npu.py::test_npu_count_nonzero -v`
+Expected: PASS
+
+**Step 6: Commit**
+
+```bash
+git add src/mindtorch_v2/_backends/npu/ops.py src/mindtorch_v2/_backends/npu/__init__.py
+git commit -m "feat(mindtorch_v2): add npu all/any/count_nonzero"
+```
+
+---
+
+### Task 6: Full verification
+
+**Files:**
+- Test: `tests/mindtorch_v2`
+
+**Step 1: Run full MindTorch v2 tests**
+
+Run: `pytest tests/mindtorch_v2 -v`
+Expected: PASS
+
+**Step 2: If new special cases discovered, update doc**
+
+- Modify: `docs/plans/2026-02-15-npu-op-integration-update.md`
+

--- a/src/mindtorch_v2/_backends/npu/__init__.py
+++ b/src/mindtorch_v2/_backends/npu/__init__.py
@@ -55,6 +55,9 @@ from .ops import (
     contiguous,
     getitem,
     setitem,
+    all_,
+    any_,
+    count_nonzero,
 )
 from .runtime import is_available, _model_dir, _probe_model_dirs
 from . import allocator
@@ -65,6 +68,10 @@ registry.register("matmul", "npu", matmul, meta=meta_infer.infer_matmul)
 registry.register("relu", "npu", relu, meta=meta_infer.infer_unary)
 registry.register("contiguous", "npu", contiguous, meta=meta_infer.infer_unary)
 registry.register("sum", "npu", sum_, meta=meta_infer.infer_sum)
+
+registry.register("all", "npu", all_, meta=meta_infer.infer_reduce_bool)
+registry.register("any", "npu", any_, meta=meta_infer.infer_reduce_bool)
+registry.register("count_nonzero", "npu", count_nonzero, meta=meta_infer.infer_argmax)
 registry.register("abs", "npu", abs, meta=meta_infer.infer_unary)
 registry.register("neg", "npu", neg, meta=meta_infer.infer_unary)
 registry.register("sign", "npu", sign, meta=meta_infer.infer_unary)

--- a/src/mindtorch_v2/_backends/npu/ops.py
+++ b/src/mindtorch_v2/_backends/npu/ops.py
@@ -1,5 +1,7 @@
 from ..._dtype import bool as bool_dtype
+from ..._dtype import int32 as int32_dtype
 from ..._dtype import int64 as int64_dtype
+from ..._dtype import float32 as float_dtype
 from ..._storage import npu_typed_storage_from_ptr
 from . import aclnn
 from . import runtime as npu_runtime
@@ -506,73 +508,103 @@ def _reduce_out_shape(shape, dims, keepdim):
     return tuple(out_shape)
 
 
+def _reduce_dim_sizes(shape, dims, keepdim):
+    dims = sorted(dims)
+    sizes = []
+    for d in dims:
+        sizes.append(shape[d])
+    if keepdim:
+        out_sizes = [1] * len(shape)
+        for d, size in zip(dims, sizes):
+            out_sizes[d] = size
+        return tuple(out_sizes)
+    return tuple(sizes)
+
+
+def _broadcast_dims_to_out(dims, out_shape, keepdim):
+    if keepdim:
+        return dims
+    offset = len(out_shape) - len(dims)
+    return tuple(range(offset, offset + len(dims)))
+
+
 def argmax(a, dim=None, keepdim=False):
     runtime = npu_runtime.get_runtime((a.device.index or 0))
     stream = npu_state.current_stream((a.device.index or 0))
     if a.device.type != "npu":
         raise ValueError("NPU argmax expects NPU tensors")
-    if not aclnn.argmax_symbols_ok():
-        raise RuntimeError("aclnnArgMax not available")
+    if not aclnn.max_dim_symbols_ok():
+        raise RuntimeError("aclnnMaxDim not available")
     if dim is None:
         from ..common import view as view_backend
 
         flat = view_backend.reshape(a, (_numel(a.shape),))
         return argmax(flat, dim=0, keepdim=False)
-    out_shape = _reduce_out_shape(a.shape, _normalize_reduction_dims(dim, len(a.shape)), keepdim)
+    dims = _normalize_reduction_dims(dim, len(a.shape))
+    if len(dims) != 1:
+        raise ValueError("NPU argmax only supports single dimension")
+    out_shape = _reduce_out_shape(a.shape, dims, keepdim)
     out_stride = npu_runtime._contiguous_stride(out_shape)
-    out_size = _numel(out_shape) * _dtype_itemsize(int64_dtype)
-    out_ptr = npu_runtime._alloc_device(out_size, runtime=runtime)
+    out_ptr = npu_runtime._alloc_device(_numel(out_shape) * _dtype_itemsize(int64_dtype), runtime=runtime)
+    val_ptr = npu_runtime._alloc_device(_numel(out_shape) * _dtype_itemsize(a.dtype), runtime=runtime)
     storage = _unwrap_storage(a)
-    aclnn.argmax(
+    aclnn.max_dim(
         storage.data_ptr(),
+        val_ptr,
         out_ptr,
         a.shape,
         a.stride,
         a.dtype,
-        dim,
+        dims[0],
         keepdim,
         out_shape,
+        out_stride,
         out_stride,
         runtime,
         stream=stream.stream,
     )
+    runtime.defer_free(val_ptr)
     out_storage = npu_typed_storage_from_ptr(out_ptr, _numel(out_shape), int64_dtype, device=a.device)
     return _wrap_tensor(out_storage, out_shape, out_stride)
-
 
 def argmin(a, dim=None, keepdim=False):
     runtime = npu_runtime.get_runtime((a.device.index or 0))
     stream = npu_state.current_stream((a.device.index or 0))
     if a.device.type != "npu":
         raise ValueError("NPU argmin expects NPU tensors")
-    if not aclnn.argmin_symbols_ok():
-        raise RuntimeError("aclnnArgMin not available")
+    if not aclnn.min_dim_symbols_ok():
+        raise RuntimeError("aclnnMinDim not available")
     if dim is None:
         from ..common import view as view_backend
 
         flat = view_backend.reshape(a, (_numel(a.shape),))
         return argmin(flat, dim=0, keepdim=False)
-    out_shape = _reduce_out_shape(a.shape, _normalize_reduction_dims(dim, len(a.shape)), keepdim)
+    dims = _normalize_reduction_dims(dim, len(a.shape))
+    if len(dims) != 1:
+        raise ValueError("NPU argmin only supports single dimension")
+    out_shape = _reduce_out_shape(a.shape, dims, keepdim)
     out_stride = npu_runtime._contiguous_stride(out_shape)
-    out_size = _numel(out_shape) * _dtype_itemsize(int64_dtype)
-    out_ptr = npu_runtime._alloc_device(out_size, runtime=runtime)
+    out_ptr = npu_runtime._alloc_device(_numel(out_shape) * _dtype_itemsize(int64_dtype), runtime=runtime)
+    val_ptr = npu_runtime._alloc_device(_numel(out_shape) * _dtype_itemsize(a.dtype), runtime=runtime)
     storage = _unwrap_storage(a)
-    aclnn.argmin(
+    aclnn.min_dim(
         storage.data_ptr(),
+        val_ptr,
         out_ptr,
         a.shape,
         a.stride,
         a.dtype,
-        dim,
+        dims[0],
         keepdim,
         out_shape,
+        out_stride,
         out_stride,
         runtime,
         stream=stream.stream,
     )
+    runtime.defer_free(val_ptr)
     out_storage = npu_typed_storage_from_ptr(out_ptr, _numel(out_shape), int64_dtype, device=a.device)
     return _wrap_tensor(out_storage, out_shape, out_stride)
-
 
 def amax(a, dim=None, keepdim=False):
     runtime = npu_runtime.get_runtime((a.device.index or 0))
@@ -655,6 +687,243 @@ def amin(a, dim=None, keepdim=False):
     out_storage = npu_typed_storage_from_ptr(out_ptr, _numel(out_shape), a.dtype, device=a.device)
     return _wrap_tensor(out_storage, out_shape, out_stride)
 
+
+def count_nonzero(a, dim=None, keepdim=False):
+    runtime = npu_runtime.get_runtime((a.device.index or 0))
+    stream = npu_state.current_stream((a.device.index or 0))
+    if a.device.type != "npu":
+        raise ValueError("NPU count_nonzero expects NPU tensors")
+    if not (aclnn.eq_scalar_symbols_ok() and aclnn.logical_not_symbols_ok() and aclnn.cast_symbols_ok()):
+        raise RuntimeError("aclnn eq_scalar/logical_not/cast not available")
+    dims = _normalize_reduction_dims(dim, len(a.shape))
+    out_shape = _reduce_out_shape(a.shape, dims, keepdim)
+    out_stride = npu_runtime._contiguous_stride(out_shape)
+    out_ptr = npu_runtime._alloc_device(_numel(out_shape) * _dtype_itemsize(int64_dtype), runtime=runtime)
+    mask_ptr = npu_runtime._alloc_device(_numel(a.shape) * _dtype_itemsize(bool_dtype), runtime=runtime)
+    aclnn.eq_scalar(
+        _unwrap_storage(a).data_ptr(),
+        0,
+        mask_ptr,
+        a.shape,
+        a.stride,
+        a.dtype,
+        runtime,
+        stream=stream.stream,
+    )
+    aclnn.logical_not(
+        mask_ptr,
+        mask_ptr,
+        a.shape,
+        a.stride,
+        bool_dtype,
+        runtime,
+        stream=stream.stream,
+    )
+    cast_ptr = npu_runtime._alloc_device(_numel(a.shape) * _dtype_itemsize(int32_dtype), runtime=runtime)
+    aclnn.cast(
+        mask_ptr,
+        cast_ptr,
+        a.shape,
+        a.stride,
+        bool_dtype,
+        int32_dtype,
+        runtime,
+        stream=stream.stream,
+    )
+    count_ptr = npu_runtime._alloc_device(_numel(out_shape) * _dtype_itemsize(int32_dtype), runtime=runtime)
+    dims_payload = {
+        "dims": dims if dim is not None else None,
+        "out_shape": out_shape,
+        "out_stride": out_stride,
+    }
+    aclnn.reduce_sum(
+        cast_ptr,
+        count_ptr,
+        a.shape,
+        a.stride,
+        int32_dtype,
+        dims_payload,
+        keepdim,
+        runtime,
+        stream=stream.stream,
+    )
+    aclnn.cast(
+        count_ptr,
+        out_ptr,
+        out_shape,
+        out_stride,
+        int32_dtype,
+        int64_dtype,
+        runtime,
+        stream=stream.stream,
+    )
+    runtime.defer_free(mask_ptr)
+    runtime.defer_free(cast_ptr)
+    runtime.defer_free(count_ptr)
+    out_storage = npu_typed_storage_from_ptr(out_ptr, _numel(out_shape), int64_dtype, device=a.device)
+    return _wrap_tensor(out_storage, out_shape, out_stride)
+
+def all_(a, dim=None, keepdim=False):
+    runtime = npu_runtime.get_runtime((a.device.index or 0))
+    stream = npu_state.current_stream((a.device.index or 0))
+    if a.device.type != "npu":
+        raise ValueError("NPU all expects NPU tensors")
+    if not (aclnn.eq_scalar_symbols_ok() and aclnn.logical_not_symbols_ok() and aclnn.cast_symbols_ok()):
+        raise RuntimeError("aclnn eq_scalar/logical_not/cast not available")
+    dims = _normalize_reduction_dims(dim, len(a.shape))
+    out_shape = _reduce_out_shape(a.shape, dims, keepdim)
+    out_stride = npu_runtime._contiguous_stride(out_shape)
+    out_ptr = npu_runtime._alloc_device(_numel(out_shape) * _dtype_itemsize(bool_dtype), runtime=runtime)
+    mask_ptr = npu_runtime._alloc_device(_numel(a.shape) * _dtype_itemsize(bool_dtype), runtime=runtime)
+    aclnn.eq_scalar(
+        _unwrap_storage(a).data_ptr(),
+        0,
+        mask_ptr,
+        a.shape,
+        a.stride,
+        a.dtype,
+        runtime,
+        stream=stream.stream,
+    )
+    aclnn.logical_not(
+        mask_ptr,
+        mask_ptr,
+        a.shape,
+        a.stride,
+        bool_dtype,
+        runtime,
+        stream=stream.stream,
+    )
+    cast_ptr = npu_runtime._alloc_device(_numel(a.shape) * _dtype_itemsize(int32_dtype), runtime=runtime)
+    aclnn.cast(
+        mask_ptr,
+        cast_ptr,
+        a.shape,
+        a.stride,
+        bool_dtype,
+        int32_dtype,
+        runtime,
+        stream=stream.stream,
+    )
+    count_ptr = npu_runtime._alloc_device(_numel(out_shape) * _dtype_itemsize(int32_dtype), runtime=runtime)
+    dims_payload = {
+        "dims": dims if dim is not None else None,
+        "out_shape": out_shape,
+        "out_stride": out_stride,
+    }
+    aclnn.reduce_sum(
+        cast_ptr,
+        count_ptr,
+        a.shape,
+        a.stride,
+        int32_dtype,
+        dims_payload,
+        keepdim,
+        runtime,
+        stream=stream.stream,
+    )
+    total = 1
+    for d in dims:
+        total *= a.shape[d]
+    aclnn.eq_scalar(
+        count_ptr,
+        total,
+        out_ptr,
+        out_shape,
+        out_stride,
+        int32_dtype,
+        runtime,
+        stream=stream.stream,
+    )
+    runtime.defer_free(mask_ptr)
+    runtime.defer_free(cast_ptr)
+    runtime.defer_free(count_ptr)
+    out_storage = npu_typed_storage_from_ptr(out_ptr, _numel(out_shape), bool_dtype, device=a.device)
+    return _wrap_tensor(out_storage, out_shape, out_stride)
+
+def any_(a, dim=None, keepdim=False):
+    runtime = npu_runtime.get_runtime((a.device.index or 0))
+    stream = npu_state.current_stream((a.device.index or 0))
+    if a.device.type != "npu":
+        raise ValueError("NPU any expects NPU tensors")
+    if not (aclnn.eq_scalar_symbols_ok() and aclnn.logical_not_symbols_ok() and aclnn.cast_symbols_ok()):
+        raise RuntimeError("aclnn eq_scalar/logical_not/cast not available")
+    dims = _normalize_reduction_dims(dim, len(a.shape))
+    out_shape = _reduce_out_shape(a.shape, dims, keepdim)
+    out_stride = npu_runtime._contiguous_stride(out_shape)
+    out_ptr = npu_runtime._alloc_device(_numel(out_shape) * _dtype_itemsize(bool_dtype), runtime=runtime)
+    mask_ptr = npu_runtime._alloc_device(_numel(a.shape) * _dtype_itemsize(bool_dtype), runtime=runtime)
+    aclnn.eq_scalar(
+        _unwrap_storage(a).data_ptr(),
+        0,
+        mask_ptr,
+        a.shape,
+        a.stride,
+        a.dtype,
+        runtime,
+        stream=stream.stream,
+    )
+    aclnn.logical_not(
+        mask_ptr,
+        mask_ptr,
+        a.shape,
+        a.stride,
+        bool_dtype,
+        runtime,
+        stream=stream.stream,
+    )
+    cast_ptr = npu_runtime._alloc_device(_numel(a.shape) * _dtype_itemsize(int32_dtype), runtime=runtime)
+    aclnn.cast(
+        mask_ptr,
+        cast_ptr,
+        a.shape,
+        a.stride,
+        bool_dtype,
+        int32_dtype,
+        runtime,
+        stream=stream.stream,
+    )
+    count_ptr = npu_runtime._alloc_device(_numel(out_shape) * _dtype_itemsize(int32_dtype), runtime=runtime)
+    dims_payload = {
+        "dims": dims if dim is not None else None,
+        "out_shape": out_shape,
+        "out_stride": out_stride,
+    }
+    aclnn.reduce_sum(
+        cast_ptr,
+        count_ptr,
+        a.shape,
+        a.stride,
+        int32_dtype,
+        dims_payload,
+        keepdim,
+        runtime,
+        stream=stream.stream,
+    )
+    aclnn.eq_scalar(
+        count_ptr,
+        0,
+        out_ptr,
+        out_shape,
+        out_stride,
+        int32_dtype,
+        runtime,
+        stream=stream.stream,
+    )
+    aclnn.logical_not(
+        out_ptr,
+        out_ptr,
+        out_shape,
+        out_stride,
+        bool_dtype,
+        runtime,
+        stream=stream.stream,
+    )
+    runtime.defer_free(mask_ptr)
+    runtime.defer_free(cast_ptr)
+    runtime.defer_free(count_ptr)
+    out_storage = npu_typed_storage_from_ptr(out_ptr, _numel(out_shape), bool_dtype, device=a.device)
+    return _wrap_tensor(out_storage, out_shape, out_stride)
 
 def exp(a):
     return _unary_op(a, aclnn.exp, "exp")

--- a/tests/mindtorch_v2/test_ops_npu.py
+++ b/tests/mindtorch_v2/test_ops_npu.py
@@ -50,7 +50,6 @@ def test_npu_matmul_batched_broadcast():
     assert out.shape == (2, 4, 2, 5)
     assert np.allclose(out.to("cpu").numpy(), np.matmul(a.to("cpu").numpy(), b.to("cpu").numpy()))
 
-
 @pytest.mark.parametrize(
     "op_name, numpy_fn",
     [
@@ -96,7 +95,6 @@ def test_npu_unary_ops(op_name, numpy_fn, dtype):
         atol=1e-3,
         rtol=1e-3,
     )
-
 
 @pytest.mark.parametrize(
     "op_name, numpy_fn",
@@ -167,8 +165,6 @@ def test_npu_relu6_hardtanh(dtype):
     assert np.allclose(relu6.to("cpu").numpy(), np.clip(data, 0.0, 6.0).astype(np.float32), atol=1e-3, rtol=1e-3)
     assert np.allclose(hardtanh.to("cpu").numpy(), np.clip(data, -1.0, 1.0).astype(np.float32), atol=1e-3, rtol=1e-3)
 
-
-
 def test_npu_isfinite_isinf_isnan_signbit():
     if not torch.npu.is_available():
         pytest.skip("NPU not available")
@@ -213,6 +209,31 @@ def test_npu_argmax_argmin():
     np.testing.assert_array_equal(
         torch.argmin(x, dim=1, keepdim=True).to("cpu").numpy(),
         expected_min.reshape(2, 1),
+    )
+
+
+def test_npu_all_any():
+    if not torch.npu.is_available():
+        pytest.skip("NPU not available")
+    x = torch.tensor([[True, False], [True, True]], device="npu", dtype=torch.bool)
+    expected_all = np.all(x.to("cpu").numpy(), axis=1)
+    expected_any = np.any(x.to("cpu").numpy(), axis=1)
+    np.testing.assert_array_equal(torch.all(x, dim=1).to("cpu").numpy(), expected_all)
+    np.testing.assert_array_equal(torch.any(x, dim=1).to("cpu").numpy(), expected_any)
+    expected_keep = np.all(x.to("cpu").numpy(), axis=1, keepdims=True)
+    np.testing.assert_array_equal(torch.all(x, dim=1, keepdim=True).to("cpu").numpy(), expected_keep)
+
+
+def test_npu_count_nonzero():
+    if not torch.npu.is_available():
+        pytest.skip("NPU not available")
+    x = torch.tensor([[0.0, 1.0, 2.0], [0.0, 0.0, 3.0]], device="npu")
+    expected = np.count_nonzero(x.to("cpu").numpy(), axis=1)
+    np.testing.assert_array_equal(torch.count_nonzero(x, dim=1).to("cpu").numpy(), expected)
+    expected_keep = np.count_nonzero(x.to("cpu").numpy(), axis=1, keepdims=True)
+    np.testing.assert_array_equal(
+        torch.count_nonzero(x, dim=1, keepdim=True).to("cpu").numpy(),
+        expected_keep,
     )
 
 


### PR DESCRIPTION
## Changes
- Add NPU reductions: argmax/argmin via MaxDim/MinDim, amin/amax, all/any/count_nonzero
- Add ACLNN Cast binding and use it for boolean/int reductions
- Extend NPU test coverage for reductions

## Constraints
- No NumPy on NPU execution path
- No MindSpore dependency

## Tests
- pytest tests/mindtorch_v2/test_ops_npu.py -v
