### PR TITLE
Dispatch: respect default device

### DIFF
--- a/src/mindtorch_v2/_dispatch/dispatcher.py
+++ b/src/mindtorch_v2/_dispatch/dispatcher.py
@@ -190,6 +190,10 @@ def _infer_dispatch_device(dispatch_device, tensors, keyset):
     for tensor in tensors:
         if hasattr(tensor, "device"):
             return tensor.device
+    if not tensors:
+        from .._device import get_default_device
+
+        return get_default_device()
     if DispatchKey.Meta in keyset:
         return "meta"
     if DispatchKey.NPU in keyset:

--- a/tests/mindtorch_v2/contract/test_backend_select.py
+++ b/tests/mindtorch_v2/contract/test_backend_select.py
@@ -1,0 +1,18 @@
+from mindtorch_v2._device import get_default_device, set_default_device
+from mindtorch_v2._dispatch.dispatcher import dispatch
+from mindtorch_v2._dtype import float32
+
+
+def test_dispatch_uses_default_device_when_no_tensors():
+    prev = get_default_device()
+    try:
+        set_default_device("meta")
+        out = dispatch("empty", None, (2, 2), dtype=float32)
+        assert out.device.type == "meta"
+    finally:
+        set_default_device(prev)
+
+
+def test_dispatch_respects_explicit_device_hint():
+    out = dispatch("empty", "meta", (2, 2), dtype=float32)
+    assert out.device.type == "meta"


### PR DESCRIPTION
## Summary
- use default device when dispatching ops without tensor inputs
- respect explicit dispatch device hints for creation ops
- add contract tests for BackendSelect semantics

## Test Plan
- [x] source /home/lvyufeng/miniconda3/bin/activate mindspore && pytest -q tests/mindtorch_v2
