### PR TITLE
Autograd: retain_graph semantics

### DIFF
--- a/src/mindtorch_v2/_autograd/engine.py
+++ b/src/mindtorch_v2/_autograd/engine.py
@@ -74,7 +74,7 @@ class _GraphTask:
                 if t.grad_fn is not None:
                     self._accumulate_node_grad(t.grad_fn, g)
             if not self.retain_graph:
-                node._saved_tensors = []
+                node.release_saved_tensors()
 
 
 def _apply_hooks(tensor, grad):
@@ -152,6 +152,8 @@ def backward(tensor, grad=None, retain_graph=False, create_graph=False):
         if tensor.numel() != 1:
             raise RuntimeError("grad can be implicitly created only for scalar outputs")
         grad = tensor._ones_like()
+    if create_graph and not retain_graph:
+        retain_graph = True
     _run_backward((tensor,), (grad,), retain_graph=retain_graph, create_graph=create_graph, accumulate_grad=True)
 
 

--- a/tests/mindtorch_v2/contract/test_autograd_create_graph.py
+++ b/tests/mindtorch_v2/contract/test_autograd_create_graph.py
@@ -1,0 +1,10 @@
+import mindtorch_v2 as torch
+
+
+def test_backward_create_graph_allows_second_backward():
+    a = torch.ones((2, 2)).requires_grad_()
+    out = (a * a).sum()
+    out.backward(create_graph=True)
+    # Second backward should succeed when create_graph=True (retain_graph implied).
+    out.backward()
+    assert a.grad is not None

--- a/tests/mindtorch_v2/contract/test_autograd_retain_graph.py
+++ b/tests/mindtorch_v2/contract/test_autograd_retain_graph.py
@@ -1,0 +1,24 @@
+import pytest
+
+import mindtorch_v2 as torch
+
+
+def test_backward_twice_without_retain_graph_errors():
+    a = torch.ones((2, 2)).requires_grad_()
+    out = (a * a).sum()
+    out.backward()
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            r"Trying to backward through the graph a second time .* retain_graph=True"
+        ),
+    ):
+        out.backward()
+
+
+def test_backward_twice_with_retain_graph_succeeds():
+    a = torch.ones((2, 2)).requires_grad_()
+    out = (a * a).sum()
+    out.backward(retain_graph=True)
+    out.backward(retain_graph=True)
+    assert a.grad is not None


### PR DESCRIPTION
## Summary
- release saved tensors after backward to match torch error behavior
- make create_graph imply retain_graph
- add contract tests for retain_graph/create_graph semantics

## Test Plan
- [x] source /home/lvyufeng/miniconda3/bin/activate mindspore && pytest -q tests/mindtorch_v2
