### PR TITLE
[mindtorch_v2] fix NPU tensor-list lifecycle crash in cat/stack paths

### DIFF
--- a/src/mindtorch_v2/_backends/npu/aclnn.py
+++ b/src/mindtorch_v2/_backends/npu/aclnn.py
@@ -4462,8 +4462,9 @@ def index_put_impl(self_ptr, self_shape, self_stride, self_dtype,
         _defer_executor(executor)
         if tensor_list is not None and bindings.acl_destroy_tensor_list:
             bindings.acl_destroy_tensor_list(tensor_list)
-        for tensor, _ in tensor_keeps:
-            bindings.acl_destroy_tensor(tensor)
+        else:
+            for tensor, _ in tensor_keeps:
+                bindings.acl_destroy_tensor(tensor)
         bindings.acl_destroy_tensor(self_tensor)
         bindings.acl_destroy_tensor(values_tensor)
         if workspace is not None:
@@ -6086,10 +6087,11 @@ def cat(tensor_ptrs, shapes, strides, dtypes, dim, out_ptr, out_shape, out_strid
         _maybe_sync(runtime)
     finally:
         _defer_executor(executor)
-        if bindings.acl_destroy_tensor_list:
+        if tensor_list is not None and bindings.acl_destroy_tensor_list:
             bindings.acl_destroy_tensor_list(tensor_list)
-        for tensor, _ in tensor_keeps:
-            bindings.acl_destroy_tensor(tensor)
+        else:
+            for tensor, _ in tensor_keeps:
+                bindings.acl_destroy_tensor(tensor)
         bindings.acl_destroy_tensor(out_tensor)
         if workspace is not None:
             runtime.defer_raw_free(workspace)
@@ -6138,10 +6140,11 @@ def stack(tensor_ptrs, shapes, strides, dtypes, dim, out_ptr, out_shape, out_str
         _maybe_sync(runtime)
     finally:
         _defer_executor(executor)
-        if bindings.acl_destroy_tensor_list:
+        if tensor_list is not None and bindings.acl_destroy_tensor_list:
             bindings.acl_destroy_tensor_list(tensor_list)
-        for tensor, _ in tensor_keeps:
-            bindings.acl_destroy_tensor(tensor)
+        else:
+            for tensor, _ in tensor_keeps:
+                bindings.acl_destroy_tensor(tensor)
         bindings.acl_destroy_tensor(out_tensor)
         if workspace is not None:
             runtime.defer_raw_free(workspace)


### PR DESCRIPTION
## Summary
- fix NPU `cat`/`stack` path stability by correcting ACL tensor-list resource lifecycle
- avoid double-destroy of tensors when `aclDestroyTensorList` is available
- apply the same tensor-list cleanup policy to `index_put_impl` for consistency
- add/restore NPU regression coverage for cat/concat/stack and stack-family wrappers

## Root Cause
`aclnn` tensor-list call sites were destroying resources twice:
- first via `aclDestroyTensorList`
- then again via per-tensor `aclDestroyTensor`

This caused use-after-free / double-destroy behavior and led to intermittent segfaults in sequences like `cat(dim=0)` followed by `concat(dim=1)`.

## Testing
- `python -m py_compile src/mindtorch_v2/_backends/npu/aclnn.py tests/mindtorch_v2/test_ops_npu.py`
- `PYTHONPATH=src pytest tests/mindtorch_v2/test_ops_npu.py -k "test_npu_cat_concat_concatenate_stack or test_npu_cat_concat_across_dims or test_npu_vstack_rowstack_columnstack_dstack_vsplit_dsplit or test_npu_split_unbind_family or test_npu_empty_mul_relu_sign_sum" -vv`
