### PR TITLE
[mindtorch_v2] add torch-compat stubs for transformers Albert and fix cpu add scalar

### DIFF
--- a/src/mindtorch_v2/__init__.py
+++ b/src/mindtorch_v2/__init__.py
@@ -2,8 +2,9 @@ __version__ = "0.1.0"
 
 from ._dtype import (
     DType,
+    float8_e4m3fn, float8_e5m2, float8_e8m0fnu,
     float16, float32, float64, bfloat16,
-    int8, int16, int32, int64, uint8,
+    int8, int16, int32, int64, uint8, uint16, uint32, uint64,
     bool,
     complex64, complex128,
     # aliases
@@ -11,8 +12,26 @@ from ._dtype import (
 )
 from ._dtype import float as float  # noqa: F811
 from ._dtype import int as int  # noqa: F811
+from ._dtype import DType as dtype  # torch.dtype compatibility
+from ._dtype import DType as Dtype  # schema/type alias compatibility
 from ._device import device as Device, _default_device, get_default_device, set_default_device
+from ._device import device
 from ._tensor import Tensor
+
+# Tensor type aliases for torch API compatibility
+FloatTensor = Tensor
+DoubleTensor = Tensor
+HalfTensor = Tensor
+BFloat16Tensor = Tensor
+ByteTensor = Tensor
+CharTensor = Tensor
+ShortTensor = Tensor
+IntTensor = Tensor
+LongTensor = Tensor
+BoolTensor = Tensor
+ComplexFloatTensor = Tensor
+ComplexDoubleTensor = Tensor
+Size = tuple
 from ._creation import tensor, zeros, ones, empty, arange, linspace, full, logspace, eye, range, randn, rand
 from ._functional import zeros_like
 from ._storage import UntypedStorage, TypedStorage
@@ -29,13 +48,19 @@ from ._functional import logaddexp, logaddexp2, hypot, remainder, fmod
 from ._printing import set_printoptions, get_printoptions
 from ._dispatch import pipeline_context, functionalize_context
 from ._backends import cpu
-from ._autograd.grad_mode import is_grad_enabled, set_grad_enabled, no_grad, enable_grad
+from ._autograd.grad_mode import is_grad_enabled, set_grad_enabled, no_grad, enable_grad, inference_mode
 from . import _autograd as autograd
 from . import npu
 from . import _C
 from . import distributed
+from . import onnx
 from . import futures
 from . import amp
+from . import compiler
+from .ops import ops
+from . import library
+from . import optim
+from . import jit
 from ._random import (
     manual_seed, seed, initial_seed, get_rng_state, set_rng_state,
     Generator, default_generator,
@@ -51,13 +76,29 @@ def functionalize():
     return functionalize_context()
 
 
+def compile(model=None, *args, **kwargs):
+    if callable(model):
+        return model
+    def decorator(fn):
+        return fn
+    return decorator
+
+
 __all__ = [
     "Device",
+    "device",
     "Tensor",
+    "Size",
+    "FloatTensor", "DoubleTensor", "HalfTensor", "BFloat16Tensor",
+    "ByteTensor", "CharTensor", "ShortTensor", "IntTensor", "LongTensor",
+    "BoolTensor", "ComplexFloatTensor", "ComplexDoubleTensor",
     "DType",
+    "dtype",
+    "Dtype",
     # dtypes
+    "float8_e4m3fn", "float8_e5m2", "float8_e8m0fnu",
     "float16", "float32", "float64", "bfloat16",
-    "int8", "int16", "int32", "int64", "uint8",
+    "int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64",
     "bool",
     "complex64", "complex128",
     # dtype aliases
@@ -206,8 +247,20 @@ __all__ = [
     "npu",
     # autograd
     "autograd",
+    "is_grad_enabled",
+    "set_grad_enabled",
+    "no_grad",
+    "enable_grad",
+    "inference_mode",
     # distributed
     "distributed",
+    "onnx",
     # amp
     "amp",
+    "ops",
+    "library",
+    "compiler",
+    "optim",
+    "jit",
+    "compile",
 ]

--- a/src/mindtorch_v2/_autograd/grad_mode.py
+++ b/src/mindtorch_v2/_autograd/grad_mode.py
@@ -42,19 +42,55 @@ class set_grad_enabled:
         _set_enabled(self._prev)
 
 
-class no_grad:
+def _decorate_with_grad_mode(fn, enabled):
+    def wrapped(*args, **kwargs):
+        with set_grad_enabled(enabled):
+            return fn(*args, **kwargs)
+    wrapped.__name__ = getattr(fn, "__name__", "wrapped")
+    wrapped.__doc__ = getattr(fn, "__doc__", None)
+    wrapped.__module__ = getattr(fn, "__module__", None)
+    return wrapped
+
+
+class _NoGradContext:
     def __enter__(self):
         self._prev = _get_enabled()
         _set_enabled(False)
+        return self
 
     def __exit__(self, exc_type, exc, tb):
         _set_enabled(self._prev)
 
+    def __call__(self, fn):
+        return _decorate_with_grad_mode(fn, False)
 
-class enable_grad:
+
+class _EnableGradContext:
     def __enter__(self):
         self._prev = _get_enabled()
         _set_enabled(True)
+        return self
 
     def __exit__(self, exc_type, exc, tb):
         _set_enabled(self._prev)
+
+    def __call__(self, fn):
+        return _decorate_with_grad_mode(fn, True)
+
+
+def no_grad(func=None):
+    ctx = _NoGradContext()
+    if func is None:
+        return ctx
+    return ctx(func)
+
+
+def enable_grad(func=None):
+    ctx = _EnableGradContext()
+    if func is None:
+        return ctx
+    return ctx(func)
+
+
+def inference_mode(mode=True):
+    return no_grad() if mode else enable_grad()

--- a/src/mindtorch_v2/ao/__init__.py
+++ b/src/mindtorch_v2/ao/__init__.py
@@ -1,0 +1,4 @@
+from .quantization import QuantStub, DeQuantStub
+from . import quantization
+
+__all__ = ["QuantStub", "DeQuantStub", "quantization"]

--- a/src/mindtorch_v2/ao/quantization.py
+++ b/src/mindtorch_v2/ao/quantization.py
@@ -1,0 +1,8 @@
+class QuantStub:
+    def __call__(self, x=None):
+        return x
+
+
+class DeQuantStub:
+    def __call__(self, x=None):
+        return x

--- a/src/mindtorch_v2/compiler.py
+++ b/src/mindtorch_v2/compiler.py
@@ -1,0 +1,5 @@
+def disable(*args, **kwargs):
+    def decorator(func):
+        return func
+    return decorator
+

--- a/src/mindtorch_v2/jit/__init__.py
+++ b/src/mindtorch_v2/jit/__init__.py
@@ -1,0 +1,39 @@
+from ._trace import _script_if_tracing
+
+
+def is_tracing():
+    return False
+
+
+def is_scripting():
+    return False
+
+
+def script(obj, optimize=None, _frames_up=0, _rcb=None, example_inputs=None):
+    return obj
+
+
+def ignore(drop=False, **kwargs):
+    if callable(drop):
+        return drop
+
+    def decorator(fn):
+        return fn
+
+    return decorator
+
+
+def unused(fn):
+    return fn
+
+
+def _overload_method(func):
+    return func
+
+
+def _script_if_tracing_wrapper(fn):
+    return _script_if_tracing(fn)
+
+
+def script_if_tracing(fn):
+    return _script_if_tracing(fn)

--- a/src/mindtorch_v2/jit/_trace.py
+++ b/src/mindtorch_v2/jit/_trace.py
@@ -1,0 +1,9 @@
+import functools
+
+
+def _script_if_tracing(fn):
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        return fn(*args, **kwargs)
+
+    return wrapper

--- a/src/mindtorch_v2/jit/annotations.py
+++ b/src/mindtorch_v2/jit/annotations.py
@@ -1,0 +1,2 @@
+BroadcastingList2 = list
+List = list

--- a/src/mindtorch_v2/library.py
+++ b/src/mindtorch_v2/library.py
@@ -1,0 +1,12 @@
+class Library:
+    def __init__(self, *_args, **_kwargs):
+        pass
+
+    def impl(self, *_args, **_kwargs):
+        return None
+
+def register_fake(_name):
+    def decorator(_fn):
+        return None
+    return decorator
+

--- a/src/mindtorch_v2/onnx/__init__.py
+++ b/src/mindtorch_v2/onnx/__init__.py
@@ -1,0 +1,6 @@
+from . import symbolic_opset11
+from . import symbolic_helper
+
+
+def register_custom_op_symbolic(*_args, **_kwargs):
+    return None

--- a/src/mindtorch_v2/onnx/symbolic_helper.py
+++ b/src/mindtorch_v2/onnx/symbolic_helper.py
@@ -1,0 +1,4 @@
+def parse_args(*_schema):
+    def decorator(fn):
+        return fn
+    return decorator

--- a/src/mindtorch_v2/onnx/symbolic_opset11.py
+++ b/src/mindtorch_v2/onnx/symbolic_opset11.py
@@ -1,0 +1,2 @@
+def __getattr__(_name):
+    return lambda *args, **kwargs: None

--- a/src/mindtorch_v2/ops.py
+++ b/src/mindtorch_v2/ops.py
@@ -1,0 +1,36 @@
+class _Op:
+    def __init__(self, return_value=None):
+        self._return_value = return_value
+
+    def __call__(self, *args, **kwargs):
+        return self._return_value
+
+    @property
+    def default(self):
+        return self
+
+
+class _Namespace:
+    def __getattr__(self, _name):
+        return _Op(None)
+
+
+class _TorchVisionNamespace(_Namespace):
+    def __getattr__(self, name):
+        if name == "_cuda_version":
+            return _Op(0)
+        return super().__getattr__(name)
+
+
+class _Ops:
+    def __init__(self):
+        self.torchvision = _TorchVisionNamespace()
+
+    def load_library(self, *_args, **_kwargs):
+        return None
+
+    def __getattr__(self, _name):
+        return _Namespace()
+
+
+ops = _Ops()

--- a/tests/mindtorch_v2/test_grad_mode_tls.py
+++ b/tests/mindtorch_v2/test_grad_mode_tls.py
@@ -43,3 +43,17 @@ def test_set_grad_enabled_is_thread_local():
         assert torch.is_grad_enabled() is False
 
     assert observed == [True, False, True]
+
+
+def test_no_grad_decorator_forms():
+    @torch.no_grad()
+    def fn_a():
+        return torch.is_grad_enabled()
+
+    @torch.no_grad
+    def fn_b():
+        return torch.is_grad_enabled()
+
+    assert fn_a() is False
+    assert fn_b() is False
+    assert torch.is_grad_enabled() is True


### PR DESCRIPTION
## Summary
- rebase `cpu-ops` to latest `ms/master` and keep mindtorch_v2-only changes
- add missing torch-compat APIs required by transformers/albert import/runtime on CPU
- fix CPU `add` kernel to support Tensor + scalar path used by albert masking flow

## Details
- top-level exports in `mindtorch_v2`:
  - dtype aliases: `dtype`, `Dtype`, uint/float8 dtypes
  - type aliases: `LongTensor` and related tensor aliases, `Size`, `device`
  - modules: `jit`, `onnx`, `ops`, `library`, `compiler`, `optim`
  - funcs: `compile`, `inference_mode`
- new compatibility stubs:
  - `src/mindtorch_v2/jit/` (`is_tracing`, `script`, `_script_if_tracing`, `annotations`)
  - `src/mindtorch_v2/onnx/` (`symbolic_opset11`, `symbolic_helper`, `register_custom_op_symbolic`)
  - `src/mindtorch_v2/ops.py` (torch.ops namespace + torchvision fallback)
  - `src/mindtorch_v2/library.py`, `src/mindtorch_v2/compiler.py`, `src/mindtorch_v2/ao/`
- grad mode compatibility:
  - `no_grad`/`enable_grad` now support both context-manager and decorator forms
  - add `inference_mode` shim
- CPU operator fix:
  - `src/mindtorch_v2/_backends/cpu/ops.py::add` handles scalar rhs

## Verification
- `python tests/run_test_v2.py -vs tests/mindtorch_v2/test_import.py::test_torch_jit_is_tracing_stub tests/mindtorch_v2/test_import.py::test_torch_compile_stub tests/mindtorch_v2/test_import.py::test_torch_ops_stub tests/mindtorch_v2/test_import.py::test_torch_onnx_symbolic_opset11_import tests/mindtorch_v2/test_import.py::test_torch_ao_quantization_stub tests/mindtorch_v2/test_import.py::test_cpu_gelu_kernel_stub tests/mindtorch_v2/test_import.py::test_cpu_embedding_kernel_stub tests/mindtorch_v2/test_import.py::test_cpu_layer_norm_kernel_stub tests/mindtorch_v2/test_grad_mode_tls.py`
- `export HF_ENDPOINT=https://hf-mirror.com && python tests/run_test_v2.py -vs -x tests/transformers/tests/models/albert/test_modeling_albert.py::AlbertModelTest::test_model`

## Scope
- CPU backend only; no new MindSpore dependency introduced.