### PR TITLE
feat(mindtorch_v2): extend NPU elementwise ops

### DIFF
--- a/src/mindtorch_v2/_backends/npu/__init__.py
+++ b/src/mindtorch_v2/_backends/npu/__init__.py
@@ -62,6 +62,31 @@ from .ops import (
     cat,
     concatenate,
     where,
+    sub,
+    div,
+    acosh,
+    addcdiv,
+    addcmul,
+    allclose,
+    asin,
+    asinh,
+    atan,
+    atan2,
+    atanh,
+    equal,
+    fmax,
+    fmin,
+    fmod,
+    hypot,
+    isclose,
+    lerp,
+    logaddexp,
+    logaddexp2,
+    max_,
+    min_,
+    remainder,
+    where,
+    acos,
 )
 from .runtime import is_available, _model_dir, _probe_model_dirs
 from . import allocator
@@ -110,6 +135,8 @@ registry.register("clamp_min", "npu", clamp_min, meta=meta_infer.infer_unary)
 registry.register("clamp_max", "npu", clamp_max, meta=meta_infer.infer_unary)
 registry.register("relu6", "npu", relu6, meta=meta_infer.infer_unary)
 registry.register("hardtanh", "npu", hardtanh, meta=meta_infer.infer_unary)
+registry.register("min", "npu", min_, meta=meta_infer.infer_binary)
+registry.register("max", "npu", max_, meta=meta_infer.infer_binary)
 registry.register("pow", "npu", pow, meta=meta_infer.infer_binary)
 
 registry.register("amin", "npu", amin, meta=meta_infer.infer_sum)
@@ -120,6 +147,31 @@ registry.register("add_", "npu", add_, meta=meta_infer.infer_binary)
 registry.register("mul_", "npu", mul_, meta=meta_infer.infer_binary)
 registry.register("relu_", "npu", relu_, meta=meta_infer.infer_unary)
 registry.register("zero_", "npu", zero_, meta=meta_infer.infer_unary)
+registry.register("sub", "npu", sub, meta=meta_infer.infer_binary)
+registry.register("div", "npu", div, meta=meta_infer.infer_binary)
+registry.register("asin", "npu", asin, meta=meta_infer.infer_unary)
+registry.register("acos", "npu", acos, meta=meta_infer.infer_unary)
+registry.register("atan", "npu", atan, meta=meta_infer.infer_unary)
+registry.register("atan2", "npu", atan2, meta=meta_infer.infer_binary)
+registry.register("asinh", "npu", asinh, meta=meta_infer.infer_unary)
+registry.register("acosh", "npu", acosh, meta=meta_infer.infer_unary)
+registry.register("atanh", "npu", atanh, meta=meta_infer.infer_unary)
+registry.register("min_", "npu", min_, meta=meta_infer.infer_binary)
+registry.register("max_", "npu", max_, meta=meta_infer.infer_binary)
+registry.register("fmin", "npu", fmin, meta=meta_infer.infer_binary)
+registry.register("fmax", "npu", fmax, meta=meta_infer.infer_binary)
+registry.register("where", "npu", where, meta=meta_infer.infer_binary)
+registry.register("lerp", "npu", lerp, meta=meta_infer.infer_binary)
+registry.register("addcmul", "npu", addcmul, meta=meta_infer.infer_binary)
+registry.register("addcdiv", "npu", addcdiv, meta=meta_infer.infer_binary)
+registry.register("logaddexp", "npu", logaddexp, meta=meta_infer.infer_binary)
+registry.register("logaddexp2", "npu", logaddexp2, meta=meta_infer.infer_binary)
+registry.register("hypot", "npu", hypot, meta=meta_infer.infer_binary)
+registry.register("remainder", "npu", remainder, meta=meta_infer.infer_binary)
+registry.register("fmod", "npu", fmod, meta=meta_infer.infer_binary)
+registry.register("allclose", "npu", allclose, meta=meta_infer.infer_reduce_bool)
+registry.register("isclose", "npu", isclose, meta=meta_infer.infer_unary_bool)
+registry.register("equal", "npu", equal, meta=meta_infer.infer_reduce_bool)
 registry.register("reshape", "npu", view_backend.reshape, meta=meta_infer.infer_view)
 registry.register("view", "npu", view_backend.view, meta=meta_infer.infer_view)
 registry.register("transpose", "npu", view_backend.transpose, meta=meta_infer.infer_transpose)

--- a/src/mindtorch_v2/_backends/npu/aclnn.py
+++ b/src/mindtorch_v2/_backends/npu/aclnn.py
@@ -154,6 +154,206 @@ class AclnnBindings:
             ctypes.c_int32,
             [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
         )
