### PR TITLE
v2: implement find_unused_parameters for DDP

### DIFF
--- a/src/mindtorch_v2/nn/parallel/distributed.py
+++ b/src/mindtorch_v2/nn/parallel/distributed.py
@@ -160,6 +160,47 @@ class _Reducer:
             future = self.comm_hook(self.comm_hook_state, grad_bucket)
             grads[pi] = future.wait()
 
+    def _find_unused_params(self, outputs):
+        """Mark unused parameters' buckets as ready with zero gradients."""
+        from ..._functional import zeros_like
+        from ..._autograd.grad_mode import no_grad
+
+        # Flatten outputs to tensors with grad_fn
+        if isinstance(outputs, dict):
+            tensors = [v for v in outputs.values() if hasattr(v, 'grad_fn') and v.grad_fn is not None]
+        elif isinstance(outputs, (tuple, list)):
+            tensors = [t for t in outputs if hasattr(t, 'grad_fn') and t.grad_fn is not None]
+        elif hasattr(outputs, 'grad_fn') and outputs.grad_fn is not None:
+            tensors = [outputs]
+        else:
+            return
+
+        # Traverse autograd graph, collect ids of all reachable leaf tensors
+        used = set()
+        visited = set()
+        stack = [t.grad_fn for t in tensors]
+        while stack:
+            node = stack.pop()
+            if id(node) in visited:
+                continue
+            visited.add(id(node))
+            for inp in node.inputs:
+                if inp.grad_fn is None:
+                    used.add(id(inp))
+                else:
+                    stack.append(inp.grad_fn)
+
+        # For each unused grad param, simulate hook firing with zero grad
+        with no_grad():
+            for idx, param in self.grad_params:
+                if id(param) not in used:
+                    bucket_idx = self._param_to_bucket.get(idx)
+                    if bucket_idx is not None:
+                        self._bucket_grads[bucket_idx][idx] = zeros_like(param)
+                        self._bucket_pending[bucket_idx] -= 1
+                        if self._bucket_pending[bucket_idx] == 0:
+                            self._reduce_bucket(bucket_idx)
+
     def prepare_for_backward(self):
         self._reset_state()
 
@@ -234,7 +275,10 @@ class DistributedDataParallel(Module):
 
         self.reducer._require_backward_grad_sync = self._require_backward_grad_sync
         self.reducer.prepare_for_backward()
-        return self.module(*args, **kwargs)
+        output = self.module(*args, **kwargs)
+        if self.find_unused_parameters and self._require_backward_grad_sync:
+            self.reducer._find_unused_params(output)
+        return output
 
     @contextmanager
     def no_sync(self):

