### PR TITLE
[mindtorch_v2] align view-like schema alias semantics

### DIFF
--- a/src/mindtorch_v2/_dispatch/schemas.py
+++ b/src/mindtorch_v2/_dispatch/schemas.py
@@ -20,21 +20,21 @@ def register_schemas():
             "unexpected": "{name}() received an invalid combination of arguments - got {got}, but expected one of:\n * (Tensor input, *, torch.dtype dtype = None)\n * (Tensor input, tuple of ints dim, bool keepdim = False, *, torch.dtype dtype = None, Tensor out = None)\n * (Tensor input, tuple of names dim, bool keepdim = False, *, torch.dtype dtype = None, Tensor out = None)\n",
         },
     )
-    registry.register_schema("reshape", "reshape(Tensor input, int[] shape) -> Tensor")
+    registry.register_schema("reshape", "reshape(Tensor(a) input, int[] shape) -> Tensor(a)")
     registry.register_error_overrides(
         "reshape",
         {
             "missing": '{name}() missing 2 required positional argument: "input", "shape"',
         },
     )
-    registry.register_schema("view", "view(Tensor input, int[] shape) -> Tensor")
+    registry.register_schema("view", "view(Tensor(a) input, int[] shape) -> Tensor(a)")
     registry.register_error_overrides(
         "view",
         {
             "missing": "{name}() received an invalid combination of arguments - got {got}, but expected one of:\n * (torch.dtype dtype)\n * (tuple of ints size)\n",
         },
     )
-    registry.register_schema("transpose", "transpose(Tensor input, int dim0, int dim1) -> Tensor")
+    registry.register_schema("transpose", "transpose(Tensor(a) input, int dim0, int dim1) -> Tensor(a)")
     registry.register_error_overrides(
         "transpose",
         {

--- a/tests/mindtorch_v2/contract/test_schema_view_alias.py
+++ b/tests/mindtorch_v2/contract/test_schema_view_alias.py
@@ -1,0 +1,16 @@
+from mindtorch_v2._dispatch.registry import registry
+from mindtorch_v2._dispatch.schema import OpSchema
+
+
+def test_schema_parses_view_alias_on_input_and_return():
+    schema = OpSchema("view(Tensor(a) input, int[] shape) -> Tensor(a)")
+    assert schema.params[0].alias_set == "a"
+    assert schema.returns[0].alias_set == "a"
+
+
+def test_core_view_like_schemas_expose_alias_sets():
+    for name in ("view", "reshape", "transpose"):
+        entry = registry.get(f"aten::{name}")
+        assert entry.schema_obj is not None
+        assert entry.schema_obj.params[0].alias_set == "a"
+        assert entry.schema_obj.returns[0].alias_set == "a"


### PR DESCRIPTION
## Summary

- align core view-like schemas with torch alias annotations (`Tensor(a) -> Tensor(a)`)
- add contract tests to lock input/return alias parsing and registry exposure for `view/reshape/transpose`

## Why

Torch marks view-like ops as alias-preserving in schema. This alias metadata is foundational for dispatcher-level view semantics and future functionalize/autograd rules.

## Changes

- `src/mindtorch_v2/_dispatch/schemas.py`
  - `reshape`: `reshape(Tensor(a) input, int[] shape) -> Tensor(a)`
  - `view`: `view(Tensor(a) input, int[] shape) -> Tensor(a)`
  - `transpose`: `transpose(Tensor(a) input, int dim0, int dim1) -> Tensor(a)`
- `tests/mindtorch_v2/contract/test_schema_view_alias.py`
  - verify parser captures alias set for input and return
  - verify registered core schemas expose alias sets via `registry`

## Verification

- `PYTHONPATH=src pytest -q tests/mindtorch_v2/contract/test_schema_view_alias.py tests/mindtorch_v2/contract/test_schema_return_alias.py tests/mindtorch_v2/contract/test_inplace_view_rules.py tests/mindtorch_v2/contract/test_functionalize.py tests/mindtorch_v2/contract/test_functionalize_multi_mutation.py tests/mindtorch_v2/contract/test_functionalize_view_writeback.py tests/mindtorch_v2/test_dispatch_autograd_wrappers.py tests/mindtorch_v2/test_dispatch_redispatch.py tests/mindtorch_v2/test_dispatch_registry.py tests/mindtorch_v2/test_autograd_inplace.py -k "not inplace_npu_versioning"`

## Note

A pre-existing, unrelated NPU segfault was observed in `test_inplace_npu_versioning` (`aclnn.relu` path). It is not introduced by this schema-only change.
