### PR TITLE
[mindtorch_v2] Tighten schema binding kw/type validation

### DIFF
--- a/tests/mindtorch_v2/contract/test_schema_binding.py
+++ b/tests/mindtorch_v2/contract/test_schema_binding.py
@@ -42,3 +42,28 @@ def test_dispatch_relu_too_many_args_matches_torch():
         pt.relu(pt.tensor([1.0]), pt.tensor([2.0]))
 
     assert_torch_error(mt, th)
+
+
+def test_dispatch_add_rejects_unexpected_device_kw_matches_torch():
+    a = torch.tensor([1.0])
+    b = torch.tensor([2.0])
+
+    def mt():
+        dispatch("add", a.device.type, a, b, device="cpu")
+
+    def th():
+        pt.add(pt.tensor([1.0]), pt.tensor([2.0]), device="cpu")
+
+    assert_torch_error(mt, th)
+
+
+def test_dispatch_sum_rejects_invalid_keepdim_type_matches_torch():
+    a = torch.tensor([1.0])
+
+    def mt():
+        dispatch("sum", a.device.type, a, keepdim="x")
+
+    def th():
+        pt.sum(pt.tensor([1.0]), keepdim="x")
+
+    assert_torch_error(mt, th)


### PR DESCRIPTION
## Summary
- tighten dispatch schema binding to reject unexpected `device` kwargs for ops whose schema does not declare `device`
- add schema parameter `type_name` metadata and use it for minimal strict type validation in binder
- validate bool-typed schema params via binder so invalid `keepdim` inputs follow torch-style invalid-combination errors
- add contract tests for strict schema behavior: `add(..., device=...)` and `sum(..., keepdim='x')`

## Test Plan
- PYTHONPATH=src pytest -q tests/mindtorch_v2/contract/test_schema_binding.py::test_dispatch_add_rejects_unexpected_device_kw_matches_torch tests/mindtorch_v2/contract/test_schema_binding.py::test_dispatch_sum_rejects_invalid_keepdim_type_matches_torch
- PYTHONPATH=src pytest -q tests/mindtorch_v2/contract/test_schema_binding.py tests/mindtorch_v2/contract/test_core_schema_errors.py tests/mindtorch_v2/contract/test_schema_positional.py tests/mindtorch_v2/contract/test_alias_resolution.py
