### PR TITLE
[mindtorch_v2] Align create_graph higher-order autograd behavior

### DIFF
--- a/tests/mindtorch_v2/contract/test_autograd_create_graph.py
+++ b/tests/mindtorch_v2/contract/test_autograd_create_graph.py
@@ -8,3 +8,29 @@ def test_backward_create_graph_allows_second_backward():
     # Second backward should succeed when create_graph=True (retain_graph implied).
     out.backward()
     assert a.grad is not None
+
+
+def test_autograd_grad_create_graph_builds_higher_order_graph():
+    x = torch.tensor([2.0], requires_grad=True)
+    y = x * x
+
+    (gx,) = torch.autograd.grad(y, (x,), create_graph=True)
+    assert gx.requires_grad is True
+    assert gx.grad_fn is not None
+
+    z = gx * gx
+    z.backward()
+    assert x.grad is not None
+
+
+def test_backward_create_graph_keeps_grad_differentiable():
+    x = torch.tensor([3.0], requires_grad=True)
+    y = x * x
+    y.backward(create_graph=True)
+
+    assert x.grad is not None
+    assert x.grad.requires_grad is True
+
+    q = x.grad * x
+    q.backward()
+    assert x.grad is not None


### PR DESCRIPTION
## Summary
- align autograd create_graph behavior so backward formulas can build higher-order graphs instead of always running under no_grad
- add engine-level create_graph state query and use it to select gradient accumulation context
- update autograd wrapper keyset handling for backward-time create_graph paths
- extend create_graph contract tests for higher-order gradient behavior

## Test Plan
- PYTHONPATH=src pytest -q tests/mindtorch_v2/contract/test_autograd_create_graph.py tests/mindtorch_v2/test_autograd_api.py tests/mindtorch_v2/test_import.py