### PR TITLE
Dispatch: align key order with torch

### DIFF
--- a/src/mindtorch_v2/_dispatch/dispatcher.py
+++ b/src/mindtorch_v2/_dispatch/dispatcher.py
@@ -168,7 +168,7 @@ def _key_order(keyset):
         DispatchKey.ADInplaceOrView,
         DispatchKey.AutogradOther,
         DispatchKey.AutogradCPU,
-        DispatchKey.AutogradCUDA,
+        DispatchKey.AutogradNPU,
         DispatchKey.AutogradXPU,
         DispatchKey.AutogradMeta,
         DispatchKey.Pipeline,

--- a/src/mindtorch_v2/_dispatch/keys.py
+++ b/src/mindtorch_v2/_dispatch/keys.py
@@ -6,7 +6,7 @@ class DispatchKey(Enum):
     ADInplaceOrView = auto()
     AutogradOther = auto()
     AutogradCPU = auto()
-    AutogradCUDA = auto()
+    AutogradNPU = auto()
     AutogradXPU = auto()
     AutogradMeta = auto()
     Autograd = auto()
@@ -74,7 +74,7 @@ class DispatchKeySet(set):
                 DispatchKey.ADInplaceOrView,
                 DispatchKey.AutogradOther,
                 DispatchKey.AutogradCPU,
-                DispatchKey.AutogradCUDA,
+                DispatchKey.AutogradNPU,
                 DispatchKey.AutogradXPU,
                 DispatchKey.AutogradMeta,
                 DispatchKey.Python,

--- a/src/mindtorch_v2/_dispatch/registry.py
+++ b/src/mindtorch_v2/_dispatch/registry.py
@@ -96,7 +96,7 @@ def _register_global_fallthroughs():
         DispatchKey.ADInplaceOrView,
         DispatchKey.AutogradOther,
         DispatchKey.AutogradCPU,
-        DispatchKey.AutogradCUDA,
+        DispatchKey.AutogradNPU,
         DispatchKey.AutogradXPU,
         DispatchKey.AutogradMeta,
         DispatchKey.Python,

--- a/tests/mindtorch_v2/contract/test_dispatch_key_order.py
+++ b/tests/mindtorch_v2/contract/test_dispatch_key_order.py
@@ -13,3 +13,8 @@ def test_dispatch_key_order_prefix_matches_torch_cuda():
         "CPU",
     ]
     assert names[: len(prefix)] == prefix
+
+
+def test_dispatch_key_includes_autograd_npu():
+    assert DispatchKey.AutogradNPU in DispatchKey
+    assert not hasattr(DispatchKey, "AutogradCUDA")


### PR DESCRIPTION
## Summary
- add placeholder dispatch keys to mirror torch key ordering
- align dispatcher key order with torch CUDA position mapping for NPU
- register global fallthrough for placeholder keys and add contract test

## Test Plan
- [x] source /home/lvyufeng/miniconda3/bin/activate mindspore && pytest -q tests/mindtorch_v2
