### PR TITLE
[mindtorch_v2] Align stream/TLS modes and device-index dispatch checks

### DIFF
--- a/src/mindtorch_v2/_dispatch/dispatcher.py
+++ b/src/mindtorch_v2/_dispatch/dispatcher.py
@@ -248,12 +248,16 @@ def _validate_tensor_devices(tensors):
         return
     expected = tensors[0].device
     expected_type = expected.type if hasattr(expected, "type") else expected
+    expected_index = expected.index if hasattr(expected, "index") else None
+    expected_label = expected_type if expected_index is None else f"{expected_type}:{expected_index}"
     for tensor in tensors[1:]:
         device = tensor.device
         dev_type = device.type if hasattr(device, "type") else device
-        if dev_type != expected_type:
+        dev_index = device.index if hasattr(device, "index") else None
+        dev_label = dev_type if dev_index is None else f"{dev_type}:{dev_index}"
+        if dev_type != expected_type or dev_index != expected_index:
             raise RuntimeError(
-                f"Tensor on device {dev_type} is not on the expected device {expected_type}!"
+                f"Tensor on device {dev_label} is not on the expected device {expected_label}!"
             )
 
 

--- a/src/mindtorch_v2/_dispatch/functionalize.py
+++ b/src/mindtorch_v2/_dispatch/functionalize.py
@@ -1,25 +1,33 @@
 import contextlib
+import threading
 import numpy as np
 
 from .registry import registry
 
 
-_ENABLED = False
+_TLS = threading.local()
+
+
+def _get_enabled():
+    return getattr(_TLS, "enabled", False)
+
+
+def _set_enabled(val):
+    _TLS.enabled = bool(val)
 
 
 @contextlib.contextmanager
 def functionalize_context():
-    global _ENABLED
-    prev = _ENABLED
-    _ENABLED = True
+    prev = _get_enabled()
+    _set_enabled(True)
     try:
         yield
     finally:
-        _ENABLED = prev
+        _set_enabled(prev)
 
 
 def is_functionalize_enabled():
-    return _ENABLED
+    return _get_enabled()
 
 
 def _has_mutation(schema_obj):

--- a/tests/mindtorch_v2/test_dispatch_resolution.py
+++ b/tests/mindtorch_v2/test_dispatch_resolution.py
@@ -1,4 +1,8 @@
+import pytest
+
 import mindtorch_v2 as torch
+from mindtorch_v2._dispatch.dispatcher import dispatch_with_keyset
+from mindtorch_v2._dispatch.keys import DispatchKey, DispatchKeySet
 
 
 def test_dispatch_prefers_meta_when_input_meta():
@@ -13,3 +17,17 @@ def test_dispatch_prefers_npu_over_cpu():
     b = torch.ones((2,), device="npu")
     c = torch.add(a, b)
     assert c.device.type == "npu"
+
+
+def test_dispatch_rejects_cross_npu_device_index():
+    class _FakeTensor:
+        def __init__(self, dev):
+            self.device = torch.Device(dev)
+            self.dtype = torch.float32
+
+    a = _FakeTensor("npu:0")
+    b = _FakeTensor("npu:1")
+    keyset = DispatchKeySet(int(DispatchKey.NPU))
+
+    with pytest.raises(RuntimeError, match=r"npu:1.*npu:0"):
+        dispatch_with_keyset("add", keyset, None, a, b)

--- a/tests/mindtorch_v2/test_dispatch_tls_modes.py
+++ b/tests/mindtorch_v2/test_dispatch_tls_modes.py
@@ -1,0 +1,37 @@
+import threading
+
+import mindtorch_v2 as torch
+from mindtorch_v2._dispatch.functionalize import is_functionalize_enabled
+from mindtorch_v2._dispatch.pipeline import current_pipeline
+
+
+def test_pipeline_context_is_thread_local():
+    seen = {}
+
+    with torch.pipeline():
+        assert current_pipeline() is not None
+
+        def worker():
+            seen["pipe"] = current_pipeline()
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join()
+
+    assert seen["pipe"] is None
+
+
+def test_functionalize_context_is_thread_local():
+    seen = {}
+
+    with torch.functionalize():
+        assert is_functionalize_enabled() is True
+
+        def worker():
+            seen["enabled"] = is_functionalize_enabled()
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join()
+
+    assert seen["enabled"] is False


### PR DESCRIPTION
## Summary
- align NPU stream semantics by making default stream device-global while keeping current stream thread-local
- make dispatch pipeline and functionalize mode states thread-local to avoid cross-thread leakage
- tighten dispatch device validation to check both device type and device index
- add regression tests for device-global default stream, TLS mode isolation, and cross-device-index rejection

## Test Plan
- PYTHONPATH=src pytest -q tests/mindtorch_v2/test_npu_streams.py::test_npu_default_stream_is_device_global tests/mindtorch_v2/test_dispatch_tls_modes.py tests/mindtorch_v2/test_dispatch_resolution.py::test_dispatch_rejects_cross_npu_device_index tests/mindtorch_v2/contract/test_functionalize.py tests/mindtorch_v2/contract/test_functionalize_pipeline.py tests/mindtorch_v2/test_dispatch_pipeline.py tests/mindtorch_v2/test_pipeline.py

## Notes
- this PR intentionally verifies a CPU-safe mechanism suite because unrelated NPU runtime instability in current environment can crash tests that execute real NPU kernels