### PR TITLE
[mindtorch_v2] functionalize writeback maps by schema return alias

### DIFF
--- a/tests/mindtorch_v2/contract/test_schema_return_alias.py
+++ b/tests/mindtorch_v2/contract/test_schema_return_alias.py
@@ -1,0 +1,13 @@
+from mindtorch_v2._dispatch.schema import OpSchema
+
+
+def test_schema_parses_single_return_alias_set():
+    schema = OpSchema("foo(Tensor x) -> Tensor(a)")
+    assert schema.returns[0].alias_set == "a"
+
+
+def test_schema_parses_tuple_return_alias_set():
+    schema = OpSchema("foo(Tensor x) -> (Tensor(a), Tensor(b), Tensor)")
+    assert schema.returns[0].alias_set == "a"
+    assert schema.returns[1].alias_set == "b"
+    assert schema.returns[2].alias_set is None


### PR DESCRIPTION
## Summary

- add schema return alias parsing via `SchemaReturn` and `OpSchema.returns`
- use functional schema return alias sets to map functionalize writeback targets
- keep positional writeback fallback when return alias metadata is absent
- preserve deduplicated version bump semantics for shared mutation targets
- add contract tests for return alias parsing and alias-based writeback routing

## Root Cause

Functionalize multi-mutation writeback previously matched outputs to mutated inputs by positional zip.
When functional output ordering differs from mutating input ordering, writeback targets are incorrect.

## Changes

- `src/mindtorch_v2/_dispatch/schema.py`
  - parse return signature and extract alias sets
  - expose `OpSchema.returns` for downstream dispatch logic
- `src/mindtorch_v2/_dispatch/functionalize.py`
  - add alias-aware writeback pair resolution
  - route each functional output to mutation target by alias set first
  - fallback to positional mapping for unmatched/no-alias returns
- `tests/mindtorch_v2/contract/test_schema_return_alias.py`
  - cover single and tuple return alias parsing
- `tests/mindtorch_v2/contract/test_functionalize_multi_mutation.py`
  - cover alias-based writeback target routing for multi-mutation functionalize

## Verification

- `PYTHONPATH=src pytest -q tests/mindtorch_v2/contract/test_functionalize_multi_mutation.py -k maps_writeback_by_return_alias_set`
- `PYTHONPATH=src pytest -q tests/mindtorch_v2/contract/test_schema_return_alias.py tests/mindtorch_v2/contract/test_functionalize_multi_mutation.py tests/mindtorch_v2/contract/test_functionalize_view_writeback.py tests/mindtorch_v2/contract/test_inplace_view_rules.py`
