### PR TITLE
v2: implement all_to_all and all_to_all_single for distributed

### DIFF
--- a/src/mindtorch_v2/distributed/_hccl/hccl_bindings.py
+++ b/src/mindtorch_v2/distributed/_hccl/hccl_bindings.py
@@ -182,6 +182,12 @@ class HcclBindings:
         self.recv = _bind(
             lib, "HcclRecv", i32,
             [vp, u64, i32, u32, vp, vp])
+        self.all_to_all = _bind(
+            lib, "HcclAlltoAll", i32,
+            [vp, u64, i32, vp, u64, i32, vp, vp])
+        self.all_to_all_v = _bind(
+            lib, "HcclAlltoAllV", i32,
+            [vp, vp, vp, i32, vp, vp, vp, i32, vp, vp])
         self.comm_destroy = _bind(
             lib, "HcclCommDestroy", i32,
             [vp])


### PR DESCRIPTION
## Summary
- Implement `all_to_all` and `all_to_all_single` for both Gloo (CPU) and HCCL (NPU) backends
- HCCL uses native `HcclAlltoAll` for 2-rank case, falls back to P2P `HcclSend`/`HcclRecv` for >2 ranks (workaround for CANN 8.3.RC2 bug where `HcclAlltoAll`/`HcclAlltoAllV` silently return zeros on >2 ranks)
- Gloo uses P2P send/recv with deadlock-free ordering (lower rank sends first)
- Supports both equal and unequal split sizes in `all_to_all_single`

## Test plan
- [x] 2-card Gloo: `all_to_all` + `all_to_all_single` PASSED
- [x] 2-card HCCL (native HcclAlltoAll): PASSED
- [x] 4-card HCCL (P2P fallback): PASSED
- [x] 8-card HCCL (P2P fallback): PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)