### PR TITLE
feat: add dsplit hsplit vsplit

### DIFF
--- a/docs/plans/2026-02-22-dsplit-hsplit-vsplit-plan.md
+++ b/docs/plans/2026-02-22-dsplit-hsplit-vsplit-plan.md
@@ -1,0 +1,251 @@
+# dsplit/hsplit/vsplit Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add CPU + meta support for `dsplit`, `hsplit`, `vsplit` with PyTorch-aligned behavior and update ops coverage.
+
+**Architecture:** Implement `dsplit/hsplit/vsplit` as thin wrappers around existing `split` in CPU backend; register ops for dispatch + meta. Meta backend adds wrapper ops and meta inference functions that select the correct dimension and enforce `dsplit` dimensionality. Functional APIs dispatch to backend kernels; `__init__` exports the functions.
+
+**Tech Stack:** Python, NumPy, PyTest, mindtorch v2 dispatch/registry.
+
+---
+
+### Task 1: Verify tests are red (TDD baseline)
+
+**Files:**
+- Test: `tests/mindtorch_v2/test_ops_cpu.py`
+- Test: `tests/mindtorch_v2/test_meta_device.py`
+
+**Step 1: Add failing tests**
+
+Add CPU tests:
+- `test_vsplit_cpu` (1D and 2D)
+- `test_hsplit_cpu` (1D uses dim=0; 2D uses dim=1)
+- `test_dsplit_cpu` (3D split + 2D error)
+
+Add meta tests:
+- `test_meta_vsplit_shape`
+- `test_meta_hsplit_shape`
+- `test_meta_dsplit_shape`
+
+**Step 2: Run tests (expect FAIL)**
+
+Run:
+`pytest tests/mindtorch_v2/test_ops_cpu.py::test_vsplit_cpu tests/mindtorch_v2/test_ops_cpu.py::test_hsplit_cpu tests/mindtorch_v2/test_ops_cpu.py::test_dsplit_cpu tests/mindtorch_v2/test_meta_device.py::test_meta_vsplit_shape tests/mindtorch_v2/test_meta_device.py::test_meta_hsplit_shape tests/mindtorch_v2/test_meta_device.py::test_meta_dsplit_shape -q`
+
+Expected: FAIL with op not registered/implemented.
+
+---
+
+### Task 2: Add CPU kernels (vsplit/hsplit/dsplit)
+
+**Files:**
+- Modify: `src/mindtorch_v2/_backends/cpu/ops.py`
+
+**Step 1: Write minimal implementations**
+
+Add:
+
+```python
+def vsplit(a, split_size_or_sections):
+    return split(a, split_size_or_sections, dim=0)
+
+
+def hsplit(a, split_size_or_sections):
+    dim = 0 if a.dim() == 1 else 1
+    return split(a, split_size_or_sections, dim=dim)
+
+
+def dsplit(a, split_size_or_sections):
+    if a.dim() < 3:
+        raise ValueError("dsplit expects input with at least 3 dimensions")
+    return split(a, split_size_or_sections, dim=2)
+```
+
+**Step 2: Run CPU tests**
+
+Run:
+`pytest tests/mindtorch_v2/test_ops_cpu.py::test_vsplit_cpu tests/mindtorch_v2/test_ops_cpu.py::test_hsplit_cpu tests/mindtorch_v2/test_ops_cpu.py::test_dsplit_cpu -q`
+
+Expected: PASS for CPU tests.
+
+---
+
+### Task 3: Register CPU ops
+
+**Files:**
+- Modify: `src/mindtorch_v2/_backends/cpu/__init__.py`
+
+**Step 1: Add imports**
+
+Add `vsplit`, `hsplit`, `dsplit` to imports.
+
+**Step 2: Register**
+
+Add:
+
+```python
+registry.register("vsplit", "cpu", vsplit, meta=meta_infer.infer_vsplit)
+registry.register("hsplit", "cpu", hsplit, meta=meta_infer.infer_hsplit)
+registry.register("dsplit", "cpu", dsplit, meta=meta_infer.infer_dsplit)
+```
+
+**Step 3: Re-run CPU tests**
+
+Run:
+`pytest tests/mindtorch_v2/test_ops_cpu.py::test_vsplit_cpu tests/mindtorch_v2/test_ops_cpu.py::test_hsplit_cpu tests/mindtorch_v2/test_ops_cpu.py::test_dsplit_cpu -q`
+
+Expected: PASS.
+
+---
+
+### Task 4: Add meta infer (vsplit/hsplit/dsplit)
+
+**Files:**
+- Modify: `src/mindtorch_v2/_backends/meta/infer.py`
+
+**Step 1: Implement infer_vsplit/infer_hsplit/infer_dsplit**
+
+```python
+def infer_vsplit(a, split_size_or_sections):
+    return infer_split(a, split_size_or_sections, dim=0)
+
+
+def infer_hsplit(a, split_size_or_sections):
+    dim = 0 if len(a.shape) == 1 else 1
+    return infer_split(a, split_size_or_sections, dim=dim)
+
+
+def infer_dsplit(a, split_size_or_sections):
+    if len(a.shape) < 3:
+        raise ValueError("dsplit expects input with at least 3 dimensions")
+    return infer_split(a, split_size_or_sections, dim=2)
+```
+
+**Step 2: Run meta tests**
+
+Run:
+`pytest tests/mindtorch_v2/test_meta_device.py::test_meta_vsplit_shape tests/mindtorch_v2/test_meta_device.py::test_meta_hsplit_shape tests/mindtorch_v2/test_meta_device.py::test_meta_dsplit_shape -q`
+
+Expected: PASS.
+
+---
+
+### Task 5: Add meta op registration
+
+**Files:**
+- Modify: `src/mindtorch_v2/_backends/meta/ops.py`
+- Modify: `src/mindtorch_v2/_backends/meta/__init__.py`
+
+**Step 1: Add meta wrapper ops**
+
+In `ops.py` add:
+
+```python
+def _meta_vsplit_meta(a, split_size_or_sections):
+    return _meta_split_meta(a, split_size_or_sections, dim=0)
+
+
+def _meta_hsplit_meta(a, split_size_or_sections):
+    dim = 0 if len(a.shape) == 1 else 1
+    return _meta_split_meta(a, split_size_or_sections, dim=dim)
+
+
+def _meta_dsplit_meta(a, split_size_or_sections):
+    if len(a.shape) < 3:
+        raise ValueError("dsplit expects input with at least 3 dimensions")
+    return _meta_split_meta(a, split_size_or_sections, dim=2)
+```
+
+**Step 2: Register**
+
+In `meta/__init__.py` add imports and register:
+
+```python
+registry.register("vsplit", "meta", _meta_vsplit_meta)
+registry.register("hsplit", "meta", _meta_hsplit_meta)
+registry.register("dsplit", "meta", _meta_dsplit_meta)
+```
+
+---
+
+### Task 6: Functional API + exports
+
+**Files:**
+- Modify: `src/mindtorch_v2/_functional.py`
+- Modify: `src/mindtorch_v2/__init__.py`
+
+**Step 1: Add functional wrappers**
+
+```python
+def vsplit(a, split_size_or_sections):
+    return dispatch("vsplit", a.device.type, a, split_size_or_sections)
+
+
+def hsplit(a, split_size_or_sections):
+    return dispatch("hsplit", a.device.type, a, split_size_or_sections)
+
+
+def dsplit(a, split_size_or_sections):
+    return dispatch("dsplit", a.device.type, a, split_size_or_sections)
+```
+
+**Step 2: Export in `__init__.py`**
+
+Add to import list and `__all__`: `vsplit`, `hsplit`, `dsplit`.
+
+---
+
+### Task 7: Update ops coverage doc
+
+**Files:**
+- Modify: `docs/plans/ops-coverage.md`
+
+**Step 1: Add entries**
+
+Add lines for:
+- `aten::vsplit`
+- `aten::hsplit`
+- `aten::dsplit`
+
+---
+
+### Task 8: Commit
+
+**Step 1: Git status**
+
+Run: `git status -sb`
+
+**Step 2: Commit**
+
+Run:
+```bash
+git add tests/mindtorch_v2/test_ops_cpu.py tests/mindtorch_v2/test_meta_device.py \
+  src/mindtorch_v2/_backends/cpu/ops.py src/mindtorch_v2/_backends/cpu/__init__.py \
+  src/mindtorch_v2/_backends/meta/infer.py src/mindtorch_v2/_backends/meta/ops.py \
+  src/mindtorch_v2/_backends/meta/__init__.py src/mindtorch_v2/_functional.py \
+  src/mindtorch_v2/__init__.py docs/plans/ops-coverage.md
+
+git commit -m "feat: add dsplit hsplit vsplit"
+```
+
+---
+
+### Task 9: Verification + PR prep
+
+**Step 1: Run focused tests**
+
+Run:
+`pytest tests/mindtorch_v2/test_ops_cpu.py::test_vsplit_cpu tests/mindtorch_v2/test_ops_cpu.py::test_hsplit_cpu tests/mindtorch_v2/test_ops_cpu.py::test_dsplit_cpu tests/mindtorch_v2/test_meta_device.py::test_meta_vsplit_shape tests/mindtorch_v2/test_meta_device.py::test_meta_hsplit_shape tests/mindtorch_v2/test_meta_device.py::test_meta_dsplit_shape -q`
+
+Expected: PASS.
+
+**Step 2: Rebase `ms/master`**
+
+Run:
+`git fetch`
+`git rebase ms/master`
+
+**Step 3: Push + create PR**
+
+Use correct PR description with real newlines (heredoc).

