### PR TITLE
[mindtorch_v2] align backend-specific autograd dispatch semantics

### DIFF
--- a/src/mindtorch_v2/_dispatch/dispatcher.py
+++ b/src/mindtorch_v2/_dispatch/dispatcher.py
@@ -213,12 +213,12 @@ def _kernel_for_entry(entry, key_order):
     for key in key_order:
         if key in entry.fallthrough:
             continue
-        global_fallthrough = getattr(registry, "_global_fallthrough", set())
-        if key in global_fallthrough:
-            continue
         kernel = entry.kernels.get(key)
         if kernel is not None:
             return kernel, key
+        global_fallthrough = getattr(registry, "_global_fallthrough", set())
+        if key in global_fallthrough:
+            continue
     return None, None
 
 

--- a/tests/mindtorch_v2/test_dispatch_redispatch.py
+++ b/tests/mindtorch_v2/test_dispatch_redispatch.py
@@ -15,3 +15,74 @@ def test_redispatch_drops_autograd_key():
     registry.register_kernel("test_redispatch", DispatchKey.Autograd, autograd_impl)
     out = dispatch("test_redispatch", "cpu", "x")
     assert out == "cpu:x"
+
+
+
+def test_redispatch_drops_backend_specific_autograd_key():
+    def cpu_impl(a):
+        return f"cpu:{a}"
+
+    def autograd_cpu_impl(a):
+        keyset = current_dispatch_keyset().without({DispatchKey.Autograd, DispatchKey.AutogradCPU})
+        return redispatch("test_redispatch_backend", keyset, a)
+
+    registry.register_kernel("test_redispatch_backend", DispatchKey.CPU, cpu_impl)
+    registry.register_kernel("test_redispatch_backend", DispatchKey.AutogradCPU, autograd_cpu_impl)
+
+    out = dispatch("test_redispatch_backend", "cpu", "x")
+    assert out == "cpu:x"
+
+
+
+def test_dispatch_prefers_backend_specific_autograd_key_over_generic():
+    import mindtorch_v2 as torch
+
+    calls = []
+
+    def cpu_impl(a):
+        calls.append("cpu")
+        return a
+
+    def autograd_impl(a):
+        calls.append("autograd")
+        keyset = current_dispatch_keyset().without(DispatchKey.Autograd)
+        return redispatch("test_autograd_key_priority", keyset, a)
+
+    def autograd_cpu_impl(a):
+        calls.append("autograd_cpu")
+        keyset = current_dispatch_keyset().without({DispatchKey.Autograd, DispatchKey.AutogradCPU})
+        return redispatch("test_autograd_key_priority", keyset, a)
+
+    registry.register_kernel("test_autograd_key_priority", DispatchKey.CPU, cpu_impl)
+    registry.register_kernel("test_autograd_key_priority", DispatchKey.Autograd, autograd_impl)
+    registry.register_kernel("test_autograd_key_priority", DispatchKey.AutogradCPU, autograd_cpu_impl)
+
+    x = torch.ones((1,))
+    x.requires_grad = True
+    dispatch("test_autograd_key_priority", x.device.type, x)
+
+    assert calls == ["autograd_cpu", "cpu"]
+
+
+def test_dispatch_falls_back_to_generic_autograd_when_backend_missing():
+    import mindtorch_v2 as torch
+
+    calls = []
+
+    def cpu_impl(a):
+        calls.append("cpu")
+        return a
+
+    def autograd_impl(a):
+        calls.append("autograd")
+        keyset = current_dispatch_keyset().without(DispatchKey.Autograd)
+        return redispatch("test_autograd_key_fallback", keyset, a)
+
+    registry.register_kernel("test_autograd_key_fallback", DispatchKey.CPU, cpu_impl)
+    registry.register_kernel("test_autograd_key_fallback", DispatchKey.Autograd, autograd_impl)
+
+    x = torch.ones((1,))
+    x.requires_grad = True
+    dispatch("test_autograd_key_fallback", x.device.type, x)
+
+    assert calls == ["autograd", "cpu"]

--- a/tests/mindtorch_v2/test_dispatch_registry.py
+++ b/tests/mindtorch_v2/test_dispatch_registry.py
@@ -7,3 +7,11 @@ def test_backend_registration_uses_keys():
     assert DispatchKey.CPU in entry.kernels
     assert DispatchKey.NPU in entry.kernels
     assert DispatchKey.Meta in entry.kernels
+
+
+
+def test_autograd_backend_key_registration_prefers_device_keys():
+    entry = registry.get("aten::add")
+    assert DispatchKey.AutogradCPU in entry.kernels
+    assert DispatchKey.AutogradNPU in entry.kernels
+    assert DispatchKey.AutogradMeta in entry.kernels


### PR DESCRIPTION
## Summary

- align autograd dispatch with backend-specific autograd keys (`AutogradCPU/NPU/Meta`) while keeping generic `Autograd` fallback
- ensure autograd wrappers redispatch after stripping all autograd keys (generic + backend-specific)
- fix dispatcher kernel resolution so explicit kernels override global fallthrough placeholders
- add tests for backend-specific autograd registration and key-priority/fallback behavior

## Root Cause

Two mechanism gaps prevented torch-like dispatch behavior:

1. Autograd wrappers only removed `Autograd` during redispatch, leaving backend-specific autograd keys unhandled for future routing expansion.
2. Dispatcher checked global fallthrough before explicit kernels, so keys like `AutogradCPU` could not intercept even when a kernel was registered.

## Changes

- `src/mindtorch_v2/_backends/autograd.py`
  - add `_strip_autograd_keys(...)` to remove `Autograd` + `AutogradOther/CPU/NPU/XPU/Meta`
  - update all autograd wrappers to use `_strip_autograd_keys(current_dispatch_keyset())`
  - register backend-specific autograd kernels alongside existing generic autograd kernels
- `src/mindtorch_v2/_dispatch/dispatcher.py`
  - in `_kernel_for_entry(...)`, prefer explicit `entry.kernels[key]` before checking global fallthrough
- `tests/mindtorch_v2/test_dispatch_registry.py`
  - verify backend-specific autograd keys are registered for core op `aten::add`
- `tests/mindtorch_v2/test_dispatch_redispatch.py`
  - verify backend-specific autograd redispatch key stripping
  - verify priority: backend-specific autograd key is chosen before generic autograd
  - verify fallback: generic autograd is used when backend-specific autograd kernel is absent

## Verification

- `PYTHONPATH=src pytest -q tests/mindtorch_v2/test_dispatch_redispatch.py tests/mindtorch_v2/test_dispatch_registry.py`
- `PYTHONPATH=src pytest -q tests/mindtorch_v2/contract/test_dispatch_key_order.py tests/mindtorch_v2/contract/test_dispatch_keyset.py tests/mindtorch_v2/contract/test_dispatch_fallthrough.py tests/mindtorch_v2/contract/test_dispatch_pipeline_priority.py tests/mindtorch_v2/contract/test_backend_select.py tests/mindtorch_v2/contract/test_dispatch_keyset_construction.py tests/mindtorch_v2/contract/test_inplace_view_rules.py tests/mindtorch_v2/test_dispatch_keys.py tests/mindtorch_v2/test_dispatch_registry.py tests/mindtorch_v2/test_dispatch_redispatch.py tests/mindtorch_v2/test_dispatch_autograd_wrappers.py tests/mindtorch_v2/test_autograd_inplace.py`
