### PR TITLE
Autograd: add topo engine

### DIFF
--- a/src/mindtorch_v2/_autograd/engine.py
+++ b/src/mindtorch_v2/_autograd/engine.py
@@ -1,4 +1,150 @@
+from collections import deque
+import threading
+
 from .grad_mode import no_grad
+
+
+_GRAPH_STATE = threading.local()
+
+
+def _task_stack():
+    stack = getattr(_GRAPH_STATE, "stack", None)
+    if stack is None:
+        stack = []
+        _GRAPH_STATE.stack = stack
+    return stack
+
+
+class _GraphTask:
+    def __init__(self, dependencies, *, retain_graph, create_graph, accumulate_grad, grads_map=None):
+        self.dependencies = dependencies
+        self.received = {}
+        self.node_grads = {}
+        self.ready = deque()
+        self.retain_graph = retain_graph
+        self.create_graph = create_graph
+        self.accumulate_grad = accumulate_grad
+        self.grads_map = grads_map if grads_map is not None else {}
+
+    def _accumulate_tensor_grad(self, tensor, grad):
+        grad = _apply_hooks(tensor, grad)
+        if self.accumulate_grad:
+            if tensor.grad_fn is None or getattr(tensor, "_retain_grad", False):
+                if tensor.grad is None:
+                    tensor.grad = grad
+                else:
+                    from .._functional import add
+                    with no_grad():
+                        tensor.grad = add(tensor.grad, grad)
+        else:
+            prev = self.grads_map.get(tensor)
+            if prev is None:
+                self.grads_map[tensor] = grad
+            else:
+                from .._functional import add
+                with no_grad():
+                    self.grads_map[tensor] = add(prev, grad)
+        return grad
+
+    def _accumulate_node_grad(self, node, grad):
+        existing = self.node_grads.get(node)
+        if existing is None:
+            self.node_grads[node] = grad
+        else:
+            from .._functional import add
+            with no_grad():
+                self.node_grads[node] = add(existing, grad)
+        self.received[node] = self.received.get(node, 0) + 1
+        if self.received[node] >= self.dependencies.get(node, 0):
+            self.ready.append(node)
+
+    def run(self):
+        while self.ready:
+            node = self.ready.popleft()
+            grad = self.node_grads.pop(node, None)
+            if grad is None:
+                continue
+            grads = node.backward(grad)
+            if grads is None:
+                grads = ()
+            for t, g in zip(node.inputs, grads):
+                if g is None:
+                    continue
+                g = self._accumulate_tensor_grad(t, g)
+                if t.grad_fn is not None:
+                    self._accumulate_node_grad(t.grad_fn, g)
+            if not self.retain_graph:
+                node._saved_tensors = []
+
+
+def _apply_hooks(tensor, grad):
+    if tensor._backward_hooks:
+        for hook in tensor._backward_hooks.values():
+            result = hook(grad)
+            if result is not None:
+                grad = result
+    return grad
+
+
+def _build_dependencies(outputs):
+    nodes = set()
+    stack = [out.grad_fn for out in outputs if out.grad_fn is not None]
+    while stack:
+        node = stack.pop()
+        if node in nodes:
+            continue
+        nodes.add(node)
+        for inp in node.inputs:
+            fn = getattr(inp, "grad_fn", None)
+            if fn is not None:
+                stack.append(fn)
+    deps = {node: 0 for node in nodes}
+    for node in nodes:
+        seen = set()
+        for inp in node.inputs:
+            fn = getattr(inp, "grad_fn", None)
+            if fn is None:
+                continue
+            if fn in seen:
+                continue
+            seen.add(fn)
+            if fn in deps:
+                deps[fn] += 1
+    return deps
+
+
+def _run_backward(outputs, grad_outputs, *, retain_graph, create_graph, accumulate_grad, inputs=None, allow_unused=False):
+    task = _GraphTask(
+        _build_dependencies(outputs),
+        retain_graph=retain_graph,
+        create_graph=create_graph,
+        accumulate_grad=accumulate_grad,
+    )
+    _task_stack().append(task)
+    try:
+        for out, grad in zip(outputs, grad_outputs):
+            if grad is None:
+                continue
+            grad = _apply_hooks(out, grad)
+            if out.grad_fn is None:
+                task._accumulate_tensor_grad(out, grad)
+            else:
+                task._accumulate_node_grad(out.grad_fn, grad)
+        task.run()
+    finally:
+        _task_stack().pop()
+
+    if inputs is None:
+        return None
+    results = []
+    for inp in inputs:
+        grad_val = task.grads_map.get(inp)
+        if grad_val is None and not allow_unused:
+            raise RuntimeError(
+                "One of the differentiated Tensors appears to not have been used in the graph."
+            )
+        results.append(grad_val)
+    return tuple(results)
 
 
 def backward(tensor, grad=None, retain_graph=False, create_graph=False):
@@ -6,32 +152,7 @@ def backward(tensor, grad=None, retain_graph=False, create_graph=False):
         if tensor.numel() != 1:
             raise RuntimeError("grad can be implicitly created only for scalar outputs")
         grad = tensor._ones_like()
