### PR TITLE
feat(mindtorch_v2): align grad mode TLS and functionalize alias semantics

### DIFF
--- a/src/mindtorch_v2/_autograd/grad_mode.py
+++ b/src/mindtorch_v2/_autograd/grad_mode.py
@@ -1,37 +1,60 @@
+import threading
+
+
+_GRAD_MODE_STATE = threading.local()
+
+
+def _get_enabled():
+    return getattr(_GRAD_MODE_STATE, "enabled", True)
+
+
+def _set_enabled(mode):
+    _GRAD_MODE_STATE.enabled = bool(mode)
+
+
 class GradMode:
-    enabled = True
+    @property
+    def enabled(self):
+        return _get_enabled()
+
+    @enabled.setter
+    def enabled(self, mode):
+        _set_enabled(mode)
+
+
+GradMode = GradMode()
 
 
 def is_grad_enabled():
-    return GradMode.enabled
+    return _get_enabled()
 
 
 class set_grad_enabled:
     def __init__(self, mode):
         self.mode = bool(mode)
-        self._prev = GradMode.enabled
-        GradMode.enabled = self.mode
+        self._prev = _get_enabled()
+        _set_enabled(self.mode)
 
     def __enter__(self):
         return self
 
     def __exit__(self, exc_type, exc, tb):
-        GradMode.enabled = self._prev
+        _set_enabled(self._prev)
 
 
 class no_grad:
     def __enter__(self):
-        self._prev = GradMode.enabled
-        GradMode.enabled = False
+        self._prev = _get_enabled()
+        _set_enabled(False)
 
     def __exit__(self, exc_type, exc, tb):
-        GradMode.enabled = self._prev
+        _set_enabled(self._prev)
 
 
 class enable_grad:
     def __enter__(self):
-        self._prev = GradMode.enabled
-        GradMode.enabled = True
+        self._prev = _get_enabled()
+        _set_enabled(True)
 
     def __exit__(self, exc_type, exc, tb):
-        GradMode.enabled = self._prev
+        _set_enabled(self._prev)

--- a/src/mindtorch_v2/_dispatch/dispatcher.py
+++ b/src/mindtorch_v2/_dispatch/dispatcher.py
@@ -85,6 +85,8 @@ def _mutating_args(schema_obj, args, kwargs):
     for param in params:
         if not param.mutates:
             continue
+        if getattr(param, "alias_set", None) in (None, ""):
+            continue
         if param.name in bound:
             mutated.append(bound[param.name])
     return mutated

--- a/src/mindtorch_v2/_dispatch/schema.py
+++ b/src/mindtorch_v2/_dispatch/schema.py
@@ -1,10 +1,11 @@
 class SchemaParam:
-    def __init__(self, name, *, kw_only=False, default=None, has_default=False, mutates=False):
+    def __init__(self, name, *, kw_only=False, default=None, has_default=False, mutates=False, alias_set=None):
         self.name = name
         self.kw_only = kw_only
         self.default = default
         self.has_default = has_default
         self.mutates = mutates
+        self.alias_set = alias_set
 
 
 def _torch_param_name(name):
@@ -114,7 +115,21 @@ def _parse_schema(schema):
         name = parts[-1]
         type_part = " ".join(parts[:-1])
         mutates = "!" in type_part
+        alias_set = None
+        start = type_part.find("(")
+        end = type_part.find(")", start + 1) if start != -1 else -1
+        if start != -1 and end != -1:
+            alias_part = type_part[start + 1:end].replace("!", "").strip()
+            if alias_part:
+                alias_set = alias_part
         parsed.append(
-            SchemaParam(name, kw_only=kw_only, default=default, has_default=has_default, mutates=mutates)
+            SchemaParam(
+                name,
+                kw_only=kw_only,
+                default=default,
+                has_default=has_default,
+                mutates=mutates,
+                alias_set=alias_set,
+            )
         )
     return name.strip(), parsed

--- a/tests/mindtorch_v2/contract/test_functionalize_multi_mutation.py
+++ b/tests/mindtorch_v2/contract/test_functionalize_multi_mutation.py
@@ -24,3 +24,59 @@ def test_functionalize_writes_back_all_mutations():
 
     assert a.storage().data.tolist() == [2.0]
     assert b.storage().data.tolist() == [1.0]