+
+        self.aclnn_sub_get_workspace = _optional_symbol(
+            libs,
+            "aclnnSubGetWorkspaceSize",
+            ctypes.c_int32,
+            [
+                ctypes.c_void_p,
+                ctypes.c_void_p,
+                ctypes.c_void_p,
+                ctypes.c_void_p,
+                ctypes.POINTER(ctypes.c_uint64),
+                ctypes.POINTER(ctypes.c_void_p),
+            ],
+        )
+        self.aclnn_sub = _optional_symbol(
+            libs,
+            "aclnnSub",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
+        self.aclnn_div_get_workspace = _optional_symbol(
+            libs,
+            "aclnnDivGetWorkspaceSize",
+            ctypes.c_int32,
+            [
+                ctypes.c_void_p,
+                ctypes.c_void_p,
+                ctypes.c_void_p,
+                ctypes.POINTER(ctypes.c_uint64),
+                ctypes.POINTER(ctypes.c_void_p),
+            ],
+        )
+        self.aclnn_div = _optional_symbol(
+            libs,
+            "aclnnDiv",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
+        self.aclnn_add_scalar_get_workspace = _optional_symbol(
+            libs,
+            "aclnnAddsGetWorkspaceSize",
+            ctypes.c_int32,
+            [
+                ctypes.c_void_p,
+                ctypes.c_void_p,
+                ctypes.c_void_p,
+                ctypes.POINTER(ctypes.c_uint64),
+                ctypes.POINTER(ctypes.c_void_p),
+            ],
+        )
+        self.aclnn_add_scalar = _optional_symbol(
+            libs,
+            "aclnnAdds",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
+        self.aclnn_sub_scalar_get_workspace = _optional_symbol(
+            libs,
+            "aclnnSubsGetWorkspaceSize",
+            ctypes.c_int32,
+            [
+                ctypes.c_void_p,
+                ctypes.c_void_p,
+                ctypes.c_void_p,
+                ctypes.POINTER(ctypes.c_uint64),
+                ctypes.POINTER(ctypes.c_void_p),
+            ],
+        )
+        self.aclnn_sub_scalar = _optional_symbol(
+            libs,
+            "aclnnSubs",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
+        self.aclnn_maximum_get_workspace = _optional_symbol(
+            libs,
+            "aclnnMaximumGetWorkspaceSize",
+            ctypes.c_int32,
+            [
+                ctypes.c_void_p,
+                ctypes.c_void_p,
+                ctypes.c_void_p,
+                ctypes.POINTER(ctypes.c_uint64),
+                ctypes.POINTER(ctypes.c_void_p),
+            ],
+        )
+        self.aclnn_maximum = _optional_symbol(
+            libs,
+            "aclnnMaximum",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
+        self.aclnn_minimum_get_workspace = _optional_symbol(
+            libs,
+            "aclnnMinimumGetWorkspaceSize",
+            ctypes.c_int32,
+            [
+                ctypes.c_void_p,
+                ctypes.c_void_p,
+                ctypes.c_void_p,
+                ctypes.POINTER(ctypes.c_uint64),
+                ctypes.POINTER(ctypes.c_void_p),
+            ],
+        )
+        self.aclnn_minimum = _optional_symbol(
+            libs,
+            "aclnnMinimum",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
+        self.aclnn_atan_get_workspace = _optional_symbol(
+            libs,
+            "aclnnAtanGetWorkspaceSize",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_void_p)],
+        )
+        self.aclnn_atan = _optional_symbol(
+            libs,
+            "aclnnAtan",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
+        self.aclnn_atan2_get_workspace = _optional_symbol(
+            libs,
+            "aclnnAtan2GetWorkspaceSize",
+            ctypes.c_int32,
+            [
+                ctypes.c_void_p,
+                ctypes.c_void_p,
+                ctypes.c_void_p,
+                ctypes.POINTER(ctypes.c_uint64),
+                ctypes.POINTER(ctypes.c_void_p),
+            ],
+        )
+        self.aclnn_atan2 = _optional_symbol(
+            libs,
+            "aclnnAtan2",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
+        self.aclnn_asin_get_workspace = _optional_symbol(
+            libs,
+            "aclnnAsinGetWorkspaceSize",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_void_p)],
+        )
+        self.aclnn_asin = _optional_symbol(
+            libs,
+            "aclnnAsin",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
+        self.aclnn_acos_get_workspace = _optional_symbol(
+            libs,
+            "aclnnAcosGetWorkspaceSize",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_void_p)],
+        )
+        self.aclnn_acos = _optional_symbol(
+            libs,
+            "aclnnAcos",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
+        self.aclnn_asinh_get_workspace = _optional_symbol(
+            libs,
+            "aclnnAsinhGetWorkspaceSize",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_void_p)],
+        )
+        self.aclnn_asinh = _optional_symbol(
+            libs,
+            "aclnnAsinh",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
+        self.aclnn_acosh_get_workspace = _optional_symbol(
+            libs,
+            "aclnnAcoshGetWorkspaceSize",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_void_p)],
+        )
+        self.aclnn_acosh = _optional_symbol(
+            libs,
+            "aclnnAcosh",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
+        self.aclnn_atanh_get_workspace = _optional_symbol(
+            libs,
+            "aclnnAtanhGetWorkspaceSize",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_void_p)],
+        )
+        self.aclnn_atanh = _optional_symbol(
+            libs,
+            "aclnnAtanh",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
+        )
         self.aclnn_relu_get_workspace = _bind_symbol(
             libs,
             "aclnnReluGetWorkspaceSize",
@@ -387,6 +587,26 @@ class AclnnBindings:
                 ctypes.POINTER(ctypes.c_uint64),
                 ctypes.POINTER(ctypes.c_void_p),
             ],
