### PR TITLE
feat(mindtorch_v2): add distributed HCCL backend with direct ctypes bindings

### DIFF
--- a/src/mindtorch_v2/__init__.py
+++ b/src/mindtorch_v2/__init__.py
@@ -14,6 +14,7 @@ from ._dtype import int as int  # noqa: F811
 from ._device import device as Device, _default_device, get_default_device, set_default_device
 from ._tensor import Tensor
 from ._creation import tensor, zeros, ones, empty, arange, linspace, full, logspace, eye, range
+from ._functional import zeros_like
 from ._storage import UntypedStorage, TypedStorage
 from ._functional import add, mul, matmul, relu, sum, all, any, argmax, argmin, count_nonzero, allclose, isclose, equal, cumsum, cumprod, cummax, argsort, sort, topk, stack, cat, concat, hstack, vstack, column_stack, pad_sequence, block_diag, cartesian_prod, chunk, split, unbind, abs, neg, exp, log, sqrt
 from ._functional import sin, cos, tan, tanh, sigmoid, floor, ceil, round, trunc, frac

--- a/src/mindtorch_v2/_functional.py
+++ b/src/mindtorch_v2/_functional.py
@@ -511,6 +511,14 @@ def zeros(shape, *, dtype=None, device=None, memory_format=None):
     return dispatch("zeros", dev, shape, dtype=dtype, memory_format=memory_format)
 
 
+def zeros_like(input, *, dtype=None, device=None, memory_format=None):
+    if dtype is None:
+        dtype = input.dtype
+    if device is None:
+        device = input.device
+    return zeros(input.shape, dtype=dtype, device=device, memory_format=memory_format)
+
+
 def ones(shape, *, dtype=None, device=None, memory_format=None):
     dev = _as_device(device)
     return dispatch("ones", dev, shape, dtype=dtype, memory_format=memory_format)

--- a/src/mindtorch_v2/distributed/_hccl/hccl_bindings.py
+++ b/src/mindtorch_v2/distributed/_hccl/hccl_bindings.py
@@ -1,13 +1,81 @@
 import ctypes
+import struct
 
 from .hccl_loader import ensure_hccl
 
 HCCL_SUCCESS = 0
 HCCL_ROOT_INFO_BYTES = 4108
+HCCL_COMM_CONFIG_INFO_BYTES = 24
+COMM_NAME_MAX_LENGTH = 128
+UDI_MAX_LENGTH = 128
+HCCL_COMM_CONFIG_MAGIC_WORD = 0xf0f0f0f0
+HCCL_COMM_CONFIG_VERSION = 6
+HCCL_COMM_DEFAULT_BUFFSIZE = 200
+HCCL_COMM_BUFFSIZE_CONFIG_NOT_SET = 0xffffffff
+HCCL_COMM_DETERMINISTIC_CONFIG_NOT_SET = 0xffffffff
+HCCL_COMM_DEFAULT_OP_EXPANSION_MODE = 0
+HCCL_COMM_TRAFFIC_CLASS_CONFIG_NOT_SET = 0xffffffff
+HCCL_COMM_SERVICE_LEVEL_CONFIG_NOT_SET = 0xffffffff
+
+# HcclCommConfigCapability enum
+HCCL_COMM_CONFIG_BUFFER_SIZE = 0
+HCCL_COMM_CONFIG_DETERMINISTIC = 1
+HCCL_COMM_CONFIG_COMM_NAME = 2
+HCCL_COMM_CONFIG_OP_EXPANSION_MODE = 3
+HCCL_COMM_CONFIG_SUPPORT_INIT_BY_ENV = 4
+HCCL_COMM_CONFIG_WORLD_RANKID = 5
+HCCL_COMM_CONFIG_JOBID = 6
 
 
 class HcclRootInfo(ctypes.Structure):
     _fields_ = [("internal", ctypes.c_char * HCCL_ROOT_INFO_BYTES)]
