### PR TITLE
v2: add clip_grad_norm_, gradient checkpointing, and AMP support

### DIFF
--- a/src/mindtorch_v2/__init__.py
+++ b/src/mindtorch_v2/__init__.py
@@ -35,6 +35,7 @@ from . import npu
 from . import _C
 from . import distributed
 from . import futures
+from . import amp
 
 
 def pipeline():
@@ -194,4 +195,6 @@ __all__ = [
     "autograd",
     # distributed
     "distributed",
+    # amp
+    "amp",
 ]

--- a/src/mindtorch_v2/_autograd/grad_mode.py
+++ b/src/mindtorch_v2/_autograd/grad_mode.py
@@ -6,21 +6,32 @@ def is_grad_enabled():
     return GradMode.enabled
 
 
-def set_grad_enabled(mode):
-    GradMode.enabled = bool(mode)
+class set_grad_enabled:
+    def __init__(self, mode):
+        self.mode = bool(mode)
+        self._prev = GradMode.enabled
+        GradMode.enabled = self.mode
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        GradMode.enabled = self._prev
 
 
 class no_grad:
     def __enter__(self):
+        self._prev = GradMode.enabled
         GradMode.enabled = False
 
     def __exit__(self, exc_type, exc, tb):
-        GradMode.enabled = True
+        GradMode.enabled = self._prev
 
 
 class enable_grad:
     def __enter__(self):
+        self._prev = GradMode.enabled
         GradMode.enabled = True
 
     def __exit__(self, exc_type, exc, tb):
-        pass
+        GradMode.enabled = self._prev

--- a/src/mindtorch_v2/amp/__init__.py
+++ b/src/mindtorch_v2/amp/__init__.py
@@ -1,0 +1,4 @@
+from .autocast_mode import autocast
+from .grad_scaler import GradScaler
+
+__all__ = ["autocast", "GradScaler"]