--- a/docs/plans/ops-coverage.md
+++ b/docs/plans/ops-coverage.md
@@ -128,4 +128,7 @@ This document is about collaboration rules only (not defining the op scope).
 | `aten::cartesian_prod` | CPU | done | - | numpy impl + meta + tests |
 | `aten::chunk` | CPU | done | - | numpy impl + meta + tests |
 | `aten::split` | CPU | done | - | numpy impl + meta + tests |
+| `aten::vsplit` | CPU | done | - | numpy impl + meta + tests |
+| `aten::hsplit` | CPU | done | - | numpy impl + meta + tests |
+| `aten::dsplit` | CPU | done | - | numpy impl + meta + tests |
 | `aten::unbind` | CPU | done | - | numpy impl + meta + tests |

--- a/src/mindtorch_v2/__init__.py
+++ b/src/mindtorch_v2/__init__.py
@@ -16,7 +16,7 @@ from ._tensor import Tensor
 from ._creation import tensor, zeros, ones, empty, arange, linspace, full, logspace, eye, range
 from ._functional import zeros_like
 from ._storage import UntypedStorage, TypedStorage
-from ._functional import add, mul, matmul, relu, sum, all, any, argmax, argmin, count_nonzero, allclose, isclose, equal, cumsum, cumprod, cummax, argsort, sort, topk, stack, cat, concat, concatenate, hstack, vstack, row_stack, dstack, column_stack, pad_sequence, block_diag, tril, triu, diag, cartesian_prod, chunk, split, unbind, tril_indices, triu_indices, abs, neg, exp, log, sqrt
+from ._functional import add, mul, matmul, relu, sum, all, any, argmax, argmin, count_nonzero, allclose, isclose, equal, cumsum, cumprod, cummax, argsort, sort, topk, stack, cat, concat, concatenate, hstack, vstack, row_stack, dstack, column_stack, pad_sequence, block_diag, tril, triu, diag, cartesian_prod, chunk, split, vsplit, hsplit, dsplit, unbind, tril_indices, triu_indices, abs, neg, exp, log, sqrt
 from ._functional import sin, cos, tan, tanh, sigmoid, floor, ceil, round, trunc, frac
 from ._functional import pow, log2, log10, exp2, rsqrt
 from ._functional import sign, signbit, isnan, isinf, isfinite
