### PR TITLE
[mindtorch_v2] add NPU coverage for repeat/scatter/diag and related tensor ops

### DIFF
--- a/src/mindtorch_v2/_backends/npu/__init__.py
+++ b/src/mindtorch_v2/_backends/npu/__init__.py
@@ -82,6 +82,16 @@ from .ops import (
     topk,
     tril,
     triu,
+    rot90,
+    repeat,
+    repeat_interleave,
+    tile,
+    scatter,
+    tril_indices,
+    triu_indices,
+    diag,
+    cartesian_prod,
+    block_diag,
     stack,
     cat,
     concatenate,
@@ -166,6 +176,16 @@ registry.register("sort", "npu", sort, meta=meta_infer.infer_sort)
 registry.register("topk", "npu", topk, meta=meta_infer.infer_topk)
 registry.register("tril", "npu", tril, meta=meta_infer.infer_unary)
 registry.register("triu", "npu", triu, meta=meta_infer.infer_unary)
+registry.register("rot90", "npu", rot90, meta=meta_infer.infer_rot90)
+registry.register("repeat", "npu", repeat, meta=meta_infer.infer_repeat)
+registry.register("repeat_interleave", "npu", repeat_interleave, meta=meta_infer.infer_repeat_interleave)
+registry.register("tile", "npu", tile, meta=meta_infer.infer_tile)
+registry.register("scatter", "npu", scatter, meta=meta_infer.infer_scatter)
+registry.register("tril_indices", "npu", tril_indices, meta=meta_infer.infer_tril_indices)
+registry.register("triu_indices", "npu", triu_indices, meta=meta_infer.infer_triu_indices)
+registry.register("diag", "npu", diag, meta=meta_infer.infer_diag)
+registry.register("cartesian_prod", "npu", cartesian_prod, meta=meta_infer.infer_cartesian_prod)
+registry.register("block_diag", "npu", block_diag, meta=meta_infer.infer_block_diag)
 registry.register("abs", "npu", abs, meta=meta_infer.infer_unary)
 registry.register("neg", "npu", neg, meta=meta_infer.infer_unary)
 registry.register("sign", "npu", sign, meta=meta_infer.infer_unary)

--- a/tests/mindtorch_v2/test_ops_npu.py
+++ b/tests/mindtorch_v2/test_ops_npu.py
@@ -667,6 +667,87 @@ def test_npu_tril_triu():
     np.testing.assert_allclose(triu_out.to("cpu").numpy(), np.triu(x.to("cpu").numpy()), atol=1e-6, rtol=1e-6)
 
 
+def test_npu_rot90():
+    if not torch.npu.is_available():
+        pytest.skip("NPU not available")
+    x = torch.tensor([[1, 2], [3, 4]], device="npu")
+    out = torch.rot90(x, k=1, dims=(0, 1))
+    np.testing.assert_array_equal(out.to("cpu").numpy(), np.rot90(x.to("cpu").numpy(), k=1, axes=(0, 1)))
+
+
+def test_npu_repeat():
+    if not torch.npu.is_available():
+        pytest.skip("NPU not available")
+    x = torch.tensor([[1, 2], [3, 4]], device="npu")
+    out = torch.repeat(x, (2, 1))
+    np.testing.assert_array_equal(out.to("cpu").numpy(), np.tile(x.to("cpu").numpy(), (2, 1)))
+
+
+def test_npu_repeat_interleave():
+    if not torch.npu.is_available():
+        pytest.skip("NPU not available")
+    x = torch.tensor([[1, 2], [3, 4]], device="npu")
+    out = torch.repeat_interleave(x, repeats=2, dim=1)
+    np.testing.assert_array_equal(out.to("cpu").numpy(), np.repeat(x.to("cpu").numpy(), 2, axis=1))
+
+
+def test_npu_tile():
+    if not torch.npu.is_available():
+        pytest.skip("NPU not available")
+    x = torch.tensor([[1, 2], [3, 4]], device="npu")
+    out = torch.tile(x, (1, 2))
+    np.testing.assert_array_equal(out.to("cpu").numpy(), np.tile(x.to("cpu").numpy(), (1, 2)))
+
+
+def test_npu_scatter():
+    if not torch.npu.is_available():
+        pytest.skip("NPU not available")
+    a = torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]], device="npu")
+    index = torch.tensor([[0, 2, 1], [1, 0, 2]], device="npu", dtype=torch.int64)
+    src = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], device="npu")
+    out = torch.scatter(a, 1, index, src)
+    expected = np.zeros((2, 3), dtype=np.float32)
+    np.put_along_axis(expected, index.to("cpu").numpy(), src.to("cpu").numpy(), axis=1)
+    np.testing.assert_allclose(out.to("cpu").numpy(), expected, atol=1e-6, rtol=1e-6)
+
+
+def test_npu_tril_indices_triu_indices():
+    if not torch.npu.is_available():
+        pytest.skip("NPU not available")
+    tril_out = torch.tril_indices(3, 4, offset=0, device="npu")
+    triu_out = torch.triu_indices(3, 4, offset=0, device="npu")
+    np.testing.assert_array_equal(tril_out.to("cpu").numpy(), np.array(np.tril_indices(3, k=0, m=4), dtype=np.int64))
+    np.testing.assert_array_equal(triu_out.to("cpu").numpy(), np.array(np.triu_indices(3, k=0, m=4), dtype=np.int64))
+
+
+def test_npu_diag():
+    if not torch.npu.is_available():
+        pytest.skip("NPU not available")
+    x = torch.tensor([1.0, 2.0, 3.0], device="npu")
+    out = torch.diag(x)
+    np.testing.assert_allclose(out.to("cpu").numpy(), np.diag(x.to("cpu").numpy()), atol=1e-6, rtol=1e-6)
+
+
+def test_npu_cartesian_prod():
+    if not torch.npu.is_available():
+        pytest.skip("NPU not available")
+    a = torch.tensor([1, 2], device="npu")
+    b = torch.tensor([3, 4], device="npu")
+    out = torch.cartesian_prod(a, b)
+    expected = np.array([[1, 3], [1, 4], [2, 3], [2, 4]], dtype=np.int64)
+    np.testing.assert_array_equal(out.to("cpu").numpy(), expected)
+
+
+def test_npu_block_diag():
+    if not torch.npu.is_available():
+        pytest.skip("NPU not available")
+    a = torch.tensor([[1.0, 2.0]], device="npu")
+    b = torch.tensor([[3.0], [4.0]], device="npu")
+    out = torch.block_diag(a, b)
+    expected = np.array([[1.0, 2.0, 0.0], [0.0, 0.0, 3.0], [0.0, 0.0, 4.0]], dtype=np.float32)
+    np.testing.assert_allclose(out.to("cpu").numpy(), expected, atol=1e-6, rtol=1e-6)
+
+
 def test_npu_to_cpu_synchronizes(monkeypatch):
     if not torch.npu.is_available():
         pytest.skip("NPU not available")