+
+
+class HcclCommConfig(ctypes.Structure):
+    _fields_ = [
+        ("reserved", ctypes.c_char * HCCL_COMM_CONFIG_INFO_BYTES),
+        ("hcclBufferSize", ctypes.c_uint32),
+        ("hcclDeterministic", ctypes.c_uint32),
+        ("hcclCommName", ctypes.c_char * COMM_NAME_MAX_LENGTH),
+        ("hcclUdi", ctypes.c_char * UDI_MAX_LENGTH),
+        ("hcclOpExpansionMode", ctypes.c_uint32),
+        ("hcclRdmaTrafficClass", ctypes.c_uint32),
+        ("hcclRdmaServiceLevel", ctypes.c_uint32),
+        ("hcclWorldRankID", ctypes.c_uint32),
+        ("hcclJobID", ctypes.c_uint64),
+    ]
+
+
+def hccl_comm_config_init(config):
+    """Python equivalent of the inline HcclCommConfigInit() from hccl.h."""
+    ctypes.memset(ctypes.byref(config), 0, ctypes.sizeof(config))
+    # reserved header: size(8B) + magicWord(4B) + version(4B) + reserved(8B)
+    header = struct.pack(
+        "<QII Q",
+        ctypes.sizeof(HcclCommConfig),  # size = sizeof(HcclCommConfig)
+        HCCL_COMM_CONFIG_MAGIC_WORD,
+        HCCL_COMM_CONFIG_VERSION,
+        0,
+    )
+    # NOTE: must write to addressof(config), NOT config.reserved
+    # (ctypes char array attribute access returns a temporary copy)
+    ctypes.memmove(ctypes.addressof(config), header, len(header))
+    config.hcclBufferSize = HCCL_COMM_BUFFSIZE_CONFIG_NOT_SET
+    config.hcclDeterministic = HCCL_COMM_DETERMINISTIC_CONFIG_NOT_SET
+    config.hcclOpExpansionMode = HCCL_COMM_DEFAULT_OP_EXPANSION_MODE
+    config.hcclRdmaTrafficClass = HCCL_COMM_TRAFFIC_CLASS_CONFIG_NOT_SET
+    config.hcclRdmaServiceLevel = HCCL_COMM_SERVICE_LEVEL_CONFIG_NOT_SET
+    config.hcclWorldRankID = 0
+    config.hcclJobID = 0
+
+
+def is_hccl_feature_supported(capability_bit):
+    """Check if an HCCL feature is supported via HcclGetCommConfigCapability."""
+    bindings = get_bindings()
+    if bindings.get_comm_config_capability is None:
+        return False
+    cap = bindings.get_comm_config_capability()
+    return bool(cap & (1 << capability_bit))
 
 
 # HcclDataType enum values
@@ -31,8 +99,21 @@ def _bind(lib, name, restype, argtypes):
     return func
 
 
+def _try_bind(lib, name, restype, argtypes):
+    """Bind a function if it exists in the library, return None otherwise."""
+    if hasattr(lib, name):
+        return _bind(lib, name, restype, argtypes)
+    return None
+
+
 def _check(ret, name):
     if ret != HCCL_SUCCESS:
+        # Try to get error string
+        bindings = get_bindings()
+        if bindings.get_error_string is not None:
+            err_str = bindings.get_error_string(ret)
+            if err_str:
+                raise RuntimeError(f"{name} failed: {err_str} (error code {ret})")
         raise RuntimeError(f"{name} failed with error code {ret}")
 
 
@@ -52,6 +133,28 @@ class HcclBindings:
         self.comm_init_root_info = _bind(
             lib, "HcclCommInitRootInfo", i32,
             [u32, ctypes.POINTER(HcclRootInfo), u32, ctypes.POINTER(vp)])
