### PR TITLE
[mindtorch_v2] add NPU pad and pad_sequence coverage

### DIFF
--- a/src/mindtorch_v2/_backends/npu/__init__.py
+++ b/src/mindtorch_v2/_backends/npu/__init__.py
@@ -151,6 +151,8 @@ from .ops import (
     take_along_dim,
     masked_select,
     dropout,
+    pad,
+    pad_sequence,
 )
 from .runtime import is_available, _model_dir, _probe_model_dirs
 from . import allocator
@@ -299,6 +301,8 @@ registry.register("index_select", "npu", index_select, meta=meta_infer.infer_ind
 registry.register("take", "npu", take, meta=meta_infer.infer_take)
 registry.register("take_along_dim", "npu", take_along_dim, meta=meta_infer.infer_take_along_dim)
 registry.register("masked_select", "npu", masked_select, meta=meta_infer.infer_masked_select)
+registry.register("pad", "npu", pad, meta=meta_infer.infer_unary)
+registry.register("pad_sequence", "npu", pad_sequence, meta=meta_infer.infer_pad_sequence)
 
 # Critical tier operations
 registry.register("mean", "npu", mean, meta=meta_infer.infer_sum)

--- a/tests/mindtorch_v2/test_ops_npu.py
+++ b/tests/mindtorch_v2/test_ops_npu.py
@@ -2,6 +2,7 @@ import math
 import numpy as np
 import pytest
 import mindtorch_v2 as torch
+from mindtorch_v2.nn import functional as F
 
 
 def test_npu_add():
@@ -747,6 +748,35 @@ def test_npu_block_diag():
     expected = np.array([[1.0, 2.0, 0.0], [0.0, 0.0, 3.0], [0.0, 0.0, 4.0]], dtype=np.float32)
     np.testing.assert_allclose(out.to("cpu").numpy(), expected, atol=1e-6, rtol=1e-6)
 
+
+
+def test_npu_pad_constant():
+    if not torch.npu.is_available():
+        pytest.skip("NPU not available")
+    x = torch.tensor([[1.0, 2.0], [3.0, 4.0]], device="npu")
+    out = F.pad(x, (1, 2, 0, 1), mode="constant", value=0.5)
+    expected = np.pad(x.to("cpu").numpy(), ((0, 1), (1, 2)), mode="constant", constant_values=0.5)
+    np.testing.assert_allclose(out.to("cpu").numpy(), expected, atol=1e-6, rtol=1e-6)
+
+
+def test_npu_pad_sequence_right():
+    if not torch.npu.is_available():
+        pytest.skip("NPU not available")
+    a = torch.tensor([1.0, 2.0], device="npu")
+    b = torch.tensor([3.0], device="npu")
+    out = torch.pad_sequence([a, b], batch_first=True, padding_value=0.0, padding_side="right")
+    expected = np.array([[1.0, 2.0], [3.0, 0.0]], dtype=np.float32)
+    np.testing.assert_allclose(out.to("cpu").numpy(), expected, atol=1e-6, rtol=1e-6)
+
+
+def test_npu_pad_sequence_left():
+    if not torch.npu.is_available():
+        pytest.skip("NPU not available")
+    a = torch.tensor([1.0, 2.0], device="npu")
+    b = torch.tensor([3.0], device="npu")
+    out = torch.pad_sequence([a, b], batch_first=True, padding_value=-1.0, padding_side="left")
+    expected = np.array([[1.0, 2.0], [-1.0, 3.0]], dtype=np.float32)
+    np.testing.assert_allclose(out.to("cpu").numpy(), expected, atol=1e-6, rtol=1e-6)
 
 def test_npu_to_cpu_synchronizes(monkeypatch):
     if not torch.npu.is_available():


### PR DESCRIPTION
## Summary
- add NPU backend coverage for `pad` and `pad_sequence`
- implement NPU `pad` constant mode via ACLNN single-op `aclnnConstantPadNd`
- add missing ACLNN runtime wrapper for `constant_pad_nd` in ctypes backend
- implement NPU `pad_sequence` write path using device-to-device memcpy over prefilled output tensor
- register `pad` and `pad_sequence` in NPU backend registry with meta infer mapping

## Testing
- `python -m py_compile src/mindtorch_v2/_backends/npu/ops.py src/mindtorch_v2/_backends/npu/aclnn.py src/mindtorch_v2/_backends/npu/__init__.py tests/mindtorch_v2/test_ops_npu.py`
- `PYTHONPATH=src pytest tests/mindtorch_v2/test_ops_npu.py -k "test_npu_pad_constant or test_npu_pad_sequence_right or test_npu_pad_sequence_left" -vv`
