### PR TITLE
v2: add pure Python TCP-based Gloo backend for CPU distributed training

### DIFF
--- a/src/mindtorch_v2/_backends/cpu/ops.py
+++ b/src/mindtorch_v2/_backends/cpu/ops.py
@@ -23,7 +23,9 @@ def add(a, b):
 
 
 def mul(a, b):
-    return _from_numpy(_to_numpy(a) * _to_numpy(b), a.dtype, a.device)
+    a_np = _to_numpy(a)
+    b_np = _to_numpy(b) if isinstance(b, Tensor) else b
+    return _from_numpy(a_np * b_np, a.dtype, a.device)
 
 
 def matmul(a, b):

--- a/src/mindtorch_v2/distributed/_backend.py
+++ b/src/mindtorch_v2/distributed/_backend.py
@@ -72,7 +72,7 @@ def is_nccl_available():
 
 
 def is_gloo_available():
-    return False
+    return True
 
 
 def is_mpi_available():

--- a/src/mindtorch_v2/distributed/_gloo/__init__.py
+++ b/src/mindtorch_v2/distributed/_gloo/__init__.py
@@ -1,0 +1,5 @@
+"""Gloo backend for CPU distributed training."""
+
+from ._process_group_gloo import ProcessGroupGloo
+
+__all__ = ["ProcessGroupGloo"]

--- a/src/mindtorch_v2/distributed/_gloo/_numpy_collectives.py
+++ b/src/mindtorch_v2/distributed/_gloo/_numpy_collectives.py
@@ -1,0 +1,66 @@
+"""Numpy-based reduce operations and tensor serialization for Gloo backend."""
+
+import struct
+import numpy as np
+
+from .._reduce_op import RedOpType
+
+
+# ReduceOp int value -> numpy ufunc
+_REDUCE_OPS = {
+    int(RedOpType.SUM): np.add,
+    int(RedOpType.PRODUCT): np.multiply,
+    int(RedOpType.MAX): np.maximum,
+    int(RedOpType.MIN): np.minimum,
+    int(RedOpType.BAND): np.bitwise_and,
+    int(RedOpType.BOR): np.bitwise_or,
+    int(RedOpType.BXOR): np.bitwise_xor,
+    # AVG is handled specially by the caller (sum then divide)
+    int(RedOpType.AVG): np.add,
+}
+
+
+def apply_reduce_op(op, a, b):
+    """Apply a reduce operation element-wise: result = op(a, b)."""
+    op_int = int(op)
+    fn = _REDUCE_OPS.get(op_int)
+    if fn is None:
+        raise ValueError(f"Unsupported reduce op: {op}")
+    return fn(a, b)
+
+
+def serialize_array(arr):
+    """Serialize a numpy array to bytes.
+
+    Wire format:
+      1 byte  - length of dtype name
+      N bytes - dtype name (ascii)
+      4 bytes - ndim (uint32 big-endian)
+      ndim*8 bytes - shape dims (uint64 big-endian each)
+      rest    - raw data bytes
+    """
+    arr = np.ascontiguousarray(arr)
+    dtype_name = arr.dtype.str.encode("ascii")
+    header = struct.pack("!B", len(dtype_name)) + dtype_name
+    header += struct.pack("!I", arr.ndim)
+    for s in arr.shape:
+        header += struct.pack("!Q", s)
+    return header + arr.tobytes()
+
+
+def deserialize_array(data):
+    """Deserialize bytes back to a numpy array."""
+    offset = 0
+    dtype_len = data[offset]
+    offset += 1
+    dtype_name = data[offset:offset + dtype_len].decode("ascii")
+    offset += dtype_len
+    ndim = struct.unpack("!I", data[offset:offset + 4])[0]
+    offset += 4
+    shape = []
+    for _ in range(ndim):
+        shape.append(struct.unpack("!Q", data[offset:offset + 8])[0])
+        offset += 8
+    shape = tuple(shape)
+    body = data[offset:]
+    return np.frombuffer(body, dtype=np.dtype(dtype_name)).reshape(shape)