--- a/src/mindtorch_v2/amp/autocast_mode.py
+++ b/src/mindtorch_v2/amp/autocast_mode.py
@@ -1,0 +1,28 @@
+import functools
+
+
+class autocast:
+    """No-op autocast context manager/decorator for API compatibility.
+
+    A proper implementation would require DispatchKey.Autocast kernels.
+    For now, users can manually cast models to fp16/bf16.
+    """
+
+    def __init__(self, device_type=None, dtype=None, enabled=True, cache_enabled=None):
+        self.device_type = device_type
+        self.dtype = dtype
+        self.enabled = enabled
+        self.cache_enabled = cache_enabled
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+    def __call__(self, func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            with self:
+                return func(*args, **kwargs)
+        return wrapper

--- a/src/mindtorch_v2/amp/grad_scaler.py
+++ b/src/mindtorch_v2/amp/grad_scaler.py
@@ -1,0 +1,120 @@
+from .._functional import isnan, isinf, any as _any
+
+
+class GradScaler:
+    """Gradient scaler for mixed precision training.
+
+    Scales loss to prevent gradient underflow in fp16,
+    then unscales gradients before optimizer step.
+    """
+
+    def __init__(
+        self,
+        init_scale=2.0 ** 16,
+        growth_factor=2.0,
+        backoff_factor=0.5,
+        growth_interval=2000,
+        enabled=True,
+    ):
+        self._enabled = enabled
+        self._scale = float(init_scale)
+        self._growth_factor = growth_factor
+        self._backoff_factor = backoff_factor
+        self._growth_interval = growth_interval
+        self._growth_tracker = 0
+        self._found_inf = False
+
+    def scale(self, loss):
+        """Scale loss tensor by the current scale factor."""
+        if not self._enabled:
+            return loss
+        from .._creation import tensor
+        scale_tensor = tensor(self._scale)
+        return loss * scale_tensor
+
+    def unscale_(self, optimizer):
+        """Unscale gradients by dividing by the scale factor. Detects inf/nan."""
+        if not self._enabled:
+            return
+
+        from .._creation import tensor
+        inv_scale = tensor(1.0 / self._scale)
+        self._found_inf = False
+
+        # Support both param_groups (PyTorch-style) and params (mindtorch-style)
+        if hasattr(optimizer, 'param_groups'):
+            params_to_unscale = []
+            for param_group in optimizer.param_groups:
+                params_to_unscale.extend(param_group['params'])
+        else:
+            params_to_unscale = optimizer.params
+
+        for p in params_to_unscale:
+            if hasattr(p, 'grad') and p.grad is not None:
+                p.grad = p.grad * inv_scale
+                # Check for inf/nan
+                if _any(isnan(p.grad)) or _any(isinf(p.grad)):
+                    self._found_inf = True
+
+    def step(self, optimizer, *args, **kwargs):
+        """Step the optimizer, skipping if inf/nan gradients were found.
+
+        If unscale_ has not been called, it will be called first.
+        """
+        if not self._enabled:
+            return optimizer.step(*args, **kwargs)
+
+        # Auto-unscale if not already done
+        if not hasattr(self, '_found_inf') or self._found_inf is None:
+            self.unscale_(optimizer)
+
+        if not self._found_inf:
+            return optimizer.step(*args, **kwargs)
+        # else: skip step due to inf/nan grads
+
+    def update(self, new_scale=None):
+        """Update the scale factor based on whether inf/nan was found."""
+        if not self._enabled:
+            return
+
+        if new_scale is not None:
+            self._scale = float(new_scale)
+            return
+
+        if self._found_inf:
+            self._scale *= self._backoff_factor
+            self._growth_tracker = 0
+        else:
+            self._growth_tracker += 1
+            if self._growth_tracker >= self._growth_interval:
+                self._scale *= self._growth_factor
+                self._growth_tracker = 0
+
+        # Reset for next iteration
+        self._found_inf = False
+
+    def get_scale(self):
+        """Return the current scale factor."""
+        return self._scale
+
+    def is_enabled(self):
+        """Return whether the scaler is enabled."""
+        return self._enabled
+
+    def state_dict(self):
+        """Return scaler state as a dict."""
+        return {
+            "scale": self._scale,
+            "growth_factor": self._growth_factor,
+            "backoff_factor": self._backoff_factor,
+            "growth_interval": self._growth_interval,
+            "growth_tracker": self._growth_tracker,
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load scaler state from a dict."""
+        self._scale = state_dict["scale"]
+        self._growth_factor = state_dict["growth_factor"]
+        self._backoff_factor = state_dict["backoff_factor"]
+        self._growth_interval = state_dict["growth_interval"]
+        self._growth_tracker = state_dict["growth_tracker"]

--- a/src/mindtorch_v2/nn/__init__.py
+++ b/src/mindtorch_v2/nn/__init__.py
@@ -54,6 +54,9 @@ from .modules.padding import (
 # Upsampling
 from .modules.upsampling import Upsample
 
+# Utils
+from . import utils
+
 # Parallel
 from . import parallel
 from .parallel import DistributedDataParallel, DataParallel

--- a/src/mindtorch_v2/nn/utils/__init__.py
+++ b/src/mindtorch_v2/nn/utils/__init__.py
@@ -1,0 +1,3 @@
+from .clip_grad import clip_grad_norm_, clip_grad_value_
+
+__all__ = ["clip_grad_norm_", "clip_grad_value_"]

--- a/src/mindtorch_v2/nn/utils/clip_grad.py
+++ b/src/mindtorch_v2/nn/utils/clip_grad.py
@@ -1,0 +1,101 @@
+from ..._functional import abs, pow, sum, sqrt, amax, amin, stack, clamp, isnan, isinf, any, mul
+from ..._creation import tensor
+
+
+def _compute_norm(t, norm_type):
+    """Compute norm of a single tensor."""
+    if norm_type == float('inf'):
+        return amax(abs(t))
+    if norm_type == float('-inf'):
+        return amin(abs(t))
+    # For p-norm: (sum(|x|^p))^(1/p)
+    return pow(sum(pow(abs(t), norm_type)), 1.0 / norm_type)
+
+
+def clip_grad_norm_(parameters, max_norm, norm_type=2.0, error_if_nonfinite=False, foreach=None):
+    """
+    Clips gradient norm of an iterable of parameters.
+
+    The norm is computed over all gradients together, as if they were
+    concatenated into a single vector. Gradients are modified in-place.
+
+    Args:
+        parameters: An iterable of Tensors or a single Tensor that will have gradients normalized
+        max_norm: Max norm of the gradients
+        norm_type: Type of the used p-norm. Can be 'inf' for infinity norm.
+        error_if_nonfinite: If True, an error is thrown if the total norm is nan, inf, or -inf.
+        foreach: Not used, for API compatibility only
+
+    Returns:
+        Total norm of the parameters (viewed as a single vector).
+    """
+    if hasattr(parameters, 'grad'):
+        parameters = [parameters]
+    elif isinstance(parameters, dict):
+        parameters = parameters.values()
+
+    parameters = [p for p in parameters if hasattr(p, 'grad') and p.grad is not None]
+
+    if len(parameters) == 0:
+        return tensor(0.0)
+
+    max_norm = float(max_norm)
+    norm_type = float(norm_type)
+
+    # Compute per-parameter norms
+    norms = []
+    for p in parameters:
+        param_norm = _compute_norm(p.grad, norm_type)
+        norms.append(param_norm)
+
+    # Compute total norm
+    if norm_type == float('inf'):
+        total_norm = amax(stack(norms))
+    elif norm_type == float('-inf'):
+        total_norm = amin(stack(norms))
+    else:
+        # Total norm: (sum of all param_norms^norm_type)^(1/norm_type)
+        total_norm = pow(sum(stack([pow(n, norm_type) for n in norms])), 1.0 / norm_type)
+
+    if error_if_nonfinite:
+        if any(isnan(total_norm)) or any(isinf(total_norm)):
+            raise RuntimeError(
+                f"The total norm of order {norm_type} for gradients from "
+                "`parameters` is non-finite, so it cannot be clipped. To disable "
+                "this error and scale the gradients by the non-finite norm anyway, "
+                "set `error_if_nonfinite=False`"
+            )
+
+    # Compute clipping coefficient
+    # clip_coef = max_norm / (total_norm + 1e-6), clamped to max of 1.0
+    inv_norm = pow(total_norm + tensor(1e-6), -1.0)
+    clip_coef = clamp(mul(tensor(max_norm), inv_norm), max_val=1.0)
+
+    # Scale all gradients in-place
+    for p in parameters:
+        p.grad = p.grad * clip_coef
+
+    return total_norm
+
+
+def clip_grad_value_(parameters, clip_value):
+    """
+    Clips gradient of an iterable of parameters at specified value.
+
+    Gradients are modified in-place.
+
+    Args:
+        parameters: An iterable of Tensors or a single Tensor that will have gradients clipped
+        clip_value: Maximum allowed value of the gradients. The gradients are clipped in the
+            range [-clip_value, clip_value]
+    """
+    if hasattr(parameters, 'grad'):
+        parameters = [parameters]
+    elif isinstance(parameters, dict):
+        parameters = parameters.values()
+
+    clip_value = float(clip_value)
+
+    for p in parameters:
+        if hasattr(p, 'grad') and p.grad is not None:
+            p.grad = clamp(p.grad, min_val=-clip_value, max_val=clip_value)

--- a/src/mindtorch_v2/utils/__init__.py
+++ b/src/mindtorch_v2/utils/__init__.py
@@ -1,3 +1,4 @@
 from . import data
+from . import checkpoint
 
-__all__ = ["data"]
+__all__ = ["data", "checkpoint"]

--- a/src/mindtorch_v2/utils/checkpoint.py
+++ b/src/mindtorch_v2/utils/checkpoint.py
@@ -1,0 +1,104 @@
+from .._autograd.grad_mode import no_grad, enable_grad
+from .._autograd.engine import _run_backward
+from .._autograd.node import Node
+
+
+def checkpoint(function, *args, use_reentrant=True, preserve_rng_state=True, **kwargs):
+    """Checkpoint a function to trade compute for memory.
+
+    Runs function(*args) without saving intermediates in forward,
+    then recomputes them during backward.
+
+    Args:
+        function: The function to checkpoint
+        *args: Arguments to pass to function
+        use_reentrant: Whether to use reentrant checkpoint (for API compatibility)
+        preserve_rng_state: Whether to preserve RNG state (not implemented, for API compatibility)
+        **kwargs: Keyword arguments to pass to function
+    """
+    # Separate tensor and non-tensor args
+    tensor_inputs = []
+    tensor_indices = []
+    for i, arg in enumerate(args):
+        if hasattr(arg, 'requires_grad') and hasattr(arg, 'grad_fn'):
+            tensor_inputs.append(arg)
+            tensor_indices.append(i)
+
+    # Forward: run without saving intermediates
+    with no_grad():
+        outputs = function(*args, **kwargs)
+
+    # If no tensor input requires grad, just return
+    if not any(t.requires_grad for t in tensor_inputs):
+        return outputs
+
+    is_tuple = isinstance(outputs, tuple)
+    if not is_tuple:
+        outputs = (outputs,)
+
+    # Detach inputs for recomputation
+    def make_recompute_inputs():
+        new_args = list(args)
+        detached = []
+        for i, idx in enumerate(tensor_indices):
+            d = tensor_inputs[i].detach()
+            d.requires_grad_(tensor_inputs[i].requires_grad)
+            new_args[idx] = d
+            detached.append(d)
+        return new_args, detached
+
+    def _checkpoint_backward(grad):
+        new_args, detached = make_recompute_inputs()
+        with enable_grad():
+            recomputed = function(*new_args, **kwargs)
+        if not isinstance(recomputed, tuple):
+            recomputed = (recomputed,)
+
+        # Only backward through outputs that got gradients
+        out_with_grad = []
+        grad_outputs = []
+        for r, o in zip(recomputed, outputs):
+            out_with_grad.append(r)
+            grad_outputs.append(grad if len(recomputed) == 1 else None)
+
+        result = _run_backward(
+            tuple(out_with_grad), tuple(grad_outputs),
+            retain_graph=False, create_graph=False,
+            accumulate_grad=False, inputs=detached,
+            allow_unused=True,
+        )
+        # Map back to original tensor_inputs order
+        all_grads = [None] * len(tensor_inputs)
+        for i, g in enumerate(result):
+            all_grads[i] = g
+        return tuple(all_grads)
+
+    node = Node(_checkpoint_backward, tuple(tensor_inputs))
+    # Attach grad_fn to outputs and mark as requiring grad
+    for out in outputs:
+        if hasattr(out, 'grad_fn'):
+            out.grad_fn = node
+            out.requires_grad = True
+
+    if is_tuple:
+        return outputs
+    return outputs[0]
+
+
+def checkpoint_sequential(functions, segments, input, **kwargs):
+    """Checkpoint a sequential model by splitting into segments."""
+    funcs = list(functions)
+    segment_size = (len(funcs) + segments - 1) // segments
+
+    def run_segment(start, end, inp):
+        def segment_fn(x):
+            for f in funcs[start:end]:
+                x = f(x)
+            return x
+        return checkpoint(segment_fn, inp, **kwargs)
+
+    x = input
+    for start in range(0, len(funcs), segment_size):
+        end = min(start + segment_size, len(funcs))
+        x = run_segment(start, end, x)
+    return x


### PR DESCRIPTION
## Summary

- **Fix `no_grad`/`enable_grad` nestability**: Save and restore previous `GradMode.enabled` state so these context managers can be nested correctly (e.g., `enable_grad` inside `no_grad` during checkpoint backward). Also convert `set_grad_enabled` to a class supporting both function-style and context manager usage.
- **Add `torch.nn.utils.clip_grad_norm_` and `clip_grad_value_`**: Gradient clipping utilities used by nearly every training script. Supports list, generator, dict, and single-tensor inputs.
- **Add `torch.utils.checkpoint`**: Gradient checkpointing (`checkpoint` and `checkpoint_sequential`) that trades compute for memory by not saving intermediates in forward and recomputing them during backward.
- **Add `torch.amp` (autocast + GradScaler)**: Mixed-precision training support. `autocast` is a no-op context manager/decorator for API compatibility. `GradScaler` is fully implemented with `scale`, `unscale_`, `step`, `update`, `state_dict`/`load_state_dict`, supporting both `optimizer.params` and `optimizer.param_groups` styles.

## Files changed

| Action | File |
|--------|------|
| Modify | `src/mindtorch_v2/_autograd/grad_mode.py` |
| Modify | `src/mindtorch_v2/__init__.py` |
| Modify | `src/mindtorch_v2/nn/__init__.py` |
| Modify | `src/mindtorch_v2/utils/__init__.py` |
| Create | `src/mindtorch_v2/nn/utils/__init__.py` |
| Create | `src/mindtorch_v2/nn/utils/clip_grad.py` |
| Create | `src/mindtorch_v2/utils/checkpoint.py` |
| Create | `src/mindtorch_v2/amp/__init__.py` |
| Create | `src/mindtorch_v2/amp/autocast_mode.py` |
| Create | `src/mindtorch_v2/amp/grad_scaler.py` |

## Test plan

- [x] `no_grad`/`enable_grad` nestability verified
- [x] `set_grad_enabled` works as both function call and context manager
- [x] `clip_grad_norm_` correctly computes total norm and clips when norm > max_norm
- [x] `clip_grad_norm_` leaves gradients unchanged when norm <= max_norm
- [x] `clip_grad_norm_` accepts single tensor, list, generator inputs
- [x] `clip_grad_value_` clamps gradient values to [-clip_value, clip_value]
- [x] `checkpoint` produces identical gradients to non-checkpointed forward
- [x] `checkpoint_sequential` produces identical gradients across segments
- [x] `autocast` works as both context manager and decorator (no-op)
- [x] `GradScaler.scale()` multiplies loss correctly
- [x] `GradScaler.unscale_()` divides grads and detects inf/nan
- [x] `GradScaler.step()` skips optimizer step on inf/nan
- [x] `GradScaler.update()` backs off on inf/nan, grows after clean interval
- [x] `GradScaler` works with both `params` and `param_groups` optimizer styles
- [x] End-to-end HuggingFace Trainer-style usage pattern verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)