-    if tensor._backward_hooks:
-        for hook in tensor._backward_hooks.values():
-            result = hook(grad)
-            if result is not None:
-                grad = result
-    tensor.grad = grad
-    if tensor.grad_fn is None:
-        return
-    grads = tensor.grad_fn.backward(grad)
-    for t, g in zip(tensor.grad_fn.inputs, grads):
-        if g is None:
-            continue
-        if t._backward_hooks:
-            for hook in t._backward_hooks.values():
-                result = hook(g)
-                if result is not None:
-                    g = result
-        if t.grad is None:
-            if t.grad_fn is None or getattr(t, "_retain_grad", False):
-                t.grad = g
-        else:
-            from .._functional import add
-            with no_grad():
-                t.grad = add(t.grad, g)
-        if t.grad_fn is not None:
-            backward(t, g, retain_graph=retain_graph, create_graph=create_graph)
+    _run_backward((tensor,), (grad,), retain_graph=retain_graph, create_graph=create_graph, accumulate_grad=True)
 
 
 def grad(outputs, inputs, grad_outputs=None, retain_graph=None, create_graph=False, allow_unused=False):
@@ -56,44 +177,12 @@ def grad(outputs, inputs, grad_outputs=None, retain_graph=None, create_graph=Fal
         grad_outputs = grad_outputs if isinstance(grad_outputs, (tuple, list)) else (grad_outputs,)
         if len(grad_outputs) != len(outs):
             raise RuntimeError("grad_outputs must be the same length as outputs")
-    grads_map = {}
-    for out, grad_value in zip(outs, grad_outputs):
-        if grad_value is None:
-            continue
-        _accumulate_grad(out, grad_value, grads_map, retain_graph=retain_graph, create_graph=create_graph)
-    results = []
-    for inp in ins:
-        grad_val = grads_map.get(inp)
-        if grad_val is None and not allow_unused:
-            raise RuntimeError(
-                "One of the differentiated Tensors appears to not have been used in the graph."
-            )
-        results.append(grad_val)
-    return tuple(results)
-
-
-def _apply_hooks(tensor, grad):
-    if tensor._backward_hooks:
-        for hook in tensor._backward_hooks.values():
-            result = hook(grad)
-            if result is not None:
-                grad = result
-    return grad
-
-
-def _accumulate_grad(tensor, grad, grads_map, retain_graph=False, create_graph=False):
-    grad = _apply_hooks(tensor, grad)
-    if tensor.grad_fn is None:
-        prev = grads_map.get(tensor)
-        if prev is None:
-            grads_map[tensor] = grad
-        else:
-            from .._functional import add
-            with no_grad():
-                grads_map[tensor] = add(prev, grad)
-        return
-    grads = tensor.grad_fn.backward(grad)
-    for t, g in zip(tensor.grad_fn.inputs, grads):
-        if g is None:
-            continue
-        _accumulate_grad(t, g, grads_map, retain_graph=retain_graph, create_graph=create_graph)
+    return _run_backward(
+        outs,
+        grad_outputs,
+        retain_graph=retain_graph,
+        create_graph=create_graph,
+        accumulate_grad=False,
+        inputs=ins,
+        allow_unused=allow_unused,
+    )

--- a/tests/mindtorch_v2/contract/test_autograd_engine_topo.py
+++ b/tests/mindtorch_v2/contract/test_autograd_engine_topo.py
@@ -1,0 +1,49 @@
+import mindtorch_v2 as torch
+
+
+def test_autograd_engine_accumulates_shared_subgraph():
+    a = torch.ones((2, 2)).requires_grad_()
+    b = a * a
+    c = b + b
+    c.sum().backward()
+    assert a.grad is not None
+    # b = a * a, c = b + b => dc/da = 4a
+    assert (a.grad.numpy() == 4).all()
+
+
+def test_autograd_engine_reentrant_backward():
+    # Backward inside backward hook should be supported.
+    a = torch.ones((2, 2)).requires_grad_()
+    b = a * a
+    c = b.sum()
+    d = (a * a).sum()
+    called = {"ok": False}
+
+    def hook(_grad):
+        d.backward()
+        called["ok"] = True
+
+    c.register_hook(hook)
+    c.backward()
+    assert called["ok"]
+
+
+def test_saved_tensors_hooks_unpacked_once_per_node():
+    a = torch.ones((2, 2)).requires_grad_()
+    counters = {"unpack": 0}
+
+    def pack(t):
+        return t
+
+    def unpack(t):
+        counters["unpack"] += 1
+        return t
+
+    from mindtorch_v2._autograd.graph import saved_tensors_hooks
+
+    with saved_tensors_hooks(pack, unpack):
+        b = a * a
+        c = b + b
+    c.sum().backward()
+    # mul saves two tensors; add saves two tensors. Each should unpack once.
+    assert counters["unpack"] == 4


### PR DESCRIPTION
## Summary
- replace recursive autograd with topo ready-queue engine
- track dependencies to execute each node once and accumulate grads
- add contract tests for shared subgraph and reentrant backward

## Test Plan
- [x] source /home/lvyufeng/miniconda3/bin/activate mindspore && pytest -q tests/mindtorch_v2
