### PR TITLE
Dispatch: refine keyset and pipeline order

### DIFF
--- a/src/mindtorch_v2/_dispatch/dispatcher.py
+++ b/src/mindtorch_v2/_dispatch/dispatcher.py
@@ -157,6 +157,7 @@ def _kernel_for_entry(entry, key_order):
 
 def _key_order(keyset):
     order = [
+        DispatchKey.Pipeline,
         DispatchKey.Functionalize,
         DispatchKey.Autograd,
         DispatchKey.Meta,
@@ -171,7 +172,6 @@ def _key_order(keyset):
         DispatchKey.AutogradNPU,
         DispatchKey.AutogradXPU,
         DispatchKey.AutogradMeta,
-        DispatchKey.Pipeline,
     ]
     return [key for key in order if key in keyset]
 

--- a/src/mindtorch_v2/_dispatch/keys.py
+++ b/src/mindtorch_v2/_dispatch/keys.py
@@ -67,18 +67,4 @@ class DispatchKeySet(set):
             keys.add(DispatchKey.Functionalize)
         if pipeline_enabled and not has_meta:
             keys.add(DispatchKey.Pipeline)
-        # Placeholders for torch-aligned key ordering; fallthrough by default.
-        keys.update(
-            {
-                DispatchKey.BackendSelect,
-                DispatchKey.ADInplaceOrView,
-                DispatchKey.AutogradOther,
-                DispatchKey.AutogradCPU,
-                DispatchKey.AutogradNPU,
-                DispatchKey.AutogradXPU,
-                DispatchKey.AutogradMeta,
-                DispatchKey.Python,
-                DispatchKey.Autocast,
-            }
-        )
         return keys

--- a/tests/mindtorch_v2/contract/test_dispatch_fallthrough.py
+++ b/tests/mindtorch_v2/contract/test_dispatch_fallthrough.py
@@ -1,0 +1,35 @@
+from mindtorch_v2._dispatch.keys import DispatchKey, DispatchKeySet
+from mindtorch_v2._dispatch.registry import registry
+from mindtorch_v2._dispatch.dispatcher import dispatch_with_keyset
+
+
+def test_dispatch_fallthrough_skips_key():
+    registry.register_schema("aten::ft_op", "ft_op(Tensor a) -> Tensor")
+
+    def cpu_impl(a):
+        return a
+
+    registry.register_kernel("aten::ft_op", DispatchKey.CPU, cpu_impl)
+    registry.register_fallthrough("aten::ft_op", DispatchKey.Autograd)
+
+    keyset = DispatchKeySet({DispatchKey.Autograd, DispatchKey.CPU})
+    out = dispatch_with_keyset("ft_op", keyset, None, 1)
+    assert out == 1
+
+
+def test_dispatch_fallthrough_prefer_next_key():
+    registry.register_schema("aten::ft_op2", "ft_op2(Tensor a) -> Tensor")
+
+    def autograd_impl(a):
+        return "autograd"
+
+    def cpu_impl(a):
+        return "cpu"
+
+    registry.register_kernel("aten::ft_op2", DispatchKey.Autograd, autograd_impl)
+    registry.register_kernel("aten::ft_op2", DispatchKey.CPU, cpu_impl)
+    registry.register_fallthrough("aten::ft_op2", DispatchKey.Autograd)
+
+    keyset = DispatchKeySet({DispatchKey.Autograd, DispatchKey.CPU})
+    out = dispatch_with_keyset("ft_op2", keyset, None, 1)
+    assert out == "cpu"

--- a/tests/mindtorch_v2/contract/test_dispatch_key_order.py
+++ b/tests/mindtorch_v2/contract/test_dispatch_key_order.py
@@ -5,6 +5,8 @@ from mindtorch_v2._dispatch.dispatcher import _key_order
 def test_dispatch_key_order_prefix_matches_torch_cuda():
     keys = _key_order(set(DispatchKey))
     names = [key.name for key in keys]
+    if names and names[0] == "Pipeline":
+        names = names[1:]
     prefix = [
         "Functionalize",
         "Autograd",

--- a/tests/mindtorch_v2/contract/test_dispatch_keyset_construction.py
+++ b/tests/mindtorch_v2/contract/test_dispatch_keyset_construction.py
@@ -1,0 +1,18 @@
+from mindtorch_v2._dispatch.keys import DispatchKey, DispatchKeySet
+import mindtorch_v2 as torch
+
+
+def test_keyset_excludes_placeholders_by_default():
+    t = torch.ones((2,))
+    keyset = DispatchKeySet.from_tensors((t,))
+    assert DispatchKey.BackendSelect not in keyset
+    assert DispatchKey.AutogradNPU not in keyset
+    assert DispatchKey.Autocast not in keyset
+
+
+def test_keyset_includes_pipeline_only_when_enabled():
+    t = torch.ones((2,))
+    keyset = DispatchKeySet.from_tensors((t,), pipeline_enabled=False)
+    assert DispatchKey.Pipeline not in keyset
+    keyset = DispatchKeySet.from_tensors((t,), pipeline_enabled=True)
+    assert DispatchKey.Pipeline in keyset

--- a/tests/mindtorch_v2/contract/test_dispatch_pipeline_priority.py
+++ b/tests/mindtorch_v2/contract/test_dispatch_pipeline_priority.py
@@ -1,0 +1,20 @@
+from mindtorch_v2._dispatch.keys import DispatchKey, DispatchKeySet
+from mindtorch_v2._dispatch.registry import registry
+from mindtorch_v2._dispatch.dispatcher import dispatch_with_keyset
+
+
+def test_pipeline_key_precedes_functionalize():
+    registry.register_schema("aten::pipe_order", "pipe_order(Tensor a) -> Tensor")
+
+    def pipeline_impl(a):
+        return "pipeline"
+
+    def func_impl(a):
+        return "functionalize"
+
+    registry.register_kernel("aten::pipe_order", DispatchKey.Pipeline, pipeline_impl)
+    registry.register_kernel("aten::pipe_order", DispatchKey.Functionalize, func_impl)
+
+    keyset = DispatchKeySet({DispatchKey.Pipeline, DispatchKey.Functionalize})
+    out = dispatch_with_keyset("pipe_order", keyset, None, 1)
+    assert out == "pipeline"


### PR DESCRIPTION
## Summary
- exclude placeholder keys from default keyset construction
- prioritize Pipeline in dispatch order and add fallthrough/pipeline/keyset contracts
- align key order test to allow Pipeline prelude

## Test Plan
- [x] source /home/lvyufeng/miniconda3/bin/activate mindspore && pytest -q tests/mindtorch_v2
