### PR TITLE
[mindtorch_v2] align ADInplaceOrView dispatch key path

### DIFF
--- a/src/mindtorch_v2/_dispatch/dispatcher.py
+++ b/src/mindtorch_v2/_dispatch/dispatcher.py
@@ -280,7 +280,8 @@ def dispatch_with_keyset(name, keyset, dispatch_device, *args, **kwargs):
 
     if entry.schema_obj is not None:
         entry.schema_obj.bind(args, kwargs, op_name=alias_name, error_overrides=entry.error_overrides)
-        _check_inplace_targets(entry.schema_obj, args, kwargs)
+        if keyset.has(DispatchKey.ADInplaceOrView):
+            _check_inplace_targets(entry.schema_obj, args, kwargs)
 
     if keyset.has(DispatchKey.Functionalize) and should_functionalize(entry):
         if pipe is not None and keyset.has(DispatchKey.Pipeline):

--- a/src/mindtorch_v2/_dispatch/keys.py
+++ b/src/mindtorch_v2/_dispatch/keys.py
@@ -208,6 +208,7 @@ class DispatchKeySet:
         else:
             mask |= int(DispatchKey.CPU)
         if grad_enabled and requires_grad:
+            mask |= int(DispatchKey.ADInplaceOrView)
             mask |= int(DispatchKey.Autograd)
             if has_meta:
                 mask |= int(DispatchKey.AutogradMeta)

--- a/tests/mindtorch_v2/contract/test_dispatch_keyset_construction.py
+++ b/tests/mindtorch_v2/contract/test_dispatch_keyset_construction.py
@@ -39,3 +39,9 @@ def test_keyset_includes_autograd_npu_when_grad_enabled():
     keyset = DispatchKeySet.from_tensors((t,), grad_enabled=True)
     assert DispatchKey.Autograd in keyset
     assert DispatchKey.AutogradNPU in keyset
+
+
+def test_keyset_includes_adinplaceorview_when_grad_enabled():
+    t = torch.ones((2,)).requires_grad_()
+    keyset = DispatchKeySet.from_tensors((t,), grad_enabled=True)
+    assert DispatchKey.ADInplaceOrView in keyset


### PR DESCRIPTION
## Summary

- include `DispatchKey.ADInplaceOrView` in keyset construction for grad-enabled tensors
- gate inplace/view safety checks in dispatcher by `ADInplaceOrView` key presence
- add contract test to lock ADInplaceOrView keyset behavior

## Why

To align with torch dispatch semantics, inplace/view autograd safety should be modeled as a dispatch-key concern rather than an unconditional side check on every op.

## Changes

- `src/mindtorch_v2/_dispatch/keys.py`
  - when `grad_enabled` and any input requires grad, keyset now includes `ADInplaceOrView`
- `src/mindtorch_v2/_dispatch/dispatcher.py`
  - `_check_inplace_targets(...)` now runs only when `keyset.has(DispatchKey.ADInplaceOrView)`
- `tests/mindtorch_v2/contract/test_dispatch_keyset_construction.py`
  - add `test_keyset_includes_adinplaceorview_when_grad_enabled`

## Verification

- `PYTHONPATH=src pytest -q tests/mindtorch_v2/contract/test_dispatch_keyset_construction.py tests/mindtorch_v2/contract/test_inplace_view_rules.py tests/mindtorch_v2/test_autograd_inplace.py`
- `PYTHONPATH=src pytest -q tests/mindtorch_v2/contract/test_dispatch_key_order.py tests/mindtorch_v2/contract/test_dispatch_keyset.py tests/mindtorch_v2/contract/test_dispatch_fallthrough.py tests/mindtorch_v2/contract/test_dispatch_pipeline_priority.py tests/mindtorch_v2/contract/test_backend_select.py tests/mindtorch_v2/contract/test_dispatch_keyset_construction.py tests/mindtorch_v2/test_dispatch_keys.py tests/mindtorch_v2/test_dispatch_redispatch.py tests/mindtorch_v2/test_dispatch_autograd_wrappers.py tests/mindtorch_v2/contract/test_inplace_view_rules.py tests/mindtorch_v2/test_autograd_inplace.py`