--- a/tests/mindtorch_v2/test_ddp_unused_params.py
+++ b/tests/mindtorch_v2/test_ddp_unused_params.py
@@ -1,0 +1,163 @@
+"""Test DDP with find_unused_parameters=True."""
+
+import os
+import sys
+import pytest
+
+# Add src to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../../src'))
+
+import mindtorch_v2 as torch
+import mindtorch_v2.nn as nn
+import mindtorch_v2.distributed as dist
+
+
+class ModelWithUnusedParam(nn.Module):
+    """Model with a parameter that may be unused depending on input."""
+
+    def __init__(self):
+        super().__init__()
+        self.fc1 = nn.Linear(10, 10)
+        self.fc2 = nn.Linear(10, 10)
+        self.fc3 = nn.Linear(10, 10)
+
+    def forward(self, x, use_fc2=True):
+        x = self.fc1(x)
+        if use_fc2:
+            x = self.fc2(x)
+        x = self.fc3(x)
+        return x
+
+
+def run_ddp_test(rank, world_size, use_fc2):
+    """Run DDP test on a single rank."""
+    os.environ['RANK'] = str(rank)
+    os.environ['WORLD_SIZE'] = str(world_size)
+    os.environ['MASTER_ADDR'] = '127.0.0.1'
+    os.environ['MASTER_PORT'] = '29500'
+
+    # Initialize process group
+    dist.init_process_group(backend='gloo', rank=rank, world_size=world_size)
+
+    # Create model
+    model = ModelWithUnusedParam()
+    ddp_model = nn.parallel.DistributedDataParallel(
+        model,
+        find_unused_parameters=True
+    )
+
+    # Forward pass
+    x = torch.randn(4, 10)
+    output = ddp_model(x, use_fc2=use_fc2)
+    loss = output.sum()
+
+    # Backward pass - should not hang even with unused parameters
+    loss.backward()
+
+    # Verify gradients exist for all parameters
+    for name, param in ddp_model.named_parameters():
+        if use_fc2:
+            # All params should have gradients
+            assert param.grad is not None, f"{name} should have gradient"
+        else:
+            # fc2 is unused, but should still have zero gradient
+            if 'fc2' in name:
+                assert param.grad is not None, f"{name} should have zero gradient"
+                # Check it's actually zero
+                assert torch.allclose(param.grad, torch.zeros_like(param.grad)), \
+                    f"{name} gradient should be zero"
+            else:
+                assert param.grad is not None, f"{name} should have gradient"
+
+    dist.destroy_process_group()
+    return True
+
+
+def test_ddp_unused_params_single_process():
+    """Test find_unused_parameters with single process (no actual distributed)."""
+    # This test doesn't require actual multi-process setup
+    model = ModelWithUnusedParam()
+
+    # Test without DDP first to understand expected behavior
+    x = torch.randn(4, 10)
+    output = model(x, use_fc2=False)
+    loss = output.sum()
+    loss.backward()
+
+    # fc2 should have no gradient since it wasn't used
+    assert model.fc2.weight.grad is None, "fc2 should not have gradient without DDP"
+
+    # Now test with DDP and find_unused_parameters=True
+    # Initialize a fake process group for single-process testing
+    os.environ['RANK'] = '0'
+    os.environ['WORLD_SIZE'] = '1'
+    os.environ['MASTER_ADDR'] = '127.0.0.1'
+    os.environ['MASTER_PORT'] = '29501'
+
+    dist.init_process_group(backend='gloo', rank=0, world_size=1)
+
+    model2 = ModelWithUnusedParam()
+    ddp_model = nn.parallel.DistributedDataParallel(
+        model2,
+        find_unused_parameters=True
+    )
+
+    x = torch.randn(4, 10)
+    output = ddp_model(x, use_fc2=False)
+    loss = output.sum()
+    loss.backward()
+
+    # With find_unused_parameters=True, fc2 should have zero gradient
+    assert model2.fc2.weight.grad is not None, "fc2 should have zero gradient with find_unused_parameters"
+    assert torch.allclose(model2.fc2.weight.grad, torch.zeros_like(model2.fc2.weight.grad)), \
+        "fc2 gradient should be zero"
+
+    # Used parameters should have non-zero gradients
+    assert model2.fc1.weight.grad is not None
+    assert not torch.allclose(model2.fc1.weight.grad, torch.zeros_like(model2.fc1.weight.grad)), \
+        "fc1 should have non-zero gradient"
+
+    dist.destroy_process_group()
+
+
+def test_ddp_all_params_used():
+    """Test that find_unused_parameters doesn't break normal case where all params are used."""
+    os.environ['RANK'] = '0'
+    os.environ['WORLD_SIZE'] = '1'
+    os.environ['MASTER_ADDR'] = '127.0.0.1'
+    os.environ['MASTER_PORT'] = '29502'
+
+    dist.init_process_group(backend='gloo', rank=0, world_size=1)
+
+    model = ModelWithUnusedParam()
+    ddp_model = nn.parallel.DistributedDataParallel(
+        model,
+        find_unused_parameters=True
+    )
+
+    x = torch.randn(4, 10)
+    output = ddp_model(x, use_fc2=True)  # All params used
+    loss = output.sum()
+    loss.backward()
+
+    # All parameters should have non-zero gradients
+    for name, param in ddp_model.named_parameters():
+        assert param.grad is not None, f"{name} should have gradient"
+        # Check gradients are not all zero (at least some non-zero values)
+        assert not torch.allclose(param.grad, torch.zeros_like(param.grad)), \
+            f"{name} should have non-zero gradient"
+
+    dist.destroy_process_group()
+
+
+if __name__ == '__main__':
+    # Run tests
+    print("Testing DDP with unused parameters (single process)...")
+    test_ddp_unused_params_single_process()
+    print("✓ Single process test passed")
+
+    print("\nTesting DDP with all parameters used...")
+    test_ddp_all_params_used()
+    print("✓ All params used test passed")
+
+    print("\n✓ All tests passed!")


### PR DESCRIPTION
## Summary
- Implements `find_unused_parameters=True` support for DistributedDataParallel
- Detects parameters not used in forward pass by traversing autograd graph
- Marks unused parameters' buckets as ready with zero gradients to prevent training hangs

## Implementation
- Added `_Reducer._find_unused_params()` that traverses the autograd graph from outputs via `grad_fn.inputs` to collect all reachable leaf tensors
- For unused parameters, simulates gradient hook firing with zero gradient to complete their buckets
- Modified `DistributedDataParallel.forward()` to call detection after module forward when flag is enabled

## Test plan
- [x] Added `test_ddp_unused_params.py` with tests for unused parameter detection
- [x] Verified unused parameters get zero gradients instead of None
- [x] Verified normal case (all params used) still works correctly
- [ ] Run on multi-GPU/NPU setup to verify no hangs with conditionally unused parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)