+        self.comm_init_root_info_config = _bind(
+            lib, "HcclCommInitRootInfoConfig", i32,
+            [u32, ctypes.POINTER(HcclRootInfo), u32,
+             ctypes.POINTER(HcclCommConfig), ctypes.POINTER(vp)])
+        self.comm_init_cluster_info = _try_bind(
+            lib, "HcclCommInitClusterInfo", i32,
+            [ctypes.c_char_p, u32, ctypes.POINTER(vp)])
+        self.comm_init_cluster_info_config = _try_bind(
+            lib, "HcclCommInitClusterInfoConfig", i32,
+            [ctypes.c_char_p, u32, ctypes.POINTER(HcclCommConfig),
+             ctypes.POINTER(vp)])
+        self.create_sub_comm_config = _try_bind(
+            lib, "HcclCreateSubCommConfig", i32,
+            [ctypes.POINTER(vp), u32, ctypes.POINTER(u32), u64, u32,
+             ctypes.POINTER(HcclCommConfig), ctypes.POINTER(vp)])
+        self.comm_init_all = _try_bind(
+            lib, "HcclCommInitAll", i32,
+            [u32, ctypes.POINTER(i32), ctypes.POINTER(vp)])
+        self.get_comm_config_capability = _try_bind(
+            lib, "HcclGetCommConfigCapability", u32, [])
+        self.get_error_string = _try_bind(
+            lib, "HcclGetErrorString", ctypes.c_char_p, [i32])
         self.all_reduce = _bind(
             lib, "HcclAllReduce", i32,
             [vp, vp, u64, i32, i32, vp, vp])

--- a/src/mindtorch_v2/distributed/_object_collectives.py
+++ b/src/mindtorch_v2/distributed/_object_collectives.py
@@ -1,138 +1,150 @@
-import io
 import pickle
 
+import mindtorch_v2 as torch
 
-def _object_to_tensor(obj):
-    """Serialize a picklable object to a uint8 tensor."""
-    import mindtorch_v2 as torch
+
+def _get_device(group, device):
+    """Get the device to use for object collectives."""
+    if device is not None:
+        return device
+    from . import _default_pg
+    from .._device import device as Device
+    pg = group or _default_pg
+    if pg is not None and hasattr(pg, '_device_id'):
+        return Device('npu', pg._device_id)
+    return Device('cpu')
+
+
+def _object_to_tensor(obj, device):
+    """Serialize a picklable object to a uint8 tensor on device."""
     buf = pickle.dumps(obj)
-    t = torch.tensor(list(buf), dtype=torch.uint8)
-    return t, torch.tensor([len(buf)], dtype=torch.int64)
+    t = torch.tensor(list(buf), dtype=torch.uint8, device=device)
+    return t, torch.tensor([len(buf)], dtype=torch.int64, device=device)
 
 
 def _tensor_to_object(tensor, size):
     """Deserialize a uint8 tensor back to a Python object."""
-    buf = bytes(tensor[:int(size)].tolist())
+    buf = bytes(tensor[:int(size)].to('cpu').tolist())
     return pickle.loads(buf)
 
 
 def broadcast_object_list(object_list, src=0, group=None, device=None):
-    from . import broadcast, get_rank, get_world_size
-    import mindtorch_v2 as torch
+    from . import broadcast, get_rank
 
     rank = get_rank(group)
-    size_list = torch.tensor([0] * len(object_list), dtype=torch.int64)
+    dev = _get_device(group, device)
+    size_list = torch.tensor([0] * len(object_list), dtype=torch.int64, device=dev)
 
     if rank == src:
         tensor_list = []
         for i, obj in enumerate(object_list):
-            t, s = _object_to_tensor(obj)
+            t, s = _object_to_tensor(obj, dev)
             tensor_list.append(t)
             size_list[i] = s[0]
 
     broadcast(size_list, src=src, group=group)
 
     if rank == src:
-        max_size = int(max(size_list).tolist())
-        flat = torch.zeros(len(object_list) * max_size, dtype=torch.uint8)
+        max_size = int(max(size_list).to('cpu').item())
+        flat = torch.zeros(len(object_list) * max_size, dtype=torch.uint8, device=dev)
         for i, t in enumerate(tensor_list):
             flat[i * max_size: i * max_size + t.numel()] = t
     else:
