### PR TITLE
[mindtorch_v2] align tensor comparison semantics with torch dispatch

### DIFF
--- a/src/mindtorch_v2/_backends/cpu/__init__.py
+++ b/src/mindtorch_v2/_backends/cpu/__init__.py
@@ -57,6 +57,12 @@ from .ops import (
     allclose,
     isclose,
     equal,
+    eq,
+    ne,
+    lt,
+    le,
+    gt,
+    ge,
     add_,
     mul_,
     relu_,
@@ -276,6 +282,12 @@ registry.register("unbind", "cpu", unbind, meta=meta_infer.infer_unbind)
 registry.register("allclose", "cpu", allclose, meta=meta_infer.infer_reduce_bool)
 registry.register("isclose", "cpu", isclose, meta=meta_infer.infer_unary_bool)
 registry.register("equal", "cpu", equal, meta=meta_infer.infer_reduce_bool)
+registry.register("eq", "cpu", eq, meta=meta_infer.infer_binary_bool)
+registry.register("ne", "cpu", ne, meta=meta_infer.infer_binary_bool)
+registry.register("lt", "cpu", lt, meta=meta_infer.infer_binary_bool)
+registry.register("le", "cpu", le, meta=meta_infer.infer_binary_bool)
+registry.register("gt", "cpu", gt, meta=meta_infer.infer_binary_bool)
+registry.register("ge", "cpu", ge, meta=meta_infer.infer_binary_bool)
 registry.register("add_", "cpu", add_, meta=meta_infer.infer_binary)
 registry.register("mul_", "cpu", mul_, meta=meta_infer.infer_binary)
 registry.register("relu_", "cpu", relu_, meta=meta_infer.infer_unary)

--- a/src/mindtorch_v2/_backends/cpu/ops.py
+++ b/src/mindtorch_v2/_backends/cpu/ops.py
@@ -585,6 +585,36 @@ def equal(a, b):
     return np.array_equal(_to_numpy(a), _to_numpy(b))
 
 
+def eq(a, b):
+    b_np = _to_numpy(b) if isinstance(b, Tensor) else b
+    return _from_numpy(np.equal(_to_numpy(a), b_np), bool_dtype, a.device)
+
+
+def ne(a, b):
+    b_np = _to_numpy(b) if isinstance(b, Tensor) else b
+    return _from_numpy(np.not_equal(_to_numpy(a), b_np), bool_dtype, a.device)
+
+
+def lt(a, b):
+    b_np = _to_numpy(b) if isinstance(b, Tensor) else b
+    return _from_numpy(np.less(_to_numpy(a), b_np), bool_dtype, a.device)
+
+
+def le(a, b):
+    b_np = _to_numpy(b) if isinstance(b, Tensor) else b
+    return _from_numpy(np.less_equal(_to_numpy(a), b_np), bool_dtype, a.device)
+
+
+def gt(a, b):
+    b_np = _to_numpy(b) if isinstance(b, Tensor) else b
+    return _from_numpy(np.greater(_to_numpy(a), b_np), bool_dtype, a.device)
+
+
+def ge(a, b):
+    b_np = _to_numpy(b) if isinstance(b, Tensor) else b
+    return _from_numpy(np.greater_equal(_to_numpy(a), b_np), bool_dtype, a.device)
+
+
 def add_(a, b):
     arr = _to_numpy(a)
     arr += _to_numpy(b)

--- a/src/mindtorch_v2/_backends/meta/infer.py
+++ b/src/mindtorch_v2/_backends/meta/infer.py
@@ -34,6 +34,11 @@ def infer_binary(a, b):
     return TensorSpec(shape=tuple(shape), stride=_contiguous_stride(shape), dtype=a.dtype)
 
 
+def infer_binary_bool(a, b):
+    shape = _broadcast_shape(a.shape, b.shape)
+    return TensorSpec(shape=tuple(shape), stride=_contiguous_stride(shape), dtype=bool_dtype)
+
+
 def infer_unary(a):
     return TensorSpec(shape=tuple(a.shape), stride=_contiguous_stride(a.shape), dtype=a.dtype)
 

--- a/src/mindtorch_v2/_backends/npu/__init__.py
+++ b/src/mindtorch_v2/_backends/npu/__init__.py
@@ -119,6 +119,12 @@ from .ops import (
     atan2,
     atanh,
     equal,
+    eq,
+    ne,
+    lt,
+    le,
+    gt,
+    ge,
     fmax,
     fmin,
     fmod,
@@ -260,6 +266,12 @@ registry.register("fmod", "npu", fmod, meta=meta_infer.infer_binary)
 registry.register("allclose", "npu", allclose, meta=meta_infer.infer_reduce_bool)
 registry.register("isclose", "npu", isclose, meta=meta_infer.infer_unary_bool)
 registry.register("equal", "npu", equal, meta=meta_infer.infer_reduce_bool)
+registry.register("eq", "npu", eq, meta=meta_infer.infer_binary_bool)
+registry.register("ne", "npu", ne, meta=meta_infer.infer_binary_bool)
+registry.register("lt", "npu", lt, meta=meta_infer.infer_binary_bool)
+registry.register("le", "npu", le, meta=meta_infer.infer_binary_bool)
+registry.register("gt", "npu", gt, meta=meta_infer.infer_binary_bool)
+registry.register("ge", "npu", ge, meta=meta_infer.infer_binary_bool)
 registry.register("reshape", "npu", view_backend.reshape, meta=meta_infer.infer_view)
 registry.register("view", "npu", view_backend.view, meta=meta_infer.infer_view)
 registry.register("transpose", "npu", view_backend.transpose, meta=meta_infer.infer_transpose)

--- a/src/mindtorch_v2/_backends/npu/ops.py
+++ b/src/mindtorch_v2/_backends/npu/ops.py
@@ -299,6 +299,8 @@ def div(a, b):
 
 
 def eq(a, b):
+    if isinstance(b, (int, float, bool)):
+        b = _scalar_to_npu_tensor(b, a)
     runtime = npu_runtime.get_runtime((a.device.index or 0))
     stream = npu_state.current_stream((a.device.index or 0))
     if not aclnn.eq_tensor_symbols_ok():
@@ -325,6 +327,8 @@ def eq(a, b):
 
 
 def ne(a, b):
+    if isinstance(b, (int, float, bool)):
+        b = _scalar_to_npu_tensor(b, a)
     runtime = npu_runtime.get_runtime((a.device.index or 0))
     stream = npu_state.current_stream((a.device.index or 0))
     if not aclnn.ne_tensor_symbols_ok():

--- a/src/mindtorch_v2/_functional.py
+++ b/src/mindtorch_v2/_functional.py
@@ -601,6 +601,38 @@ def equal(a, b):
     return dispatch("equal", a.device.type, a, b)
 
 
+def _compare_dispatch(op_name, a, b):
+    if not hasattr(a, "device"):
+        raise TypeError(f"'{op_name}' not supported between instances of '{type(a).__name__}' and '{type(b).__name__}'")
+    if not hasattr(b, "device") and not isinstance(b, (int, float, bool)):
+        raise TypeError(f"'{op_name}' not supported between instances of 'Tensor' and '{type(b).__name__}'")
+    return dispatch(op_name, a.device.type, a, b)
+
+
+def eq(a, b):
+    return _compare_dispatch("eq", a, b)
+
+
+def ne(a, b):
+    return _compare_dispatch("ne", a, b)
+
+
+def lt(a, b):
+    return _compare_dispatch("lt", a, b)
+
+
+def le(a, b):
+    return _compare_dispatch("le", a, b)
+
+
+def gt(a, b):
+    return _compare_dispatch("gt", a, b)
+
+
+def ge(a, b):
+    return _compare_dispatch("ge", a, b)
+
+
 def logspace(start, end, steps, dtype=None, device=None):
     dev = _as_device(device)
     return dispatch("logspace", dev, start, end, steps, dtype=dtype)

--- a/tests/mindtorch_v2/contract/test_tensor_comparison_contract.py
+++ b/tests/mindtorch_v2/contract/test_tensor_comparison_contract.py
@@ -1,0 +1,67 @@
+import operator
+
+import numpy as np
+import torch as pt
+
+import mindtorch_v2 as torch
+
+from tests.mindtorch_v2.contract.helpers import assert_torch_error
+
+
+def test_tensor_eq_ne_return_tensor_matches_torch():
+    mt_a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    mt_b = torch.tensor([[1.0, 0.0], [3.0, 5.0]])
+    pt_a = pt.tensor([[1.0, 2.0], [3.0, 4.0]])
+    pt_b = pt.tensor([[1.0, 0.0], [3.0, 5.0]])
+
+    mt_eq = mt_a == mt_b
+    mt_ne = mt_a != 2.0
+    pt_eq = pt_a == pt_b
+    pt_ne = pt_a != 2.0
+
+    assert isinstance(mt_eq, torch.Tensor)
+    assert isinstance(mt_ne, torch.Tensor)
+    np.testing.assert_array_equal(mt_eq.numpy(), pt_eq.numpy())
+    np.testing.assert_array_equal(mt_ne.numpy(), pt_ne.numpy())
+
+
+def test_tensor_ordering_return_tensor_matches_torch():
+    mt_a = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    mt_b = torch.tensor([[1.0, 0.0], [3.0, 5.0]])
+    pt_a = pt.tensor([[1.0, 2.0], [3.0, 4.0]])
+    pt_b = pt.tensor([[1.0, 0.0], [3.0, 5.0]])
+
+    for op in (operator.lt, operator.le, operator.gt, operator.ge):
+        mt_out = op(mt_a, mt_b)
+        pt_out = op(pt_a, pt_b)
+        assert isinstance(mt_out, torch.Tensor)
+        np.testing.assert_array_equal(mt_out.numpy(), pt_out.numpy())
+
+
+def test_tensor_bool_ambiguous_matches_torch():
+    assert_torch_error(
+        lambda: bool(torch.tensor([1, 2])),
+        lambda: bool(pt.tensor([1, 2])),
+    )
+    assert_torch_error(
+        lambda: bool(torch.tensor([])),
+        lambda: bool(pt.tensor([])),
+    )
+
+
+def test_tensor_eq_unsupported_rhs_matches_torch():
+    mt_x = torch.tensor([1, 2])
+    pt_x = pt.tensor([1, 2])
+
+    mt_out = mt_x == [1, 2]
+    pt_out = pt_x == [1, 2]
+
+    assert type(mt_out) is type(pt_out)
+    assert mt_out == pt_out
+
+
+def test_tensor_ordering_unsupported_rhs_matches_torch():
+    assert_torch_error(
+        lambda: torch.tensor([1, 2]) > [1, 2],
+        lambda: pt.tensor([1, 2]) > [1, 2],
+    )


### PR DESCRIPTION
## Summary
- align `Tensor` comparison magic methods (`__eq__/__ne__/__lt__/__le__/__gt__/__ge__`) to dispatch-backed tensor semantics instead of scalarizing via `item()`
- align `Tensor.__bool__` ambiguity behavior with Torch for empty and multi-element tensors
- add comparison functional entries (`eq/ne/lt/le/gt/ge`) and wire CPU/NPU backend kernel registration
- add `meta` bool-shape inference for binary comparisons to keep pipeline/meta behavior consistent
- add contract coverage for tensor-returning comparisons, bool ambiguity, and unsupported RHS behavior

## Tests
- `PYTHONPATH=src pytest -q tests/mindtorch_v2/contract/test_tensor_comparison_contract.py tests/mindtorch_v2/contract`
