### PR TITLE
[mindtorch_v2] Isolate dispatch registry state per test

### DIFF
--- a/docs/agents/dispatch_registry_isolation.md
+++ b/docs/agents/dispatch_registry_isolation.md
@@ -1,0 +1,72 @@
+# Dispatch Registry Isolation Contract
+
+## Scope
+
+This document defines the required test-time isolation behavior for the mutable dispatch registry in `mindtorch_v2`.
+
+It is intended for contributors and coding agents that register temporary schemas/kernels/aliases during tests.
+
+## Problem
+
+`mindtorch_v2._dispatch.registry` is global mutable state.
+
+Without isolation, one test can change registered kernels/schemas and silently affect later tests.
+This causes order-dependent failures and makes parallel agent development unreliable.
+
+## Internal API
+
+The dispatch registry now provides two internal helpers:
+
+- `registry.snapshot()`
+  - Returns a deep-copied state object containing:
+    - operator table (`_ops`)
+    - alias table (`_aliases`)
+    - global fallthrough set (`_global_fallthrough`)
+- `registry.restore(state)`
+  - Restores the exact state from `snapshot()`.
+
+These methods are for test isolation and developer tooling.
+They are not a stable public runtime API.
+
+## Required Test Policy
+
+Any test that mutates dispatch registry state must be isolated.
+
+The default repository policy is an autouse fixture in `tests/conftest.py`:
+
+```python
+@pytest.fixture(autouse=True)
+def _dispatch_registry_isolation():
+    state = registry.snapshot()
+    try:
+        yield
+    finally:
+        registry.restore(state)
+```
+
+This means all tests run with per-test registry rollback by default.
+
+## Agent Guidance
+
+When writing or modifying tests:
+
+1. You may freely call `register_schema/register_kernel/register_alias/register_fallthrough`.
+2. Do not add manual cleanup logic for registry mutations unless there is a strong reason.
+3. If you intentionally bypass `tests/conftest.py` (custom harness), you must call `snapshot/restore` yourself.
+
+Minimal manual pattern:
+
+```python
+state = registry.snapshot()
+try:
+    registry.register_kernel(...)
+    # run assertions
+finally:
+    registry.restore(state)
+```
+
+## Expected Outcome
+
+- No cross-test registry leakage.
+- Deterministic behavior independent of test order.
+- Safer multi-agent parallel development for operator registration work.

--- a/src/mindtorch_v2/_dispatch/registry.py
+++ b/src/mindtorch_v2/_dispatch/registry.py
@@ -1,3 +1,4 @@
+import copy
 from .keys import DispatchKey
 from .schema import OpSchema
 
@@ -85,6 +86,18 @@ class OpRegistry:
 
     def get(self, name):
         return self._ops[self._canonical_name(name)]
+
+    def snapshot(self):
+        return {
+            "ops": copy.deepcopy(self._ops),
+            "aliases": copy.deepcopy(self._aliases),
+            "global_fallthrough": copy.deepcopy(getattr(self, "_global_fallthrough", set())),
+        }
+
+    def restore(self, state):
+        self._ops = copy.deepcopy(state["ops"])
+        self._aliases = copy.deepcopy(state["aliases"])
+        self._global_fallthrough = copy.deepcopy(state.get("global_fallthrough", set()))
 
 
 registry = OpRegistry()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,21 @@
 import os
 import sys
 
+import pytest
+
+
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 SRC = os.path.join(ROOT, "src")
 if SRC not in sys.path:
     sys.path.insert(0, SRC)
+
+
+@pytest.fixture(autouse=True)
+def _dispatch_registry_isolation():
+    from mindtorch_v2._dispatch.registry import registry
+
+    state = registry.snapshot()
+    try:
+        yield
+    finally:
+        registry.restore(state)

--- a/tests/mindtorch_v2/contract/test_registry_isolation.py
+++ b/tests/mindtorch_v2/contract/test_registry_isolation.py
@@ -1,0 +1,18 @@
+import mindtorch_v2 as torch
+from mindtorch_v2._dispatch.keys import DispatchKey
+from mindtorch_v2._dispatch.registry import registry
+
+
+def test_registry_mutation_step1():
+    def bad_add(a, b):
+        return torch.tensor([99.0], device=a.device)
+
+    registry.register_kernel("add", DispatchKey.CPU, bad_add)
+
+    out = torch.add(torch.tensor([1.0]), torch.tensor([2.0]))
+    assert out.storage().data.tolist() == [99.0]
+
+
+def test_registry_mutation_step2_restores_baseline_add():
+    out = torch.add(torch.tensor([1.0]), torch.tensor([2.0]))
+    assert out.storage().data.tolist() == [3.0]


### PR DESCRIPTION
## Summary
- add dispatch registry snapshot/restore helpers to support deterministic rollback of mutable registry state
- add an autouse pytest fixture in tests/conftest.py to snapshot before each test and restore afterward
- add a contract regression test to prove registry mutation in one test does not leak into the next test
- add agent-facing contract doc at docs/agents/dispatch_registry_isolation.md

## Test Plan
- PYTHONPATH=src pytest -q tests/mindtorch_v2/contract/test_registry_isolation.py
- PYTHONPATH=src pytest -q tests/mindtorch_v2/contract/test_functionalize.py tests/mindtorch_v2/contract/test_functionalize_pipeline.py tests/mindtorch_v2/test_pipeline.py tests/mindtorch_v2/test_dispatch_redispatch.py tests/mindtorch_v2/test_dispatch_registry.py tests/mindtorch_v2/contract/test_dispatch_keyset.py tests/mindtorch_v2/contract/test_dispatch_fallthrough.py tests/mindtorch_v2/test_dispatch_keys.py