### PR DESCRIPTION
## Summary
- add NPU backend operator coverage for `rot90`, `repeat`, `repeat_interleave`, `tile`, `scatter`, `tril_indices`, `triu_indices`, `diag`, `cartesian_prod`, and `block_diag`
- wire ACLNN ctypes bindings/wrappers for single-op paths where available: `repeat`, `repeat_interleave(int)`, `scatter`, and `diag`
- register new NPU ops in backend registry with corresponding meta infer functions
- repair previously broken/incomplete NPU op implementation block and remove NumPy usage from NPU execution paths

## Testing
- `python -m py_compile src/mindtorch_v2/_backends/npu/ops.py src/mindtorch_v2/_backends/npu/aclnn.py src/mindtorch_v2/_backends/npu/__init__.py tests/mindtorch_v2/test_ops_npu.py`
- `PYTHONPATH=src pytest tests/mindtorch_v2/test_ops_npu.py -k "test_npu_rot90 or test_npu_repeat or test_npu_repeat_interleave or test_npu_tile or test_npu_scatter or test_npu_tril_indices_triu_indices or test_npu_diag or test_npu_cartesian_prod or test_npu_block_diag" -vv`
- `PYTHONPATH=src pytest tests/mindtorch_v2 -q` (known existing env-level segfault at `test_npu_pow`)