+        )
+
+        self.aclnn_swhere_get_workspace = _optional_symbol(
+            libs,
+            "aclnnSWhereGetWorkspaceSize",
+            ctypes.c_int32,
+            [
+                ctypes.c_void_p,
+                ctypes.c_void_p,
+                ctypes.c_void_p,
+                ctypes.c_void_p,
+                ctypes.POINTER(ctypes.c_uint64),
+                ctypes.POINTER(ctypes.c_void_p),
+            ],
+        )
+        self.aclnn_swhere = _optional_symbol(
+            libs,
+            "aclnnSWhere",
+            ctypes.c_int32,
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_void_p],
         )
         self.aclnn_logical_xor = _optional_symbol(
             libs,
@@ -1364,14 +1584,15 @@ def is_available():
         return False
 
 
-def add(self_ptr, other_ptr, out_ptr, shape, stride, dtype, runtime, stream=None):
+def add(self_ptr, other_ptr, out_ptr, self_shape, self_stride, other_shape, other_stride,
+        out_shape, out_stride, dtype, runtime, stream=None):
     global acl
     if acl is None:
         acl = ensure_acl()
     bindings = get_bindings()
-    self_tensor, self_keep = _create_tensor(bindings, shape, stride, dtype, self_ptr)
-    other_tensor, other_keep = _create_tensor(bindings, shape, stride, dtype, other_ptr)
-    out_tensor, out_keep = _create_tensor(bindings, shape, stride, dtype, out_ptr)
+    self_tensor, self_keep = _create_tensor(bindings, self_shape, self_stride, dtype, self_ptr)
+    other_tensor, other_keep = _create_tensor(bindings, other_shape, other_stride, dtype, other_ptr)
+    out_tensor, out_keep = _create_tensor(bindings, out_shape, out_stride, dtype, out_ptr)
     scalar = None
     alpha_arr = None
     executor = ctypes.c_void_p()
@@ -1415,14 +1636,15 @@ def add(self_ptr, other_ptr, out_ptr, shape, stride, dtype, runtime, stream=None
         _ = (self_keep, other_keep, out_keep, alpha_arr)
 
 
-def mul(self_ptr, other_ptr, out_ptr, shape, stride, dtype, runtime, stream=None):
+def mul(self_ptr, other_ptr, out_ptr, self_shape, self_stride, other_shape, other_stride,
+        out_shape, out_stride, dtype, runtime, stream=None):
     global acl
     if acl is None:
         acl = ensure_acl()
     bindings = get_bindings()
-    self_tensor, self_keep = _create_tensor(bindings, shape, stride, dtype, self_ptr)
-    other_tensor, other_keep = _create_tensor(bindings, shape, stride, dtype, other_ptr)
-    out_tensor, out_keep = _create_tensor(bindings, shape, stride, dtype, out_ptr)
+    self_tensor, self_keep = _create_tensor(bindings, self_shape, self_stride, dtype, self_ptr)
+    other_tensor, other_keep = _create_tensor(bindings, other_shape, other_stride, dtype, other_ptr)
+    out_tensor, out_keep = _create_tensor(bindings, out_shape, out_stride, dtype, out_ptr)
     executor = ctypes.c_void_p()
     workspace_size = ctypes.c_uint64(0)
     workspace = None
@@ -1458,6 +1680,412 @@ def mul(self_ptr, other_ptr, out_ptr, shape, stride, dtype, runtime, stream=None
         if workspace is not None:
             runtime.defer_free(workspace)
         _ = (self_keep, other_keep, out_keep)
+
+
+def sub(self_ptr, other_ptr, out_ptr, self_shape, self_stride, other_shape, other_stride,
+        out_shape, out_stride, dtype, runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    if bindings.aclnn_sub_get_workspace is None or bindings.aclnn_sub is None:
+        raise RuntimeError("aclnnSub symbols not available")
+    self_tensor, self_keep = _create_tensor(bindings, self_shape, self_stride, dtype, self_ptr)
+    other_tensor, other_keep = _create_tensor(bindings, other_shape, other_stride, dtype, other_ptr)
+    out_tensor, out_keep = _create_tensor(bindings, out_shape, out_stride, dtype, out_ptr)
+    scalar = None
+    alpha_arr = None
+    executor = ctypes.c_void_p()
+    workspace_size = ctypes.c_uint64(0)
+    workspace = None
+    try:
+        scalar, alpha_arr = _create_scalar(bindings, 1, dtype)
+        ret = bindings.aclnn_sub_get_workspace(
+            self_tensor,
+            other_tensor,
+            scalar,
+            out_tensor,
+            ctypes.byref(workspace_size),
+            ctypes.byref(executor),
+        )
+        if ret != 0:
+            raise RuntimeError(f"aclnnSubGetWorkspaceSize failed: {ret}")
+        if workspace_size.value:
+            workspace_ptr, ret = acl.rt.malloc(int(workspace_size.value), 0)
+            if ret != 0:
+                raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+            workspace = workspace_ptr
+        ret = bindings.aclnn_sub(
+            ctypes.c_void_p(0 if workspace is None else int(workspace)),
+            ctypes.c_uint64(workspace_size.value),
+            executor,
+            ctypes.c_void_p(int(runtime.stream if stream is None else stream)),
+        )
+        if ret != 0:
+            raise RuntimeError(f"aclnnSub failed: {ret}")
+        _maybe_sync(runtime)
+    finally:
+        _defer_executor(executor)
+        if scalar:
+            bindings.acl_destroy_scalar(scalar)
+        bindings.acl_destroy_tensor(self_tensor)
+        bindings.acl_destroy_tensor(other_tensor)
+        bindings.acl_destroy_tensor(out_tensor)
+        if workspace is not None:
+            runtime.defer_free(workspace)
+        _ = (self_keep, other_keep, out_keep, alpha_arr)
+
+
+def div(self_ptr, other_ptr, out_ptr, self_shape, self_stride, other_shape, other_stride,
+        out_shape, out_stride, dtype, runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    if bindings.aclnn_div_get_workspace is None or bindings.aclnn_div is None:
+        raise RuntimeError("aclnnDiv symbols not available")
+    self_tensor, self_keep = _create_tensor(bindings, self_shape, self_stride, dtype, self_ptr)
+    other_tensor, other_keep = _create_tensor(bindings, other_shape, other_stride, dtype, other_ptr)
+    out_tensor, out_keep = _create_tensor(bindings, out_shape, out_stride, dtype, out_ptr)
+    executor = ctypes.c_void_p()
+    workspace_size = ctypes.c_uint64(0)
+    workspace = None
+    try:
+        ret = bindings.aclnn_div_get_workspace(
+            self_tensor,
+            other_tensor,
+            out_tensor,
+            ctypes.byref(workspace_size),
+            ctypes.byref(executor),
+        )
+        if ret != 0:
+            raise RuntimeError(f"aclnnDivGetWorkspaceSize failed: {ret}")
+        if workspace_size.value:
+            workspace_ptr, ret = acl.rt.malloc(int(workspace_size.value), 0)
+            if ret != 0:
+                raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+            workspace = workspace_ptr
+        ret = bindings.aclnn_div(
+            ctypes.c_void_p(0 if workspace is None else int(workspace)),
+            ctypes.c_uint64(workspace_size.value),
+            executor,
+            ctypes.c_void_p(int(runtime.stream if stream is None else stream)),
+        )
+        if ret != 0:
+            raise RuntimeError(f"aclnnDiv failed: {ret}")
+        _maybe_sync(runtime)
+    finally:
+        _defer_executor(executor)
+        bindings.acl_destroy_tensor(self_tensor)
+        bindings.acl_destroy_tensor(other_tensor)
+        bindings.acl_destroy_tensor(out_tensor)
+        if workspace is not None:
+            runtime.defer_free(workspace)
+        _ = (self_keep, other_keep, out_keep)
+
+
+def add_scalar(self_ptr, scalar_value, out_ptr, shape, stride, dtype, runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    if bindings.aclnn_add_scalar_get_workspace is None or bindings.aclnn_add_scalar is None:
+        raise RuntimeError("aclnnAdds symbols not available")
+    self_tensor, self_keep = _create_tensor(bindings, shape, stride, dtype, self_ptr)
+    out_tensor, out_keep = _create_tensor(bindings, shape, stride, dtype, out_ptr)
+    scalar, scalar_keep = _create_scalar(bindings, scalar_value, dtype)
+    executor = ctypes.c_void_p()
+    workspace_size = ctypes.c_uint64(0)
+    workspace = None
+    try:
+        ret = bindings.aclnn_add_scalar_get_workspace(
+            self_tensor,
+            scalar,
+            out_tensor,
+            ctypes.byref(workspace_size),
+            ctypes.byref(executor),
+        )
+        if ret != 0:
+            raise RuntimeError(f"aclnnAddsGetWorkspaceSize failed: {ret}")
+        if workspace_size.value:
+            workspace_ptr, ret = acl.rt.malloc(int(workspace_size.value), 0)
+            if ret != 0:
+                raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+            workspace = workspace_ptr
+        ret = bindings.aclnn_add_scalar(
+            ctypes.c_void_p(0 if workspace is None else int(workspace)),
+            ctypes.c_uint64(workspace_size.value),
+            executor,
+            ctypes.c_void_p(int(runtime.stream if stream is None else stream)),
+        )
+        if ret != 0:
+            raise RuntimeError(f"aclnnAdds failed: {ret}")
+        _maybe_sync(runtime)
+    finally:
+        _defer_executor(executor)
+        bindings.acl_destroy_tensor(self_tensor)
+        bindings.acl_destroy_tensor(out_tensor)
+        bindings.acl_destroy_scalar(scalar)
+        if workspace is not None:
+            runtime.defer_free(workspace)
+        _ = (self_keep, out_keep, scalar_keep)
+
+
+def sub_scalar(self_ptr, scalar_value, out_ptr, shape, stride, dtype, runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    if bindings.aclnn_sub_scalar_get_workspace is None or bindings.aclnn_sub_scalar is None:
+        raise RuntimeError("aclnnSubs symbols not available")
+    self_tensor, self_keep = _create_tensor(bindings, shape, stride, dtype, self_ptr)
+    out_tensor, out_keep = _create_tensor(bindings, shape, stride, dtype, out_ptr)
+    scalar, scalar_keep = _create_scalar(bindings, scalar_value, dtype)
+    executor = ctypes.c_void_p()
+    workspace_size = ctypes.c_uint64(0)
+    workspace = None
+    try:
+        ret = bindings.aclnn_sub_scalar_get_workspace(
+            self_tensor,
+            scalar,
+            out_tensor,
+            ctypes.byref(workspace_size),
+            ctypes.byref(executor),
+        )
+        if ret != 0:
+            raise RuntimeError(f"aclnnSubsGetWorkspaceSize failed: {ret}")
+        if workspace_size.value:
+            workspace_ptr, ret = acl.rt.malloc(int(workspace_size.value), 0)
+            if ret != 0:
+                raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+            workspace = workspace_ptr
+        ret = bindings.aclnn_sub_scalar(
+            ctypes.c_void_p(0 if workspace is None else int(workspace)),
+            ctypes.c_uint64(workspace_size.value),
+            executor,
+            ctypes.c_void_p(int(runtime.stream if stream is None else stream)),
+        )
+        if ret != 0:
+            raise RuntimeError(f"aclnnSubs failed: {ret}")
+        _maybe_sync(runtime)
+    finally:
+        _defer_executor(executor)
+        bindings.acl_destroy_tensor(self_tensor)
+        bindings.acl_destroy_tensor(out_tensor)
+        bindings.acl_destroy_scalar(scalar)
+        if workspace is not None:
+            runtime.defer_free(workspace)
+        _ = (self_keep, out_keep, scalar_keep)
+
+
+def maximum(self_ptr, other_ptr, out_ptr, self_shape, self_stride, other_shape, other_stride, out_shape, out_stride,
+            dtype, runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    if bindings.aclnn_maximum_get_workspace is None or bindings.aclnn_maximum is None:
+        raise RuntimeError("aclnnMaximum symbols not available")
+    self_tensor, self_keep = _create_tensor(bindings, self_shape, self_stride, dtype, self_ptr)
+    other_tensor, other_keep = _create_tensor(bindings, other_shape, other_stride, dtype, other_ptr)
+    out_tensor, out_keep = _create_tensor(bindings, out_shape, out_stride, dtype, out_ptr)
+    executor = ctypes.c_void_p()
+    workspace_size = ctypes.c_uint64(0)
+    workspace = None
+    try:
+        ret = bindings.aclnn_maximum_get_workspace(
+            self_tensor,
+            other_tensor,
+            out_tensor,
+            ctypes.byref(workspace_size),
+            ctypes.byref(executor),
+        )
+        if ret != 0:
+            raise RuntimeError(f"aclnnMaximumGetWorkspaceSize failed: {ret}")
+        if workspace_size.value:
+            workspace_ptr, ret = acl.rt.malloc(int(workspace_size.value), 0)
+            if ret != 0:
+                raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+            workspace = workspace_ptr
+        ret = bindings.aclnn_maximum(
+            ctypes.c_void_p(0 if workspace is None else int(workspace)),
+            ctypes.c_uint64(workspace_size.value),
+            executor,
+            ctypes.c_void_p(int(runtime.stream if stream is None else stream)),
+        )
+        if ret != 0:
+            raise RuntimeError(f"aclnnMaximum failed: {ret}")
+        _maybe_sync(runtime)
+    finally:
+        _defer_executor(executor)
+        bindings.acl_destroy_tensor(self_tensor)
+        bindings.acl_destroy_tensor(other_tensor)
+        bindings.acl_destroy_tensor(out_tensor)
+        if workspace is not None:
+            runtime.defer_free(workspace)
+        _ = (self_keep, other_keep, out_keep)
+
+
+def minimum(self_ptr, other_ptr, out_ptr, self_shape, self_stride, other_shape, other_stride, out_shape, out_stride,
+            dtype, runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    if bindings.aclnn_minimum_get_workspace is None or bindings.aclnn_minimum is None:
+        raise RuntimeError("aclnnMinimum symbols not available")
+    self_tensor, self_keep = _create_tensor(bindings, self_shape, self_stride, dtype, self_ptr)
+    other_tensor, other_keep = _create_tensor(bindings, other_shape, other_stride, dtype, other_ptr)
+    out_tensor, out_keep = _create_tensor(bindings, out_shape, out_stride, dtype, out_ptr)
+    executor = ctypes.c_void_p()
+    workspace_size = ctypes.c_uint64(0)
+    workspace = None
+    try:
+        ret = bindings.aclnn_minimum_get_workspace(
+            self_tensor,
+            other_tensor,
+            out_tensor,
+            ctypes.byref(workspace_size),
+            ctypes.byref(executor),
+        )
+        if ret != 0:
+            raise RuntimeError(f"aclnnMinimumGetWorkspaceSize failed: {ret}")
+        if workspace_size.value:
+            workspace_ptr, ret = acl.rt.malloc(int(workspace_size.value), 0)
+            if ret != 0:
+                raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+            workspace = workspace_ptr
+        ret = bindings.aclnn_minimum(
+            ctypes.c_void_p(0 if workspace is None else int(workspace)),
+            ctypes.c_uint64(workspace_size.value),
+            executor,
+            ctypes.c_void_p(int(runtime.stream if stream is None else stream)),
+        )
+        if ret != 0:
+            raise RuntimeError(f"aclnnMinimum failed: {ret}")
+        _maybe_sync(runtime)
+    finally:
+        _defer_executor(executor)
+        bindings.acl_destroy_tensor(self_tensor)
+        bindings.acl_destroy_tensor(other_tensor)
+        bindings.acl_destroy_tensor(out_tensor)
+        if workspace is not None:
+            runtime.defer_free(workspace)
+        _ = (self_keep, other_keep, out_keep)
+
+
+def atan(self_ptr, out_ptr, shape, stride, dtype, runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    if bindings.aclnn_atan_get_workspace is None or bindings.aclnn_atan is None:
+        raise RuntimeError("aclnnAtan symbols not available")
+    return _unary_call(bindings, "aclnnAtan", bindings.aclnn_atan_get_workspace, bindings.aclnn_atan,
+                       self_ptr, out_ptr, shape, stride, dtype, runtime, stream)
+
+
+def atan2(self_ptr, other_ptr, out_ptr, self_shape, self_stride, other_shape, other_stride, out_shape, out_stride,
+          dtype, runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    if bindings.aclnn_atan2_get_workspace is None or bindings.aclnn_atan2 is None:
+        raise RuntimeError("aclnnAtan2 symbols not available")
+    self_tensor, self_keep = _create_tensor(bindings, self_shape, self_stride, dtype, self_ptr)
+    other_tensor, other_keep = _create_tensor(bindings, other_shape, other_stride, dtype, other_ptr)
+    out_tensor, out_keep = _create_tensor(bindings, out_shape, out_stride, dtype, out_ptr)
+    executor = ctypes.c_void_p()
+    workspace_size = ctypes.c_uint64(0)
+    workspace = None
+    try:
+        ret = bindings.aclnn_atan2_get_workspace(
+            self_tensor,
+            other_tensor,
+            out_tensor,
+            ctypes.byref(workspace_size),
+            ctypes.byref(executor),
+        )
+        if ret != 0:
+            raise RuntimeError(f"aclnnAtan2GetWorkspaceSize failed: {ret}")
+        if workspace_size.value:
+            workspace_ptr, ret = acl.rt.malloc(int(workspace_size.value), 0)
+            if ret != 0:
+                raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+            workspace = workspace_ptr
+        ret = bindings.aclnn_atan2(
+            ctypes.c_void_p(0 if workspace is None else int(workspace)),
+            ctypes.c_uint64(workspace_size.value),
+            executor,
+            ctypes.c_void_p(int(runtime.stream if stream is None else stream)),
+        )
+        if ret != 0:
+            raise RuntimeError(f"aclnnAtan2 failed: {ret}")
+        _maybe_sync(runtime)
+    finally:
+        _defer_executor(executor)
+        bindings.acl_destroy_tensor(self_tensor)
+        bindings.acl_destroy_tensor(other_tensor)
+        bindings.acl_destroy_tensor(out_tensor)
+        if workspace is not None:
+            runtime.defer_free(workspace)
+        _ = (self_keep, other_keep, out_keep)
+
+
+def asin(self_ptr, out_ptr, shape, stride, dtype, runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    if bindings.aclnn_asin_get_workspace is None or bindings.aclnn_asin is None:
+        raise RuntimeError("aclnnAsin symbols not available")
+    return _unary_call(bindings, "aclnnAsin", bindings.aclnn_asin_get_workspace, bindings.aclnn_asin,
+                       self_ptr, out_ptr, shape, stride, dtype, runtime, stream)
+
+
+def acos(self_ptr, out_ptr, shape, stride, dtype, runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    if bindings.aclnn_acos_get_workspace is None or bindings.aclnn_acos is None:
+        raise RuntimeError("aclnnAcos symbols not available")
+    return _unary_call(bindings, "aclnnAcos", bindings.aclnn_acos_get_workspace, bindings.aclnn_acos,
+                       self_ptr, out_ptr, shape, stride, dtype, runtime, stream)
+
+
+def asinh(self_ptr, out_ptr, shape, stride, dtype, runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    if bindings.aclnn_asinh_get_workspace is None or bindings.aclnn_asinh is None:
+        raise RuntimeError("aclnnAsinh symbols not available")
+    return _unary_call(bindings, "aclnnAsinh", bindings.aclnn_asinh_get_workspace, bindings.aclnn_asinh,
+                       self_ptr, out_ptr, shape, stride, dtype, runtime, stream)
+
+
+def acosh(self_ptr, out_ptr, shape, stride, dtype, runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    if bindings.aclnn_acosh_get_workspace is None or bindings.aclnn_acosh is None:
+        raise RuntimeError("aclnnAcosh symbols not available")
+    return _unary_call(bindings, "aclnnAcosh", bindings.aclnn_acosh_get_workspace, bindings.aclnn_acosh,
+                       self_ptr, out_ptr, shape, stride, dtype, runtime, stream)
+
+
+def atanh(self_ptr, out_ptr, shape, stride, dtype, runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    if bindings.aclnn_atanh_get_workspace is None or bindings.aclnn_atanh is None:
+        raise RuntimeError("aclnnAtanh symbols not available")
+    return _unary_call(bindings, "aclnnAtanh", bindings.aclnn_atanh_get_workspace, bindings.aclnn_atanh,
+                       self_ptr, out_ptr, shape, stride, dtype, runtime, stream)
 
 
 def relu(self_ptr, out_ptr, shape, stride, dtype, runtime, stream=None):
@@ -1881,6 +2509,8 @@ def cast(self_ptr, out_ptr, shape, stride, src_dtype, dst_dtype, runtime, stream
         if workspace is not None:
             runtime.defer_free(workspace)
         _ = (self_keep, out_keep)
+
+
 def _unary_call(bindings, name, get_workspace_fn, exec_fn, self_ptr, out_ptr, shape, stride, dtype, runtime, stream, out_dtype=None):
     self_tensor, self_keep = _create_tensor(bindings, shape, stride, dtype, self_ptr)
     if out_dtype is None:
@@ -1965,7 +2595,7 @@ def logical_xor(self_ptr, other_ptr, out_ptr, self_shape, self_stride, other_sha
         raise RuntimeError("aclnnLogicalXor symbols not available")
     self_tensor, self_keep = _create_tensor(bindings, self_shape, self_stride, dtype, self_ptr)
     other_tensor, other_keep = _create_tensor(bindings, other_shape, other_stride, dtype, other_ptr)
-    out_tensor, out_keep = _create_tensor(bindings, out_shape, out_stride, dtype, out_ptr)
+    out_tensor, out_keep = _create_tensor(bindings, out_shape, out_stride, "bool", out_ptr)
     executor = ctypes.c_void_p()
     workspace_size = ctypes.c_uint64(0)
     workspace = None
@@ -2012,7 +2642,7 @@ def logical_or(self_ptr, other_ptr, out_ptr, self_shape, self_stride, other_shap
         raise RuntimeError("aclnnLogicalOr symbols not available")
     self_tensor, self_keep = _create_tensor(bindings, self_shape, self_stride, dtype, self_ptr)
     other_tensor, other_keep = _create_tensor(bindings, other_shape, other_stride, dtype, other_ptr)
-    out_tensor, out_keep = _create_tensor(bindings, out_shape, out_stride, dtype, out_ptr)
+    out_tensor, out_keep = _create_tensor(bindings, out_shape, out_stride, "bool", out_ptr)
     executor = ctypes.c_void_p()
     workspace_size = ctypes.c_uint64(0)
     workspace = None
@@ -2059,7 +2689,7 @@ def logical_and(self_ptr, other_ptr, out_ptr, self_shape, self_stride, other_sha
         raise RuntimeError("aclnnLogicalAnd symbols not available")
     self_tensor, self_keep = _create_tensor(bindings, self_shape, self_stride, dtype, self_ptr)
     other_tensor, other_keep = _create_tensor(bindings, other_shape, other_stride, dtype, other_ptr)
-    out_tensor, out_keep = _create_tensor(bindings, out_shape, out_stride, dtype, out_ptr)
+    out_tensor, out_keep = _create_tensor(bindings, out_shape, out_stride, "bool", out_ptr)
     executor = ctypes.c_void_p()
     workspace_size = ctypes.c_uint64(0)
     workspace = None
@@ -2095,6 +2725,59 @@ def logical_and(self_ptr, other_ptr, out_ptr, self_shape, self_stride, other_sha
         if workspace is not None:
             runtime.defer_free(workspace)
         _ = (self_keep, other_keep, out_keep)
+
+
+
+def swhere(cond_ptr, self_ptr, other_ptr, out_ptr, cond_shape, cond_stride, self_shape, self_stride,
+          other_shape, other_stride, out_shape, out_stride, dtype, runtime, stream=None):
+    global acl
+    if acl is None:
+        acl = ensure_acl()
+    bindings = get_bindings()
+    if bindings.aclnn_swhere_get_workspace is None or bindings.aclnn_swhere is None:
+        raise RuntimeError("aclnnSWhere symbols not available")
+    cond_tensor, cond_keep = _create_tensor(bindings, cond_shape, cond_stride, "bool", cond_ptr)
+    self_tensor, self_keep = _create_tensor(bindings, self_shape, self_stride, dtype, self_ptr)
+    other_tensor, other_keep = _create_tensor(bindings, other_shape, other_stride, dtype, other_ptr)
+    out_tensor, out_keep = _create_tensor(bindings, out_shape, out_stride, dtype, out_ptr)
+    executor = ctypes.c_void_p()
+    workspace_size = ctypes.c_uint64(0)
+    workspace = None
+    try:
+        ret = bindings.aclnn_swhere_get_workspace(
+            cond_tensor,
+            self_tensor,
+            other_tensor,
+            out_tensor,
+            ctypes.byref(workspace_size),
+            ctypes.byref(executor),
+        )
+        if ret != 0:
+            raise RuntimeError(f"aclnnSWhereGetWorkspaceSize failed: {ret}")
+        if workspace_size.value:
+            workspace_ptr, ret = acl.rt.malloc(int(workspace_size.value), 0)
+            if ret != 0:
+                raise RuntimeError(f"acl.rt.malloc failed: {ret}")
+            workspace = workspace_ptr
+        ret = bindings.aclnn_swhere(
+            ctypes.c_void_p(0 if workspace is None else int(workspace)),
+            ctypes.c_uint64(workspace_size.value),
+            executor,
+            ctypes.c_void_p(int(runtime.stream if stream is None else stream)),
+        )
+        if ret != 0:
+            raise RuntimeError(f"aclnnSWhere failed: {ret}")
+        _maybe_sync(runtime)
+    finally:
+        _defer_executor(executor)
+        bindings.acl_destroy_tensor(cond_tensor)
+        bindings.acl_destroy_tensor(self_tensor)
+        bindings.acl_destroy_tensor(other_tensor)
+        bindings.acl_destroy_tensor(out_tensor)
+        if workspace is not None:
+            runtime.defer_free(workspace)
+        _ = (cond_keep, self_keep, other_keep, out_keep)
+
 
 def logical_not(self_ptr, out_ptr, shape, stride, dtype, runtime, stream=None):
     global acl
@@ -2644,7 +3327,7 @@ def eq_tensor(self_ptr, other_ptr, out_ptr, self_shape, self_stride, other_shape
         raise RuntimeError("aclnnEqTensor symbols not available")
     self_tensor, self_keep = _create_tensor(bindings, self_shape, self_stride, dtype, self_ptr)
     other_tensor, other_keep = _create_tensor(bindings, other_shape, other_stride, dtype, other_ptr)
-    out_tensor, out_keep = _create_tensor(bindings, out_shape, out_stride, dtype, out_ptr)
+    out_tensor, out_keep = _create_tensor(bindings, out_shape, out_stride, "bool", out_ptr)
     executor = ctypes.c_void_p()
     workspace_size = ctypes.c_uint64(0)
     workspace = None
@@ -2691,7 +3374,7 @@ def ne_tensor(self_ptr, other_ptr, out_ptr, self_shape, self_stride, other_shape
         raise RuntimeError("aclnnNeTensor symbols not available")
     self_tensor, self_keep = _create_tensor(bindings, self_shape, self_stride, dtype, self_ptr)
     other_tensor, other_keep = _create_tensor(bindings, other_shape, other_stride, dtype, other_ptr)
-    out_tensor, out_keep = _create_tensor(bindings, out_shape, out_stride, dtype, out_ptr)
+    out_tensor, out_keep = _create_tensor(bindings, out_shape, out_stride, "bool", out_ptr)
     executor = ctypes.c_void_p()
     workspace_size = ctypes.c_uint64(0)
     workspace = None

--- a/src/mindtorch_v2/npu.py
+++ b/src/mindtorch_v2/npu.py
@@ -222,12 +222,7 @@ def _reset_init_for_test():
 
 
 def _get_memory_stats(device=None):
-    try:
-        import mindspore
-
-        return mindspore.hal.memory_stats()
-    except Exception:
-        return {}
+    return {}
 
 
 def _enforce_memory_fraction(requested_bytes, device=None):

--- a/tests/mindtorch_v2/test_ops_npu.py
+++ b/tests/mindtorch_v2/test_ops_npu.py
@@ -252,8 +252,64 @@ def test_npu_pow(dtype):
         rtol=1e-3,
     )
 
-    scalar_out = torch.pow(base, 2.0)
-    scalar_expected = np.power(base.to("cpu").numpy(), 2.0)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float32])
+def test_npu_elementwise_batch2(dtype):
+    if not torch.npu.is_available():
+        pytest.skip("NPU not available")
+    base = np.array([-2.0, -0.5, 0.5, 2.0], dtype=np.float32)
+    x = torch.tensor(base, device="npu", dtype=dtype)
+    y = torch.tensor(base[::-1], device="npu", dtype=dtype)
+
+    expected_asin = np.arcsin(base).astype(np.float32)
+    expected_acos = np.arccos(base).astype(np.float32)
+    out_asin = torch.asin(x).to("cpu").numpy().astype(np.float32)
+    out_acos = torch.acos(x).to("cpu").numpy().astype(np.float32)
+    if dtype == torch.float16:
+        valid = np.abs(base) <= 1.0
+        assert np.allclose(out_asin[valid], expected_asin[valid], atol=1e-3, rtol=1e-3)
+        assert np.allclose(out_acos[valid], expected_acos[valid], atol=1e-3, rtol=1e-3)
+    else:
+        assert np.allclose(out_asin, expected_asin, atol=1e-3, rtol=1e-3, equal_nan=True)
+        assert np.allclose(out_acos, expected_acos, atol=1e-3, rtol=1e-3, equal_nan=True)
+    assert np.allclose(torch.atan(x).to("cpu").numpy(), np.arctan(base).astype(np.float32), atol=1e-3, rtol=1e-3)
+    assert np.allclose(torch.atan2(x, y).to("cpu").numpy(), np.arctan2(base, base[::-1]).astype(np.float32), atol=1e-3, rtol=1e-3)
+    assert np.allclose(torch.asinh(x).to("cpu").numpy(), np.arcsinh(base).astype(np.float32), atol=1e-3, rtol=1e-3)
+    assert np.allclose(torch.acosh(torch.abs(x) + 1.5).to("cpu").numpy(), np.arccosh(np.abs(base) + 1.5).astype(np.float32), atol=1e-3, rtol=1e-3)
+    assert np.allclose(torch.atanh(x * 0.25).to("cpu").numpy(), np.arctanh(base * 0.25).astype(np.float32), atol=1e-3, rtol=1e-3)
+
+    assert np.allclose(torch.addcmul(x, x, y).to("cpu").numpy(), (base + base * base[::-1]).astype(np.float32), atol=1e-3, rtol=1e-3)
+    assert np.allclose(torch.addcdiv(x, x, y).to("cpu").numpy(), (base + base / base[::-1]).astype(np.float32), atol=1e-3, rtol=1e-3)
+
+    assert np.allclose(torch.logaddexp(x, y).to("cpu").numpy(), np.logaddexp(base, base[::-1]).astype(np.float32), atol=1e-3, rtol=1e-3)
+    assert np.allclose(torch.logaddexp2(x, y).to("cpu").numpy(), np.logaddexp2(base, base[::-1]).astype(np.float32), atol=1e-3, rtol=1e-3)
+    assert np.allclose(torch.hypot(x, y).to("cpu").numpy(), np.hypot(base, base[::-1]).astype(np.float32), atol=1e-3, rtol=1e-3)
+
+    assert np.allclose(torch.remainder(x, y).to("cpu").numpy(), np.remainder(base, base[::-1]).astype(np.float32), atol=1e-3, rtol=1e-3)
+    assert np.allclose(torch.fmod(x, y).to("cpu").numpy(), np.fmod(base, base[::-1]).astype(np.float32), atol=1e-3, rtol=1e-3)
+
+    assert np.allclose(torch.fmin(x, y).to("cpu").numpy(), np.fmin(base, base[::-1]).astype(np.float32), atol=1e-3, rtol=1e-3)
+    assert np.allclose(torch.fmax(x, y).to("cpu").numpy(), np.fmax(base, base[::-1]).astype(np.float32), atol=1e-3, rtol=1e-3)
+    assert np.allclose(torch.min(x, y).to("cpu").numpy(), np.minimum(base, base[::-1]).astype(np.float32), atol=1e-3, rtol=1e-3)
+    assert np.allclose(torch.max(x, y).to("cpu").numpy(), np.maximum(base, base[::-1]).astype(np.float32), atol=1e-3, rtol=1e-3)
+
+    where_cond = torch.tensor([True, False, True, False], device="npu")
+    where_out = torch.where(where_cond, x, y)
+    expected_where = np.where(np.array([True, False, True, False]), base, base[::-1]).astype(np.float32)
+    assert np.allclose(where_out.to("cpu").numpy().astype(np.float32), expected_where, atol=1e-3, rtol=1e-3)
+
+    lerp_out = torch.lerp(x, y, 0.25).to("cpu").numpy()
+    expected_lerp = (base + 0.25 * (base[::-1] - base)).astype(np.float32)
+    assert np.allclose(lerp_out, expected_lerp, atol=1e-3, rtol=1e-3)
+
+    assert torch.allclose(x, y) == np.allclose(base, base[::-1])
+    isclose_out = torch.isclose(x, y).to("cpu").numpy()
+    assert np.all(isclose_out == np.isclose(base, base[::-1]))
+    assert torch.equal(x, y) == np.array_equal(base, base[::-1])
+
+
+    scalar_base = torch.tensor(base, device="npu", dtype=dtype)
+    scalar_out = torch.pow(scalar_base, 2.0)
+    scalar_expected = np.power(base, 2.0)
     assert np.allclose(
         scalar_out.to("cpu").numpy().astype(np.float32),
         scalar_expected.astype(np.float32),


### PR DESCRIPTION
## Summary
- add/extend NPU elementwise ops (trig, min/max, addc*, logaddexp, hypot, remainder/fmod, where/lerp, allclose/isclose/equal)
- fix aclnn output dtypes for NPU elementwise bindings
- remove mindspore dependency from mindtorch_v2 NPU memory stats
- update NPU tests for new ops and float16 domain checks

## Testing
- PYTHONPATH=src pytest tests/mindtorch_v2 -vv