@@ -107,6 +107,9 @@ __all__ = [
     "cartesian_prod",
     "chunk",
     "split",
+    "vsplit",
+    "hsplit",
+    "dsplit",
     "unbind",
     "tril_indices",
     "triu_indices",

--- a/src/mindtorch_v2/_backends/cpu/__init__.py
+++ b/src/mindtorch_v2/_backends/cpu/__init__.py
@@ -47,6 +47,9 @@ from .ops import (
     cartesian_prod,
     chunk,
     split,
+    vsplit,
+    hsplit,
+    dsplit,
     unbind,
     allclose,
     isclose,
@@ -214,6 +217,9 @@ registry.register("diag", "cpu", diag, meta=meta_infer.infer_diag)
 registry.register("cartesian_prod", "cpu", cartesian_prod, meta=meta_infer.infer_cartesian_prod)
 registry.register("chunk", "cpu", chunk, meta=meta_infer.infer_chunk)
 registry.register("split", "cpu", split, meta=meta_infer.infer_split)
+registry.register("vsplit", "cpu", vsplit, meta=meta_infer.infer_vsplit)
+registry.register("hsplit", "cpu", hsplit, meta=meta_infer.infer_hsplit)
+registry.register("dsplit", "cpu", dsplit, meta=meta_infer.infer_dsplit)
 registry.register("unbind", "cpu", unbind, meta=meta_infer.infer_unbind)
 registry.register("allclose", "cpu", allclose, meta=meta_infer.infer_reduce_bool)
 registry.register("isclose", "cpu", isclose, meta=meta_infer.infer_unary_bool)

--- a/src/mindtorch_v2/_backends/meta/__init__.py
+++ b/src/mindtorch_v2/_backends/meta/__init__.py
@@ -52,6 +52,9 @@ from .ops import (
     _meta_cartesian_prod_meta,
     _meta_chunk_meta,
     _meta_split_meta,
+    _meta_vsplit_meta,
+    _meta_hsplit_meta,
+    _meta_dsplit_meta,
     _meta_unbind_meta,
 )
 
@@ -131,6 +134,9 @@ registry.register("triu_indices", "meta", _meta_triu_indices_meta)
 registry.register("cartesian_prod", "meta", _meta_cartesian_prod_meta)
 registry.register("chunk", "meta", _meta_chunk_meta)
 registry.register("split", "meta", _meta_split_meta)
+registry.register("vsplit", "meta", _meta_vsplit_meta)
+registry.register("hsplit", "meta", _meta_hsplit_meta)
+registry.register("dsplit", "meta", _meta_dsplit_meta)
 registry.register("unbind", "meta", _meta_unbind_meta)
 registry.register("allclose", "meta", _meta_reduce_bool_meta)
 registry.register("isclose", "meta", _meta_binary_meta)

--- a/src/mindtorch_v2/_backends/meta/infer.py
+++ b/src/mindtorch_v2/_backends/meta/infer.py
@@ -289,6 +289,37 @@ def infer_split(a, split_size_or_sections, dim=0):
     return tuple(specs)
 
 
+def infer_vsplit(a, split_size_or_sections):
+    if isinstance(split_size_or_sections, int):
+        sizes = _split_sections_from_count(a.shape[0], split_size_or_sections)
+        return infer_split(a, sizes, dim=0)
+    return infer_split(a, split_size_or_sections, dim=0)
+
+
+def infer_hsplit(a, split_size_or_sections):
+    dim = 0 if len(a.shape) == 1 else 1
+    if isinstance(split_size_or_sections, int):
+        sizes = _split_sections_from_count(a.shape[dim], split_size_or_sections)
+        return infer_split(a, sizes, dim=dim)
+    return infer_split(a, split_size_or_sections, dim=dim)
+
+
+def infer_dsplit(a, split_size_or_sections):
+    if len(a.shape) < 3:
+        raise ValueError("dsplit expects input with at least 3 dimensions")
+    if isinstance(split_size_or_sections, int):
+        sizes = _split_sections_from_count(a.shape[2], split_size_or_sections)
+        return infer_split(a, sizes, dim=2)
+    return infer_split(a, split_size_or_sections, dim=2)
+
+
+def _split_sections_from_count(dim_size, sections):
+    if sections <= 0:
+        raise ValueError("sections must be > 0")
+    size, extra = divmod(dim_size, sections)
+    return [size + 1] * extra + [size] * (sections - extra)
+
+
 def infer_unbind(a, dim=0):
     dim_size = a.shape[dim]
     specs = []

--- a/src/mindtorch_v2/_backends/meta/ops.py
+++ b/src/mindtorch_v2/_backends/meta/ops.py
@@ -345,6 +345,37 @@ def _meta_split_meta(a, split_size_or_sections, dim=0):
     return tuple(specs)
 
 
+
+
+def _split_sections_from_count(dim_size, sections):
+    if sections <= 0:
+        raise ValueError("sections must be > 0")
+    size, extra = divmod(dim_size, sections)
+    return [size + 1] * extra + [size] * (sections - extra)
+def _meta_vsplit_meta(a, split_size_or_sections):
+    if isinstance(split_size_or_sections, int):
+        sizes = _split_sections_from_count(a.shape[0], split_size_or_sections)
+        return _meta_split_meta(a, sizes, dim=0)
+    return _meta_split_meta(a, split_size_or_sections, dim=0)
+
+
+def _meta_hsplit_meta(a, split_size_or_sections):
+    dim = 0 if len(a.shape) == 1 else 1
+    if isinstance(split_size_or_sections, int):
+        sizes = _split_sections_from_count(a.shape[dim], split_size_or_sections)
+        return _meta_split_meta(a, sizes, dim=dim)
+    return _meta_split_meta(a, split_size_or_sections, dim=dim)
+
+
+def _meta_dsplit_meta(a, split_size_or_sections):
+    if len(a.shape) < 3:
+        raise ValueError("dsplit expects input with at least 3 dimensions")
+    if isinstance(split_size_or_sections, int):
+        sizes = _split_sections_from_count(a.shape[2], split_size_or_sections)
+        return _meta_split_meta(a, sizes, dim=2)
+    return _meta_split_meta(a, split_size_or_sections, dim=2)
+
+
 def _meta_unbind_meta(a, dim=0):
     dim_size = a.shape[dim]
     specs = []
@@ -447,6 +478,9 @@ __all__ = [
     "_meta_cartesian_prod_meta",
     "_meta_chunk_meta",
     "_meta_split_meta",
+    "_meta_vsplit_meta",
+    "_meta_hsplit_meta",
+    "_meta_dsplit_meta",
     "_meta_unbind_meta",
     "_meta_transpose_meta",
     "_meta_unary_meta",

--- a/src/mindtorch_v2/_functional.py
+++ b/src/mindtorch_v2/_functional.py
@@ -492,6 +492,18 @@ def split(a, split_size_or_sections, dim=0):
     return dispatch("split", a.device.type, a, split_size_or_sections, dim)
 
 
+def vsplit(a, split_size_or_sections):
+    return dispatch("vsplit", a.device.type, a, split_size_or_sections)
+
+
+def hsplit(a, split_size_or_sections):
+    return dispatch("hsplit", a.device.type, a, split_size_or_sections)
+
+
+def dsplit(a, split_size_or_sections):
+    return dispatch("dsplit", a.device.type, a, split_size_or_sections)
+
+
 def unbind(a, dim=0):
     return dispatch("unbind", a.device.type, a, dim)
 

--- a/tests/mindtorch_v2/test_meta_device.py
+++ b/tests/mindtorch_v2/test_meta_device.py
@@ -312,6 +312,38 @@ def test_meta_tril_triu_indices_shape():
     assert out.shape == (2, 11)
 
 
+def test_meta_vsplit_shape():
+    x = torch.tensor([1.0, 2.0, 3.0, 4.0], device="meta")
+    out = torch.vsplit(x, 2)
+    assert len(out) == 2
+    assert out[0].shape == (2,)
+    assert out[1].shape == (2,)
+
+
+def test_meta_hsplit_shape():
+    x = torch.tensor([1.0, 2.0, 3.0, 4.0], device="meta")
+    out = torch.hsplit(x, 2)
+    assert len(out) == 2
+    assert out[0].shape == (2,)
+    assert out[1].shape == (2,)
+    y = torch.tensor([[1.0, 2.0], [3.0, 4.0]], device="meta")
+    out = torch.hsplit(y, 2)
+    assert len(out) == 2
+    assert out[0].shape == (2, 1)
+    assert out[1].shape == (2, 1)
+
+
+def test_meta_dsplit_shape():
+    x = torch.tensor([[[1.0, 2.0], [3.0, 4.0]]], device="meta")
+    out = torch.dsplit(x, 2)
+    assert len(out) == 2
+    assert out[0].shape == (1, 2, 1)
+    assert out[1].shape == (1, 2, 1)
+    y = torch.tensor([[1.0, 2.0], [3.0, 4.0]], device="meta")
+    with pytest.raises(ValueError):
+        torch.dsplit(y, 2)
+
+
 def test_meta_tril_triu_shape():
     x = torch.tensor([[1.0, 2.0]], device="meta")
     out = torch.tril(x, diagonal=-1)

--- a/tests/mindtorch_v2/test_ops_cpu.py
+++ b/tests/mindtorch_v2/test_ops_cpu.py
@@ -1,5 +1,6 @@
 import math
 import numpy as np
+import pytest
 import mindtorch_v2 as torch
 
 
@@ -672,6 +673,43 @@ def test_triu_indices_cpu():
     expected = np.vstack(np.triu_indices(row, k=offset, m=col))
     out = torch.triu_indices(row, col, offset=offset)
     np.testing.assert_allclose(out.numpy(), expected)
+
+
+def test_vsplit_cpu():
+    x = torch.tensor([1.0, 2.0, 3.0, 4.0])
+    out = torch.vsplit(x, 2)
+    assert len(out) == 2
+    np.testing.assert_allclose(out[0].numpy(), np.array([1.0, 2.0]))
+    np.testing.assert_allclose(out[1].numpy(), np.array([3.0, 4.0]))
+    y = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    out = torch.vsplit(y, 2)
+    assert len(out) == 2
+    np.testing.assert_allclose(out[0].numpy(), np.array([[1.0, 2.0]]))
+    np.testing.assert_allclose(out[1].numpy(), np.array([[3.0, 4.0]]))
+
+
+def test_hsplit_cpu():
+    x = torch.tensor([1.0, 2.0, 3.0, 4.0])
+    out = torch.hsplit(x, 2)
+    assert len(out) == 2
+    np.testing.assert_allclose(out[0].numpy(), np.array([1.0, 2.0]))
+    np.testing.assert_allclose(out[1].numpy(), np.array([3.0, 4.0]))
+    y = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    out = torch.hsplit(y, 2)
+    assert len(out) == 2
+    np.testing.assert_allclose(out[0].numpy(), np.array([[1.0], [3.0]]))
+    np.testing.assert_allclose(out[1].numpy(), np.array([[2.0], [4.0]]))
+
+
+def test_dsplit_cpu():
+    x = torch.tensor([[[1.0, 2.0], [3.0, 4.0]]])
+    out = torch.dsplit(x, 2)
+    assert len(out) == 2
+    np.testing.assert_allclose(out[0].numpy(), np.array([[[1.0], [3.0]]]))
+    np.testing.assert_allclose(out[1].numpy(), np.array([[[2.0], [4.0]]]))
+    y = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    with pytest.raises(ValueError):
+        torch.dsplit(y, 2)
 
 
 def test_logspace_cpu():


### PR DESCRIPTION
## Summary
- add CPU vsplit/hsplit/dsplit ops with array_split semantics
- add meta shape inference/registrations and functional exports
- add tests and update ops coverage

## Testing
- pytest tests/mindtorch_v2/test_ops_cpu.py::test_vsplit_cpu tests/mindtorch_v2/test_ops_cpu.py::test_hsplit_cpu tests/mindtorch_v2/test_ops_cpu.py::test_dsplit_cpu tests/mindtorch_v2/test_meta_device.py::test_meta_vsplit_shape tests/mindtorch_v2/test_meta_device.py::test_meta_hsplit_shape tests/mindtorch_v2/test_meta_device.py::test_meta_dsplit_shape -q