+
+
+def test_functionalize_multi_mutation_dedup_version_bump():
+    registry.register_schema("alias_pair", "alias_pair(Tensor x, Tensor y) -> (Tensor, Tensor)")
+    registry.register_schema(
+        "alias_pair_",
+        "alias_pair_(Tensor(a!) x, Tensor(a!) y) -> (Tensor, Tensor)",
+    )
+
+    def alias_pair_kernel(x, y):
+        out_x = torch.tensor(x._numpy_view().copy() + 1.0, device=x.device)
+        out_y = torch.tensor(y._numpy_view().copy() + 2.0, device=y.device)
+        return out_x, out_y
+
+    registry.register_kernel("alias_pair", DispatchKey.CPU, alias_pair_kernel)
+    registry.register_kernel("alias_pair_", DispatchKey.CPU, alias_pair_kernel)
+
+    x = torch.tensor([1.0])
+    v0 = x._version_counter.value
+
+    with torch.functionalize():
+        dispatch("alias_pair_", x.device.type, x, x)
+
+    assert x.storage().data.tolist() == [3.0]
+    assert x._version_counter.value == v0 + 1
+
+
+def test_functionalize_mutating_args_require_alias_set():
+    from mindtorch_v2._dispatch.functionalize import _mutating_args
+    from mindtorch_v2._dispatch.schema import OpSchema
+
+    schema = OpSchema("foo_(Tensor(a!) x, Tensor(!) y, Tensor z) -> Tensor")
+    mutated = _mutating_args(schema, (1, 2, 3), {})
+    assert mutated == [1]
+
+
+def test_dispatch_functionalize_ignores_mutation_without_alias_set():
+    registry.register_schema("noalias", "noalias(Tensor x) -> Tensor")
+    registry.register_schema("noalias_", "noalias_(Tensor(!) x) -> Tensor")
+
+    def noalias_kernel(x):
+        return torch.tensor(x._numpy_view().copy() + 1.0, device=x.device)
+
+    registry.register_kernel("noalias", DispatchKey.CPU, noalias_kernel)
+    registry.register_kernel("noalias_", DispatchKey.CPU, noalias_kernel)
+
+    x = torch.tensor([1.0])
+    v0 = x._version_counter.value
+
+    with torch.functionalize():
+        out = dispatch("noalias_", x.device.type, x)
+
+    # no alias-set on mutating arg: functionalize should not write back to input
+    assert x.storage().data.tolist() == [1.0]
+    assert x._version_counter.value == v0
+    assert out.storage().data.tolist() == [2.0]

--- a/tests/mindtorch_v2/test_grad_mode_tls.py
+++ b/tests/mindtorch_v2/test_grad_mode_tls.py
@@ -1,0 +1,45 @@
+import threading
+
+import mindtorch_v2 as torch
+
+
+def test_no_grad_is_thread_local():
+    parent_states = []
+    child_states = []
+
+    with torch.no_grad():
+        parent_states.append(torch.is_grad_enabled())
+
+        def _worker():
+            child_states.append(torch.is_grad_enabled())
+            with torch.no_grad():
+                child_states.append(torch.is_grad_enabled())
+            child_states.append(torch.is_grad_enabled())
+
+        t = threading.Thread(target=_worker)
+        t.start()
+        t.join()
+
+        parent_states.append(torch.is_grad_enabled())
+
+    assert parent_states == [False, False]
+    assert child_states == [True, False, True]
+
+
+def test_set_grad_enabled_is_thread_local():
+    observed = []
+
+    def _worker():
+        observed.append(torch.is_grad_enabled())
+        with torch.set_grad_enabled(False):
+            observed.append(torch.is_grad_enabled())
+        observed.append(torch.is_grad_enabled())
+
+    with torch.set_grad_enabled(False):
+        assert torch.is_grad_enabled() is False
+        t = threading.Thread(target=_worker)
+        t.start()
+        t.join()
+        assert torch.is_grad_enabled() is False
+
+    assert observed == [True, False, True]


### PR DESCRIPTION
## Summary
- make autograd grad mode state thread-local to align with torch thread semantics
- parse schema alias sets and use alias-gated mutation targets in dispatcher and functionalize
- deduplicate functionalize writeback version bumps for repeated alias targets
- add contract coverage for grad mode TLS and dispatch/functionalize alias interactions

## Testing
- source /home/lvyufeng/miniconda3/bin/activate mindspore && pytest -q tests/mindtorch_v2/contract/test_functionalize_multi_mutation.py tests/mindtorch_v2/contract/test_functionalize_view_writeback.py tests/mindtorch_v2/contract/test_inplace_view_rules.py tests/mindtorch_v2/test_grad_mode_tls.py