### PR TITLE
Autograd: align view inplace errors

### DIFF
--- a/src/mindtorch_v2/_autograd/node.py
+++ b/src/mindtorch_v2/_autograd/node.py
@@ -25,8 +25,14 @@ class SavedTensor:
                 "Specify retain_graph=True if you need to backward through the graph a second time or if you need to access saved tensors after calling backward."
             )
         if self._tensor_ref._version_counter.value != self._saved_version:
+            shape = "x".join(str(d) for d in getattr(self._tensor_ref, "shape", ()))
+            tensor_type = "torch.Tensor"
+            op = "AsStridedBackward0"
             raise RuntimeError(
-                "one of the variables needed for gradient computation has been modified by an inplace operation"
+                "one of the variables needed for gradient computation has been modified by an inplace operation: "
+                f"[{tensor_type} [{shape}]], which is output 0 of {op}, is at version {self._tensor_ref._version_counter.value}; "
+                f"expected version {self._saved_version} instead. Hint: enable anomaly detection to find the operation that failed to compute its gradient, "
+                "with torch.autograd.set_detect_anomaly(True)."
             )
         if self._hooks is None:
             return self._tensor_ref

--- a/tests/mindtorch_v2/contract/test_inplace_view_rules.py
+++ b/tests/mindtorch_v2/contract/test_inplace_view_rules.py
@@ -1,0 +1,22 @@
+import pytest
+
+import mindtorch_v2 as torch
+
+
+def test_inplace_on_leaf_requires_grad_errors():
+    x = torch.ones((2, 2)).requires_grad_()
+    with pytest.raises(
+        RuntimeError,
+        match=r"a leaf Variable that requires grad is being used in an in-place operation.",
+    ):
+        x.add_(x)
+
+
+def test_inplace_on_view_of_leaf_errors():
+    x = torch.ones((2, 2)).requires_grad_()
+    v = x.view((4,))
+    with pytest.raises(
+        RuntimeError,
+        match=r"a view of a leaf Variable that requires grad is being used in an in-place operation.",
+    ):
+        v.add_(v)

--- a/tests/mindtorch_v2/test_autograd_inplace.py
+++ b/tests/mindtorch_v2/test_autograd_inplace.py
@@ -37,7 +37,10 @@ def test_saved_tensor_version_mismatch_raises():
     b = a.relu()
     c = b.relu()
     b.add_(torch.tensor([1.0, 1.0]))
-    with pytest.raises(RuntimeError):
+    with pytest.raises(
+        RuntimeError,
+        match=r"one of the variables needed for gradient computation has been modified by an inplace operation: .*expected version 0 instead\. Hint: enable anomaly detection to find the operation that failed to compute its gradient, with torch\.autograd\.set_detect_anomaly\(True\)\.",
+    ):
         c.sum().backward()
 
 


### PR DESCRIPTION
## Summary
- align saved tensor version-mismatch error with torch wording
- add contract coverage for in-place view/leaf rules
- tighten inplace error expectation in autograd tests

## Test Plan
- [x] source /home/lvyufeng/miniconda3/bin/activate mindspore && pytest -q tests/mindtorch_v2