-        max_size = int(max(size_list).tolist())
-        flat = torch.zeros(len(object_list) * max_size, dtype=torch.uint8)
+        max_size = int(max(size_list).to('cpu').item())
+        flat = torch.zeros(len(object_list) * max_size, dtype=torch.uint8, device=dev)
 
     broadcast(flat, src=src, group=group)
 
     if rank != src:
         for i in range(len(object_list)):
-            sz = int(size_list[i])
+            sz = int(size_list[i].to('cpu').item())
             object_list[i] = _tensor_to_object(
                 flat[i * max_size: i * max_size + sz], sz
             )
 
 
 def all_gather_object(object_list, obj, group=None):
-    from . import all_gather, get_rank, get_world_size, broadcast, all_reduce
-    import mindtorch_v2 as torch
+    from . import all_gather, get_world_size
 
     world_size = get_world_size(group)
-    t, size_tensor = _object_to_tensor(obj)
+    dev = _get_device(group, None)
+    t, size_tensor = _object_to_tensor(obj, dev)
 
     # Gather sizes
-    size_list = [torch.tensor([0], dtype=torch.int64) for _ in range(world_size)]
+    size_list = [torch.tensor([0], dtype=torch.int64, device=dev) for _ in range(world_size)]
     all_gather(size_list, size_tensor, group=group)
 
-    max_size = max(int(s[0]) for s in size_list)
-    padded = torch.zeros(max_size, dtype=torch.uint8)
+    max_size = max(int(s[0].to('cpu').item()) for s in size_list)
+    padded = torch.zeros(max_size, dtype=torch.uint8, device=dev)
     padded[:t.numel()] = t
 
-    tensor_list = [torch.zeros(max_size, dtype=torch.uint8) for _ in range(world_size)]
+    tensor_list = [torch.zeros(max_size, dtype=torch.uint8, device=dev) for _ in range(world_size)]
     all_gather(tensor_list, padded, group=group)
 
     for i in range(world_size):
-        sz = int(size_list[i][0])
+        sz = int(size_list[i][0].to('cpu').item())
         object_list[i] = _tensor_to_object(tensor_list[i], sz)
 
 
 def gather_object(obj, object_gather_list=None, dst=0, group=None):
-    from . import gather, get_rank, get_world_size, all_gather
-    import mindtorch_v2 as torch
+    from . import get_rank, get_world_size, all_gather
 
     rank = get_rank(group)
     world_size = get_world_size(group)
-    t, size_tensor = _object_to_tensor(obj)
+    dev = _get_device(group, None)
+    t, size_tensor = _object_to_tensor(obj, dev)
 
     # Use all_gather for sizes since HCCL may not support gather directly
-    size_list = [torch.tensor([0], dtype=torch.int64) for _ in range(world_size)]
+    size_list = [torch.tensor([0], dtype=torch.int64, device=dev) for _ in range(world_size)]
     all_gather(size_list, size_tensor, group=group)
 
-    max_size = max(int(s[0]) for s in size_list)
-    padded = torch.zeros(max_size, dtype=torch.uint8)
+    max_size = max(int(s[0].to('cpu').item()) for s in size_list)
+    padded = torch.zeros(max_size, dtype=torch.uint8, device=dev)
     padded[:t.numel()] = t
 
-    tensor_list = [torch.zeros(max_size, dtype=torch.uint8) for _ in range(world_size)]
+    tensor_list = [torch.zeros(max_size, dtype=torch.uint8, device=dev) for _ in range(world_size)]
     all_gather(tensor_list, padded, group=group)
 
     if rank == dst and object_gather_list is not None:
         for i in range(world_size):