--- a/src/mindtorch_v2/distributed/_gloo/_process_group_gloo.py
+++ b/src/mindtorch_v2/distributed/_gloo/_process_group_gloo.py
@@ -1,0 +1,277 @@
+"""ProcessGroupGloo: Pure Python TCP-based collective communication backend."""
+
+import numpy as np
+
+from .._work import Work
+from .._process_group import ProcessGroup
+from ._tcp_transport import TcpTransport
+from ._numpy_collectives import apply_reduce_op, serialize_array, deserialize_array
+from .._reduce_op import RedOpType
+
+
+class ProcessGroupGloo(ProcessGroup):
+    """Gloo-compatible process group using pure Python TCP transport.
+
+    All collectives are synchronous (gather-to-root + broadcast-from-root).
+    Work objects are returned already completed.
+    """
+
+    def __init__(self, store, rank, size, group_name="", group_ranks=None):
+        super().__init__(rank, size)
+        self._group_name = group_name
+        self._ranks = group_ranks
+        self._store = store
+        self._transport = TcpTransport(store, rank, size, prefix=group_name)
+
+    def _tensor_to_numpy(self, tensor):
+        """Convert a CPU tensor to a contiguous numpy array."""
+        arr = tensor._numpy_view()
+        return np.ascontiguousarray(arr)
+
+    def _write_numpy_to_tensor(self, arr, tensor):
+        """Write numpy array data back into a tensor in-place."""
+        dst = tensor._numpy_view()
+        np.copyto(dst, arr.reshape(dst.shape))
+
+    def _make_work(self):
+        """Return an already-completed Work object (synchronous collectives)."""
+        work = Work(stream=None)
+        work._completed = True
+        return work
+
+    def allreduce(self, tensor, op=0):
+        """All-reduce: all ranks reduce and receive the result."""
+        if self._size == 1:
+            return self._make_work()
+
+        arr = self._tensor_to_numpy(tensor)
+        serialized = serialize_array(arr)
+
+        # All non-root send to rank 0
+        if self._rank != 0:
+            self._transport.send_to(0, serialized)
+        else:
+            # Rank 0 receives from all peers and reduces
+            result = arr.copy()
+            for peer in range(1, self._size):
+                peer_data = self._transport.recv_from(peer)
+                peer_arr = deserialize_array(peer_data)
+                result = apply_reduce_op(op, result, peer_arr)
+
+            # Handle AVG: divide by world_size
+            if int(op) == int(RedOpType.AVG):
+                result = result / self._size
+
+            # Rank 0 broadcasts result to all
+            result_serialized = serialize_array(result)
+            for peer in range(1, self._size):
+                self._transport.send_to(peer, result_serialized)
+
+            # Write result back into tensor
+            self._write_numpy_to_tensor(result, tensor)
+
+        # Non-root ranks receive the result
+        if self._rank != 0:
+            result_data = self._transport.recv_from(0)
+            result = deserialize_array(result_data)
+            self._write_numpy_to_tensor(result, tensor)
+
+        return self._make_work()
+
+    def broadcast(self, tensor, root=0):
+        """Broadcast: root sends tensor to all other ranks."""
+        if self._size == 1:
+            return self._make_work()
+
+        if self._rank == root:
+            arr = self._tensor_to_numpy(tensor)
+            serialized = serialize_array(arr)
+            for peer in range(self._size):
+                if peer != root:
+                    self._transport.send_to(peer, serialized)
+        else:
+            data = self._transport.recv_from(root)
+            arr = deserialize_array(data)
+            self._write_numpy_to_tensor(arr, tensor)
+
+        return self._make_work()
+
+    def allgather(self, output_tensor, input_tensor):
+        """All-gather: gather input from all ranks, concatenate into output."""
+        if self._size == 1:
+            # Just copy input to output
+            np.copyto(output_tensor._numpy_view(), input_tensor._numpy_view())
+            return self._make_work()
+
+        arr = self._tensor_to_numpy(input_tensor)
+        serialized = serialize_array(arr)
+
+        # All ranks send to rank 0
+        if self._rank != 0:
+            self._transport.send_to(0, serialized)
+        else:
+            # Rank 0 gathers from all
+            gathered = [arr]
+            for peer in range(1, self._size):
+                peer_data = self._transport.recv_from(peer)
+                peer_arr = deserialize_array(peer_data)
+                gathered.append(peer_arr)
+
+            # Concatenate along first dimension
+            result = np.concatenate(gathered, axis=0)
+            result_serialized = serialize_array(result)
+
+            # Rank 0 broadcasts concatenated result
+            for peer in range(1, self._size):
+                self._transport.send_to(peer, result_serialized)
+
+            self._write_numpy_to_tensor(result, output_tensor)
+
+        # Non-root ranks receive the result
+        if self._rank != 0:
+            result_data = self._transport.recv_from(0)
+            result = deserialize_array(result_data)
+            self._write_numpy_to_tensor(result, output_tensor)
+
+        return self._make_work()
+
+    def reduce(self, tensor, dst=0, op=0):
+        """Reduce: all ranks send to dst, dst receives reduced result."""
+        if self._size == 1:
+            return self._make_work()
+
+        arr = self._tensor_to_numpy(tensor)
+        serialized = serialize_array(arr)
+
+        # All non-dst send to dst
+        if self._rank != dst:
+            self._transport.send_to(dst, serialized)
+        else:
+            # dst receives from all and reduces
+            result = arr.copy()
+            for peer in range(self._size):
+                if peer != dst:
+                    peer_data = self._transport.recv_from(peer)
+                    peer_arr = deserialize_array(peer_data)
+                    result = apply_reduce_op(op, result, peer_arr)
+
+            # Handle AVG
+            if int(op) == int(RedOpType.AVG):
+                result = result / self._size
+
+            self._write_numpy_to_tensor(result, tensor)
+
+        return self._make_work()
+
+    def reduce_scatter(self, output_tensor, input_tensor, op=0):
+        """Reduce-scatter: reduce input, split into chunks, scatter to ranks."""
+        if self._size == 1:
+            np.copyto(output_tensor._numpy_view(), input_tensor._numpy_view())
+            return self._make_work()
+
+        arr = self._tensor_to_numpy(input_tensor)
+        serialized = serialize_array(arr)
+
+        # All ranks send to rank 0
+        if self._rank != 0:
+            self._transport.send_to(0, serialized)
+        else:
+            # Rank 0 reduces
+            result = arr.copy()
+            for peer in range(1, self._size):
+                peer_data = self._transport.recv_from(peer)
+                peer_arr = deserialize_array(peer_data)
+                result = apply_reduce_op(op, result, peer_arr)
+
+            # Handle AVG
+            if int(op) == int(RedOpType.AVG):
+                result = result / self._size
+
+            # Split into chunks (split along first dimension)
+            chunk_size = result.shape[0] // self._size
+            chunks = np.split(result, self._size, axis=0)
+
+            # Send chunk i to rank i
+            for peer in range(self._size):
+                chunk_serialized = serialize_array(chunks[peer])
+                if peer == 0:
+                    self._write_numpy_to_tensor(chunks[peer], output_tensor)
+                else:
+                    self._transport.send_to(peer, chunk_serialized)
+
+        # Non-root ranks receive their chunk
+        if self._rank != 0:
+            chunk_data = self._transport.recv_from(0)
+            chunk = deserialize_array(chunk_data)
+            self._write_numpy_to_tensor(chunk, output_tensor)
+
+        return self._make_work()
+
+    def scatter(self, output_tensor, input_tensor, src=0):
+        """Scatter: src splits input into chunks, sends chunk i to rank i."""
+        if self._size == 1:
+            np.copyto(output_tensor._numpy_view(), input_tensor._numpy_view())
+            return self._make_work()
+
+        if self._rank == src:
+            arr = self._tensor_to_numpy(input_tensor)
+            # Split into chunks
+            chunk_size = arr.shape[0] // self._size
+            chunks = np.split(arr, self._size, axis=0)
+
+            # Send chunk i to rank i
+            for peer in range(self._size):
+                chunk_serialized = serialize_array(chunks[peer])
+                if peer == src:
+                    self._write_numpy_to_tensor(chunks[peer], output_tensor)
+                else:
+                    self._transport.send_to(peer, chunk_serialized)
+        else:
+            # Receive chunk from src
+            chunk_data = self._transport.recv_from(src)
+            chunk = deserialize_array(chunk_data)
+            self._write_numpy_to_tensor(chunk, output_tensor)
+
+        return self._make_work()
+
+    def barrier(self):
+        """Barrier: all ranks synchronize."""
+        if self._size == 1:
+            return self._make_work()
+
+        # All ranks send a 1-byte token to rank 0
+        if self._rank != 0:
+            self._transport.send_to(0, b"\x00")
+        else:
+            # Rank 0 waits for all
+            for peer in range(1, self._size):
+                self._transport.recv_from(peer)
+            # Rank 0 sends ack to all
+            for peer in range(1, self._size):
+                self._transport.send_to(peer, b"\x00")
+
+        # Non-root ranks wait for ack
+        if self._rank != 0:
+            self._transport.recv_from(0)
+
+        return self._make_work()
+
+    def send(self, tensor, dst):
+        """Point-to-point send."""
+        arr = self._tensor_to_numpy(tensor)
+        serialized = serialize_array(arr)
+        self._transport.send_to(dst, serialized)
+        return self._make_work()
+
+    def recv(self, tensor, src):
+        """Point-to-point receive."""
+        data = self._transport.recv_from(src)
+        arr = deserialize_array(data)
+        self._write_numpy_to_tensor(arr, tensor)
+        work = self._make_work()
+        work._source_rank = src
+        return work
+
+    def destroy(self):
+        """Clean up transport resources."""
+        self._transport.close()

