### PR TITLE
[mindtorch_v2] align functionalize pipeline alias writeback semantics

### DIFF
--- a/tests/mindtorch_v2/contract/test_functionalize_pipeline.py
+++ b/tests/mindtorch_v2/contract/test_functionalize_pipeline.py
@@ -1,3 +1,4 @@
+import numpy as np
 import mindtorch_v2 as torch
 
 
@@ -9,3 +10,69 @@ def test_pipeline_records_functionalized_inplace():
             out = a.add_(b)
             assert out._pending is True
     assert out._pending is False
+
+
+
+def test_pipeline_functionalize_inplace_returns_self_and_writebacks():
+    a = torch.tensor([1.0, 2.0])
+    b = torch.tensor([3.0, 4.0])
+    with torch.functionalize():
+        with torch.pipeline():
+            out = a.add_(b)
+            assert out is a
+            assert out._pending is True
+    assert out._pending is False
+    assert a.storage().data.tolist() == [4.0, 6.0]
+
+
+def test_pipeline_functionalize_multi_mutation_uses_return_alias_mapping():
+    from mindtorch_v2._dispatch.dispatcher import dispatch
+    from mindtorch_v2._dispatch.keys import DispatchKey
+    from mindtorch_v2._dispatch.registry import registry
+
+    registry.register_schema(
+        "swap_alias",
+        "swap_alias(Tensor a, Tensor b) -> (Tensor(b), Tensor(a))",
+    )
+    registry.register_schema(
+        "swap_alias_",
+        "swap_alias_(Tensor(a!) a, Tensor(b!) b) -> Tensor",
+    )
+
+    def _raw_cpu_tensor(values, ref):
+        from mindtorch_v2._storage import typed_storage_from_numpy
+        from mindtorch_v2._tensor import Tensor
+
+        arr = np.array(values, dtype=np.float32)
+        storage = typed_storage_from_numpy(arr, ref.dtype, device=ref.device)
+        stride = tuple(np.array(arr.strides) // arr.itemsize)
+        return Tensor(storage, arr.shape, stride)
+
+    def swap_alias_kernel(a, b):
+        # Build outputs without calling high-level dispatch to avoid nested pipeline enqueue.
+        out_for_b = _raw_cpu_tensor([10.0], a)
+        out_for_a = _raw_cpu_tensor([20.0], a)
+        return out_for_b, out_for_a
+
+    registry.register_kernel("swap_alias", DispatchKey.CPU, swap_alias_kernel)
+    registry.register_kernel("swap_alias_", DispatchKey.CPU, swap_alias_kernel)
+
+    from mindtorch_v2._backends.meta.infer import infer_binary
+
+    def swap_alias_meta(a, b):
+        return infer_binary(a, b)
+
+    registry.register_kernel("swap_alias_", DispatchKey.Meta, swap_alias_meta)
+
+    a = torch.tensor([1.0])
+    b = torch.tensor([2.0])
+
+    with torch.functionalize():
+        with torch.pipeline():
+            out = dispatch("swap_alias_", a.device.type, a, b)
+            assert out is a
+            assert out._pending is True
+
+    assert out._pending is False
+    assert a.storage().data.tolist() == [20.0]
+    assert b.storage().data.tolist() == [10.0]


### PR DESCRIPTION
## Summary

- align functionalize+pipeline semantics with non-pipeline functionalize writeback behavior
- make inplace functionalize ops in pipeline return the mutated target tensor (`self`) rather than a detached pending placeholder
- reuse alias-based writeback mapping (`return alias -> mutating input alias`) during pipeline flush

## Root Cause

Pipeline functionalize path diverged from non-pipeline path:

1. It always produced a standalone pending output tensor, so inplace ops (`add_`, etc.) did not return `self`.
2. It did not apply alias-aware multi-mutation writeback mapping at flush time, so behavior could diverge from non-pipeline functionalize logic.

## Changes

- `src/mindtorch_v2/_dispatch/dispatcher.py`
  - extend `_FunctionalizePendingOp` with optional `finalize` callback
  - if `finalize` is provided, execute callback on thunk result and skip default target-copy path
- `src/mindtorch_v2/_dispatch/functionalize.py`
  - add `_functionalize_finalize(...)` to apply `_resolve_writeback_pairs(...)`, `_writeback(...)`, and version bumping during flush
  - in pipeline functionalize path:
    - for mutating ops, use first mutation target as returned pending tensor and mark all mutation targets pending
    - wire finalize callback for alias-aware writeback
    - keep non-mutating ops on existing pending-spec path (no finalize)
- `tests/mindtorch_v2/contract/test_functionalize_pipeline.py`
  - add test for inplace return-self + writeback under pipeline
  - add test for alias-mapped multi-mutation writeback under pipeline

## Verification

- `PYTHONPATH=src pytest -q tests/mindtorch_v2/contract/test_functionalize_pipeline.py`
- `PYTHONPATH=src pytest -q tests/mindtorch_v2/contract/test_functionalize_pipeline.py tests/mindtorch_v2/contract/test_functionalize_multi_mutation.py tests/mindtorch_v2/contract/test_functionalize_view_writeback.py tests/mindtorch_v2/test_dispatch_pipeline.py tests/mindtorch_v2/test_pipeline.py`
