### PR TITLE
feat: enforce inplace checks in dispatch

### DIFF
--- a/tests/mindtorch_v2/contract/test_inplace_view_rules.py
+++ b/tests/mindtorch_v2/contract/test_inplace_view_rules.py
@@ -20,3 +20,24 @@ def test_inplace_on_view_of_leaf_errors():
         match=r"a view of a leaf Variable that requires grad is being used in an in-place operation.",
     ):
         v.add_(v)
+
+
+def test_dispatch_inplace_checks_leaf():
+    x = torch.ones((2, 2)).requires_grad_()
+    from mindtorch_v2._dispatch.dispatcher import dispatch
+    with pytest.raises(
+        RuntimeError,
+        match=r"a leaf Variable that requires grad is being used in an in-place operation.",
+    ):
+        dispatch("add_", x.device.type, x, x)
+
+
+def test_dispatch_inplace_checks_view_of_leaf():
+    x = torch.ones((2, 2)).requires_grad_()
+    v = x.view((4,))
+    from mindtorch_v2._dispatch.dispatcher import dispatch
+    with pytest.raises(
+        RuntimeError,
+        match=r"a view of a leaf Variable that requires grad is being used in an in-place operation.",
+    ):
+        dispatch("add_", v.device.type, v, v)


### PR DESCRIPTION
## Summary
- enforce inplace/view safety checks in dispatch for all mutating ops
- add dispatch-level inplace rule tests

## Testing
- pytest -q tests/mindtorch_v2/contract/test_inplace_view_rules.py -k dispatch_inplace_checks
- pytest -q tests/mindtorch_v2/contract/test_inplace_view_rules.py