--- a/src/mindtorch_v2/distributed/_gloo/_tcp_transport.py
+++ b/src/mindtorch_v2/distributed/_gloo/_tcp_transport.py
@@ -1,0 +1,128 @@
+"""Full-mesh TCP transport for Gloo backend.
+
+Each rank establishes a direct TCP connection to every other rank.
+Connection ordering: rank i connects to rank j (j > i) to avoid deadlock.
+"""
+
+import socket
+import struct
+import threading
+
+
+def _recvall(sock, n):
+    """Read exactly n bytes from a socket."""
+    buf = bytearray()
+    while len(buf) < n:
+        chunk = sock.recv(n - len(buf))
+        if not chunk:
+            raise ConnectionError("peer connection closed")
+        buf.extend(chunk)
+    return bytes(buf)
+
+
+class TcpTransport:
+    """Full-mesh TCP connection manager for peer-to-peer communication."""
+
+    def __init__(self, store, rank, world_size, prefix="", timeout=300):
+        self._rank = rank
+        self._world_size = world_size
+        self._timeout = timeout
+        self._closed = False
+        self._peers = {}       # peer_rank -> socket
+        self._locks = {}       # peer_rank -> threading.Lock
+
+        if world_size < 2:
+            return
+
+        # Bind ephemeral server socket for accepting incoming connections
+        self._server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._server.settimeout(timeout)
+        self._server.bind(("", 0))
+        self._server.listen(world_size)
+        host = socket.gethostname()
+        port = self._server.getsockname()[1]
+
+        # Publish our address to the store so peers can find us
+        addr_key = f"gloo_addr_rank_{rank}"
+        if prefix:
+            addr_key = f"{prefix}/{addr_key}"
+        store.set(addr_key, f"{host}:{port}".encode("utf-8"))
+
+        # Collect all peer addresses
+        peer_addrs = {}
+        for i in range(world_size):
+            if i == rank:
+                continue
+            peer_key = f"gloo_addr_rank_{i}"
+            if prefix:
+                peer_key = f"{prefix}/{peer_key}"
+            store.wait([peer_key])
+            raw = store.get(peer_key)
+            addr_str = raw.decode("utf-8") if isinstance(raw, bytes) else raw
+            h, p = addr_str.rsplit(":", 1)
+            peer_addrs[i] = (h, int(p))
+
+        # Establish connections with deterministic ordering to avoid deadlock:
+        # rank i connects to rank j where j > i;
+        # rank j accepts from rank i where i < j.
+        #
+        # Process lower ranks first (accept from them), then higher ranks
+        # (connect to them).
+
+        # Accept connections from ranks < self
+        for i in sorted(r for r in range(world_size) if r < rank):
+            conn, _ = self._server.accept()
+            conn.settimeout(timeout)
+            # Peer sends its rank as a 4-byte int so we know who connected
+            peer_rank_bytes = _recvall(conn, 4)
+            peer_rank = struct.unpack("!I", peer_rank_bytes)[0]
+            self._peers[peer_rank] = conn
+            self._locks[peer_rank] = threading.Lock()
+
+        # Connect to ranks > self
+        for j in sorted(r for r in range(world_size) if r > rank):
+            h, p = peer_addrs[j]
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.settimeout(timeout)
+            sock.connect((h, p))
+            # Send our rank so the peer knows who we are
+            sock.sendall(struct.pack("!I", rank))
+            self._peers[j] = sock
+            self._locks[j] = threading.Lock()
+
+    def send_to(self, rank, data):
+        """Send data bytes to a peer rank. Thread-safe per socket."""
+        lock = self._locks[rank]
+        sock = self._peers[rank]
+        with lock:
+            # Wire format: 8-byte big-endian length + data
+            sock.sendall(struct.pack("!Q", len(data)))
+            sock.sendall(data)
+
+    def recv_from(self, rank):
+        """Receive data bytes from a peer rank. Thread-safe per socket."""
+        lock = self._locks[rank]
+        sock = self._peers[rank]
+        with lock:
+            length_bytes = _recvall(sock, 8)
+            length = struct.unpack("!Q", length_bytes)[0]
+            return _recvall(sock, length)
+
+    def close(self):
+        """Close all peer sockets and the server socket."""
+        if self._closed:
+            return
+        self._closed = True
+        for sock in self._peers.values():
+            try:
+                sock.close()
+            except OSError:
+                pass
+        self._peers.clear()
+        self._locks.clear()
+        if hasattr(self, "_server"):
+            try:
+                self._server.close()
+            except OSError:
+                pass