-            sz = int(size_list[i][0])
+            sz = int(size_list[i][0].to('cpu').item())
             object_gather_list[i] = _tensor_to_object(tensor_list[i], sz)
 
 
 def scatter_object_list(scatter_object_output_list, scatter_object_input_list=None,
                         src=0, group=None):
     from . import broadcast, get_rank, get_world_size
-    import mindtorch_v2 as torch
 
     rank = get_rank(group)
     world_size = get_world_size(group)
+    dev = _get_device(group, None)
 
     if rank == src:
         tensor_sizes = []
         tensors = []
         for obj in scatter_object_input_list:
-            t, s = _object_to_tensor(obj)
+            t, s = _object_to_tensor(obj, dev)
             tensors.append(t)
-            tensor_sizes.append(int(s[0]))
+            tensor_sizes.append(int(s[0].to('cpu').item()))
         max_size = max(tensor_sizes)
-        size_tensor = torch.tensor(tensor_sizes, dtype=torch.int64)
+        size_tensor = torch.tensor(tensor_sizes, dtype=torch.int64, device=dev)
     else:
         max_size = 0
-        size_tensor = torch.tensor([0] * world_size, dtype=torch.int64)
+        size_tensor = torch.tensor([0] * world_size, dtype=torch.int64, device=dev)
 
     broadcast(size_tensor, src=src, group=group)
-    max_size = int(max(size_tensor).tolist())
+    max_size = int(max(size_tensor).to('cpu').item())
 
     if rank == src:
-        flat = torch.zeros(world_size * max_size, dtype=torch.uint8)
+        flat = torch.zeros(world_size * max_size, dtype=torch.uint8, device=dev)
         for i, t in enumerate(tensors):
             flat[i * max_size: i * max_size + t.numel()] = t
     else:
-        flat = torch.zeros(world_size * max_size, dtype=torch.uint8)
+        flat = torch.zeros(world_size * max_size, dtype=torch.uint8, device=dev)
 
     broadcast(flat, src=src, group=group)
 
-    sz = int(size_tensor[rank])
+    sz = int(size_tensor[rank].to('cpu').item())
     scatter_object_output_list[0] = _tensor_to_object(
         flat[rank * max_size: rank * max_size + sz], sz
     )


### PR DESCRIPTION
## Summary

Add ProcessGroupHCCL using direct ctypes bindings to libhccl.so, with **no MindSpore dependency**. Supports all core collective operations for distributed training on Ascend NPU.

## Supported Operations

✅ All collective operations:
- `all_reduce`, `broadcast`, `reduce`
- `all_gather`, `all_gather_into_tensor`, `reduce_scatter`
- `scatter`, `send`, `recv`, `barrier`
- Object collectives: `broadcast_object_list`, `all_gather_object`, `gather_object`, `scatter_object_list`

## Key Implementation Details

1. **Direct HCCL ctypes bindings** - No MindSpore communication layer dependency
2. **HcclCommConfig initialization** - Matches `hccl.h` inline `HcclCommConfigInit()` (size=312, not 32)
3. **Root info exchange** - Via TCPStore for multi-process coordination
4. **Ranktable fallback** - Supports `RANK_TABLE_FILE` + `HcclCommInitClusterInfoConfig` for multi-node
5. **Feature detection** - Uses `HcclGetCommConfigCapability` for CANN version compatibility
6. **ctypes char array fix** - Critical: `memmove` to `addressof(struct)` not `struct.field` (field accessor returns temp copy)
7. **NPU device tensors** - Object collectives create tensors on NPU (not CPU) to avoid HCCL runtime errors

## Test Results

Comprehensive 2-process test: **9/9 passed**
- all_reduce: [1] + [2] = [3] ✓
- broadcast: rank 0's [42] → all ranks ✓
- reduce, all_gather, reduce_scatter ✓
- send/recv, barrier ✓
- broadcast_object_list (Python objects) ✓

## Additional Changes

- Added `zeros_like` utility function needed by distributed collectives

🤖 Generated with [Claude Code](https://claude.com/claude-code)