### PR TITLE
v2: add NPU aclnn direct-call support for stack, cat, where

### DIFF
--- a/src/mindtorch_v2/_backends/npu/__init__.py
+++ b/src/mindtorch_v2/_backends/npu/__init__.py
@@ -58,6 +58,10 @@ from .ops import (
     all_,
     any_,
     count_nonzero,
+    stack,
+    cat,
+    concatenate,
+    where,
 )
 from .runtime import is_available, _model_dir, _probe_model_dirs
 from . import allocator
@@ -127,5 +131,11 @@ registry.register("ones", "npu", ones_create)
 registry.register("empty", "npu", empty_create)
 registry.register("getitem", "npu", getitem)
 registry.register("setitem", "npu", setitem)
+
+registry.register("stack", "npu", stack, meta=meta_infer.infer_stack)
+registry.register("cat", "npu", cat, meta=meta_infer.infer_cat)
+registry.register("concat", "npu", cat, meta=meta_infer.infer_cat)
+registry.register("concatenate", "npu", concatenate, meta=meta_infer.infer_cat)
+registry.register("where", "npu", where, meta=meta_infer.infer_binary)
 
 __all__ = ["is_available", "_probe_model_dirs", "_model_dir", "allocator"]


### PR DESCRIPTION
## Summary

- Add `aclCreateTensorList`/`aclDestroyTensorList` bindings to support TensorList inputs
- Add `aclnnCat`, `aclnnStack`, `aclnnSWhere` aclnn direct-call bindings and wrapper functions
- Implement `stack`, `cat`, `concatenate`, `where` NPU ops using aclnn direct calls
- Register new ops in NPU dispatch

## Implementation

All NPU ops use aclnn direct calls — no D2D memcpy composites or CPU fallback:

- **`cat`/`concatenate`**: `aclnnCat(tensorList, dim, out)`
- **`stack`**: `aclnnStack(tensorList, dim, out)`
- **`where`**: `aclnnSWhere(condition, self, other, out)`

TensorList support is added via `aclCreateTensorList`/`aclDestroyTensorList` bindings, used by both `cat` and `stack`.

## Test plan

- [x] NPU ops module imports without errors
- [x] All aclnn wrapper functions and `_symbols_ok()` checks exist
- [x] NPU dispatch registrations verified
- [x] CPU backend regression tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)