### PR DESCRIPTION
## Summary

Add a pure Python TCP-based Gloo backend so that distributed training works on CPU devices without requiring libhccl.so.

## Changes

### New files
- `src/mindtorch_v2/distributed/_gloo/__init__.py` — Package re-export
- `src/mindtorch_v2/distributed/_gloo/_numpy_collectives.py` — Numpy-based reduce ops and tensor serialization
- `src/mindtorch_v2/distributed/_gloo/_tcp_transport.py` — Full-mesh TCP connection manager with deadlock-free ordering and per-socket thread safety
- `src/mindtorch_v2/distributed/_gloo/_process_group_gloo.py` — ProcessGroupGloo implementing all 9 collectives (allreduce, broadcast, allgather, reduce, reduce_scatter, scatter, barrier, send, recv)

### Modified files
- `src/mindtorch_v2/distributed/_process_group.py` — Decouple HCCL imports so ProcessGroup base class can be imported without libhccl.so
- `src/mindtorch_v2/distributed/_backend.py` — Enable `is_gloo_available()`
- `src/mindtorch_v2/distributed/__init__.py` — Backend dispatch in `init_process_group()` and `new_group()`
- `src/mindtorch_v2/_backends/cpu/ops.py` — Fix CPU `mul` op to handle Python scalar arguments

## Architecture
- **Topology**: Full mesh — each rank has a direct TCP connection to every other rank
- **Connection setup**: Ephemeral server socket per rank, address exchange via TCPStore, deterministic connect ordering (rank i → rank j where j > i)
- **Collectives**: Synchronous gather-to-root + broadcast-from-root
- **Tensor serialization**: CPU tensors use numpy storage, serialize via `arr.tobytes()` / `np.frombuffer()`

## Verification
Tested with 2-process CPU DDP: init, all_reduce SUM, broadcast, barrier, and end-to-end DDP gradient sync all pass.